### PR TITLE
feat: 支持自定义手柄退出组合键，解决特定掌机兼容性问题

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -2012,6 +2012,70 @@ Flickable {
                     ToolTip.visible: hovered
                     ToolTip.text: qsTr("Allows Moonlight to capture gamepad inputs even if it's not the current window in focus")
                 }
+
+                Label {
+                    width: parent.width
+                    text: qsTr("Gamepad quit combo")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
+                AutoResizingComboBox {
+                    Component.onCompleted: {
+                        var saved_combo = StreamingPreferences.gamepadQuitCombo
+                        currentIndex = 0
+                        for (var i = 0; i < gamepadQuitComboListModel.count; i++) {
+                            if (saved_combo === gamepadQuitComboListModel.get(i).val) {
+                                currentIndex = i
+                                break
+                            }
+                        }
+                        activated(currentIndex)
+                    }
+
+                    id: gamepadQuitComboComboBox
+                    textRole: "text"
+                    model: ListModel {
+                        id: gamepadQuitComboListModel
+                        ListElement {
+                            text: qsTr("Start + Select + L1 + R1 (Default)")
+                            val: StreamingPreferences.GQC_DEFAULT
+                        }
+                        ListElement {
+                            text: qsTr("Select + L1 + R1 + X")
+                            val: StreamingPreferences.GQC_SELECT_L1_R1_X
+                        }
+                        ListElement {
+                            text: qsTr("Select + L1 + R1 + Y")
+                            val: StreamingPreferences.GQC_SELECT_L1_R1_Y
+                        }
+                        ListElement {
+                            text: qsTr("Start + L1 + R1 + A")
+                            val: StreamingPreferences.GQC_START_L1_R1_A
+                        }
+                        ListElement {
+                            text: qsTr("Start + L1 + R1 + B")
+                            val: StreamingPreferences.GQC_START_L1_R1_B
+                        }
+                        ListElement {
+                            text: qsTr("L1 + R1 + X + Y")
+                            val: StreamingPreferences.GQC_L1_R1_X_Y
+                        }
+                        ListElement {
+                            text: qsTr("L1 + R1 + A + B")
+                            val: StreamingPreferences.GQC_L1_R1_A_B
+                        }
+                    }
+
+                    onActivated: {
+                        StreamingPreferences.gamepadQuitCombo = gamepadQuitComboListModel.get(currentIndex).val
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Choose which button combination exits streaming. Use alternatives if the default doesn't work on your device.")
+                }
             }
         }
 

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -56,6 +56,7 @@
 #define SER_SWAPWINALTKEYS "swapwinaltkeys"
 #define SER_MUTEONFOCUSLOSS "muteonfocusloss"
 #define SER_BACKGROUNDGAMEPAD "backgroundgamepad"
+#define SER_GAMEPADQUITCOMBO "gamepadquitcombo"
 #define SER_REVERSESCROLL "reversescroll"
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
@@ -180,6 +181,8 @@ void StreamingPreferences::reload()
     swapWinAltKeys = settings.value(SER_SWAPWINALTKEYS, false).toBool();
     muteOnFocusLoss = settings.value(SER_MUTEONFOCUSLOSS, false).toBool();
     backgroundGamepad = settings.value(SER_BACKGROUNDGAMEPAD, false).toBool();
+    gamepadQuitCombo = static_cast<GamepadQuitCombo>(settings.value(SER_GAMEPADQUITCOMBO,
+                                                     static_cast<int>(GamepadQuitCombo::GQC_DEFAULT)).toInt());
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
@@ -401,6 +404,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPWINALTKEYS, swapWinAltKeys);
     settings.setValue(SER_MUTEONFOCUSLOSS, muteOnFocusLoss);
     settings.setValue(SER_BACKGROUNDGAMEPAD, backgroundGamepad);
+    settings.setValue(SER_GAMEPADQUITCOMBO, static_cast<int>(gamepadQuitCombo));
     settings.setValue(SER_REVERSESCROLL, reverseScrollDirection);
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -125,6 +125,18 @@ public:
     };
     Q_ENUM(HdrMode);
 
+    enum GamepadQuitCombo
+    {
+        GQC_DEFAULT         = 0,  // Start + Select + L1 + R1 (original)
+        GQC_SELECT_L1_R1_X  = 1,  // Select + L1 + R1 + X (avoids Start+Select conflict)
+        GQC_SELECT_L1_R1_Y  = 2,  // Select + L1 + R1 + Y
+        GQC_START_L1_R1_A   = 3,  // Start + L1 + R1 + A (avoids Select conflict)
+        GQC_START_L1_R1_B   = 4,  // Start + L1 + R1 + B (avoids Select conflict)
+        GQC_L1_R1_X_Y       = 5,  // L1 + R1 + X + Y (no Select/Start at all)
+        GQC_L1_R1_A_B       = 6,  // L1 + R1 + A + B (no Select/Start at all)
+    };
+    Q_ENUM(GamepadQuitCombo);
+
     Q_PROPERTY(int width MEMBER width NOTIFY displayModeChanged)
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
@@ -168,6 +180,7 @@ public:
     Q_PROPERTY(bool swapWinAltKeys MEMBER swapWinAltKeys NOTIFY swapWinAltKeysChanged)
     Q_PROPERTY(bool muteOnFocusLoss MEMBER muteOnFocusLoss NOTIFY muteOnFocusLossChanged)
     Q_PROPERTY(bool backgroundGamepad MEMBER backgroundGamepad NOTIFY backgroundGamepadChanged)
+    Q_PROPERTY(GamepadQuitCombo gamepadQuitCombo MEMBER gamepadQuitCombo NOTIFY gamepadQuitComboChanged)
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
@@ -216,6 +229,7 @@ public:
     bool swapWinAltKeys;
     bool muteOnFocusLoss;
     bool backgroundGamepad;
+    GamepadQuitCombo gamepadQuitCombo;
     bool reverseScrollDirection;
     bool swapFaceButtons;
     bool keepAwake;
@@ -279,6 +293,7 @@ signals:
     void swapWinAltKeysChanged();
     void muteOnFocusLossChanged();
     void backgroundGamepadChanged();
+    void gamepadQuitComboChanged();
     void reverseScrollDirectionChanged();
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -367,21 +367,49 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         }
     }
 
-    // Handle Start+Select+L1+R1 as a gamepad quit combo
-    if (state->buttons == (PLAY_FLAG | BACK_FLAG | LB_FLAG | RB_FLAG) && qgetenv("NO_GAMEPAD_QUIT") != "1") {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "Detected quit gamepad button combo");
+    // Handle configurable gamepad quit combo
+    if (qgetenv("NO_GAMEPAD_QUIT") != "1") {
+        int quitComboMask;
+        switch (m_GamepadQuitCombo) {
+        case StreamingPreferences::GQC_SELECT_L1_R1_X:
+            quitComboMask = BACK_FLAG | LB_FLAG | RB_FLAG | X_FLAG;
+            break;
+        case StreamingPreferences::GQC_SELECT_L1_R1_Y:
+            quitComboMask = BACK_FLAG | LB_FLAG | RB_FLAG | Y_FLAG;
+            break;
+        case StreamingPreferences::GQC_START_L1_R1_A:
+            quitComboMask = PLAY_FLAG | LB_FLAG | RB_FLAG | A_FLAG;
+            break;
+        case StreamingPreferences::GQC_START_L1_R1_B:
+            quitComboMask = PLAY_FLAG | LB_FLAG | RB_FLAG | B_FLAG;
+            break;
+        case StreamingPreferences::GQC_L1_R1_X_Y:
+            quitComboMask = LB_FLAG | RB_FLAG | X_FLAG | Y_FLAG;
+            break;
+        case StreamingPreferences::GQC_L1_R1_A_B:
+            quitComboMask = LB_FLAG | RB_FLAG | A_FLAG | B_FLAG;
+            break;
+        case StreamingPreferences::GQC_DEFAULT:
+        default:
+            quitComboMask = PLAY_FLAG | BACK_FLAG | LB_FLAG | RB_FLAG;
+            break;
+        }
 
-        // Push a quit event to the main loop
-        SDL_Event event;
-        event.type = SDL_QUIT;
-        event.quit.timestamp = SDL_GetTicks();
-        SDL_PushEvent(&event);
+        if (state->buttons == quitComboMask) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Detected quit gamepad button combo");
 
-        // Clear buttons down on this gamepad
-        LiSendMultiControllerEvent(state->index, m_GamepadMask,
-                                   0, 0, 0, 0, 0, 0, 0);
-        return;
+            // Push a quit event to the main loop
+            SDL_Event event;
+            event.type = SDL_QUIT;
+            event.quit.timestamp = SDL_GetTicks();
+            SDL_PushEvent(&event);
+
+            // Clear buttons down on this gamepad
+            LiSendMultiControllerEvent(state->index, m_GamepadMask,
+                                       0, 0, 0, 0, 0, 0, 0);
+            return;
+        }
     }
 
     // Handle Select+L1+R1+X as a gamepad overlay combo

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -16,6 +16,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_SwapWinAltKeys(prefs.swapWinAltKeys),
       m_ReverseScrollDirection(prefs.reverseScrollDirection),
       m_SwapFaceButtons(prefs.swapFaceButtons),
+      m_GamepadQuitCombo(prefs.gamepadQuitCombo),
       m_MouseWasInVideoRegion(false),
       m_PendingMouseButtonsAllUpOnVideoRegionLeave(false),
       m_PointerRegionLockActive(false),

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -221,6 +221,7 @@ private:
     bool m_SwapWinAltKeys;
     bool m_ReverseScrollDirection;
     bool m_SwapFaceButtons;
+    StreamingPreferences::GamepadQuitCombo m_GamepadQuitCombo;
 
     bool m_MouseWasInVideoRegion;
     bool m_PendingMouseButtonsAllUpOnVideoRegionLeave;


### PR DESCRIPTION
## 问题
默认退出组合键 `Start + Select + L1 + R1` 在部分掌机（如飞行家 F1 Pro）上无法使用。原因是设备固件将 `Start + Select` 绑定为自定义功能键，会优先截获信号，导致 Moonlight 无法识别完整的四键组合。

## 方案
在设置界面新增「Gamepad quit combo」下拉选项，提供 7 种预设组合键，用户可根据设备情况选择不会产生冲突的方案。

### 可选预设
| 组合键 | 适用场景 |
|--------|----------|
| Start + Select + L1 + R1 | 默认，大部分手柄通用 |
| Select + L1 + R1 + X / Y | 避开 Start+Select 冲突 |
| Start + L1 + R1 + A / B | 避开 Select 冲突 |
| L1 + R1 + X + Y / A + B | 完全不依赖 Select 和 Start |

Closes #29