### PR TITLE
feat(streaming): add bidirectional clipboard sync over 0x5508

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -189,6 +189,7 @@ SOURCES += \
     streaming/input/mouse.cpp \
     streaming/input/reltouch.cpp \
     streaming/session.cpp \
+    streaming/clipboardsync.cpp \
     streaming/audio/audio.cpp \
     streaming/audio/renderers/sdlaud.cpp \
     streaming/network/bandwidth.cpp \
@@ -233,6 +234,7 @@ HEADERS += \
     settings/streamingpreferences.h \
     streaming/input/input.h \
     streaming/session.h \
+    streaming/clipboardsync.h \
     streaming/audio/renderers/renderer.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \

--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -1,0 +1,258 @@
+#include "clipboardsync.h"
+
+#include <QClipboard>
+#include <QDateTime>
+#include <QGuiApplication>
+#include <QMetaObject>
+#include <QtEndian>
+
+#include <SDL.h>
+
+#include <Limelight.h>
+
+ClipboardSync::ClipboardSync(QObject* parent)
+    : QObject(parent)
+{
+    qRegisterMetaType<QByteArray>("QByteArray");
+}
+
+ClipboardSync::~ClipboardSync()
+{
+    stop();
+}
+
+void ClipboardSync::start()
+{
+    if (m_Active) {
+        return;
+    }
+
+    QClipboard* cb = QGuiApplication::clipboard();
+    if (cb == nullptr) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: no QClipboard available; sync disabled");
+        return;
+    }
+
+    connect(cb, &QClipboard::dataChanged,
+            this, &ClipboardSync::onLocalClipboardChanged,
+            Qt::UniqueConnection);
+
+    m_Active = true;
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "ClipboardSync: started (text-only, bidirectional)");
+}
+
+void ClipboardSync::stop()
+{
+    if (!m_Active) {
+        return;
+    }
+
+    QClipboard* cb = QGuiApplication::clipboard();
+    if (cb != nullptr) {
+        disconnect(cb, &QClipboard::dataChanged,
+                   this, &ClipboardSync::onLocalClipboardChanged);
+    }
+
+    m_EchoCache.clear();
+    m_SuppressNextChange = false;
+    m_Active = false;
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "ClipboardSync: stopped");
+}
+
+void ClipboardSync::handleIncomingFrame(const char* data, int length)
+{
+    if (data == nullptr || length <= 0) {
+        return;
+    }
+
+    // Copy out of the recv-thread buffer and marshal to the GUI thread.
+    QByteArray frame(data, length);
+    QMetaObject::invokeMethod(this, "onIncomingFrame", Qt::QueuedConnection,
+                              Q_ARG(QByteArray, frame));
+}
+
+void ClipboardSync::onIncomingFrame(QByteArray frame)
+{
+    if (!m_Active) {
+        return;
+    }
+
+    uint8_t kind = 0;
+    QByteArray payload;
+    if (!decodeFrame(frame, kind, payload)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: discarding malformed inbound frame (%d bytes)",
+                    frame.size());
+        return;
+    }
+
+    if (kind != KIND_TEXT) {
+        // Image / file kinds are not yet wired up on the Qt client.
+        return;
+    }
+
+    // Validate UTF-8 by round-tripping through QString. Reject anything that
+    // contains an embedded NUL since SDL_SetClipboardText is C-string-based.
+    if (payload.contains('\0')) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping inbound text payload with embedded NUL");
+        return;
+    }
+
+    // Record hash *before* writing so the dataChanged echo we're about to
+    // trigger is suppressed.
+    uint64_t hash = hashBytes(payload);
+    recordHash(hash);
+    m_SuppressNextChange = true;
+
+    // SDL_SetClipboardText copies internally; payload is already null-safe
+    // because QByteArray's data() guarantees a trailing NUL.
+    if (SDL_SetClipboardText(payload.constData()) != 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: SDL_SetClipboardText failed: %s",
+                    SDL_GetError());
+        m_SuppressNextChange = false;
+    }
+}
+
+void ClipboardSync::onLocalClipboardChanged()
+{
+    if (!m_Active) {
+        return;
+    }
+
+    if (m_SuppressNextChange) {
+        m_SuppressNextChange = false;
+        return;
+    }
+
+    QClipboard* cb = QGuiApplication::clipboard();
+    if (cb == nullptr) {
+        return;
+    }
+
+    QString text = cb->text();
+    if (text.isEmpty()) {
+        return;
+    }
+
+    QByteArray utf8 = text.toUtf8();
+    if (utf8.isEmpty() || utf8.size() > MAX_PAYLOAD) {
+        return;
+    }
+
+    uint64_t hash = hashBytes(utf8);
+    if (seenRecently(hash)) {
+        // This change was the echo of a payload the host just pushed to us.
+        return;
+    }
+    recordHash(hash);
+
+    QByteArray frame;
+    if (!encodeTextFrame(utf8, frame)) {
+        return;
+    }
+
+    int rc = LiSendClipboardData(frame.constData(), frame.size());
+    if (rc != 0) {
+        // Negative return = no active session, host doesn't support clipboard,
+        // or send failed; log once at debug level to avoid spam.
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "ClipboardSync: LiSendClipboardData(%d bytes) -> %d",
+                     frame.size(), rc);
+    }
+}
+
+bool ClipboardSync::encodeTextFrame(const QByteArray& utf8, QByteArray& outFrame) const
+{
+    if (utf8.size() > MAX_PAYLOAD) {
+        return false;
+    }
+
+    outFrame.clear();
+    outFrame.reserve(10 + utf8.size());
+
+    // u8 version
+    outFrame.append(static_cast<char>(WIRE_VERSION));
+    // u8 kind
+    outFrame.append(static_cast<char>(KIND_TEXT));
+    // u32 token (LE) - we don't generate tokens client-side; 0 is accepted.
+    quint32 tokenLE = qToLittleEndian<quint32>(0);
+    outFrame.append(reinterpret_cast<const char*>(&tokenLE), sizeof(tokenLE));
+    // u32 length (LE)
+    quint32 lenLE = qToLittleEndian<quint32>(static_cast<quint32>(utf8.size()));
+    outFrame.append(reinterpret_cast<const char*>(&lenLE), sizeof(lenLE));
+    // bytes payload
+    outFrame.append(utf8);
+    return true;
+}
+
+bool ClipboardSync::decodeFrame(const QByteArray& frame,
+                                uint8_t& outKind,
+                                QByteArray& outPayload) const
+{
+    // 1 + 1 + 4 + 4 = 10 byte header minimum.
+    if (frame.size() < 10) {
+        return false;
+    }
+
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(frame.constData());
+    uint8_t version = p[0];
+    if (version != WIRE_VERSION) {
+        return false;
+    }
+
+    outKind = p[1];
+
+    quint32 lenLE = 0;
+    memcpy(&lenLE, p + 6, sizeof(lenLE));
+    quint32 length = qFromLittleEndian<quint32>(lenLE);
+
+    if (length > static_cast<quint32>(frame.size() - 10)) {
+        return false;
+    }
+
+    outPayload = QByteArray(reinterpret_cast<const char*>(p + 10),
+                            static_cast<int>(length));
+    return true;
+}
+
+bool ClipboardSync::seenRecently(uint64_t hash)
+{
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+    // Drop stale entries off the front first.
+    while (!m_EchoCache.isEmpty() && (now - m_EchoCache.front().second) > ECHO_TTL_MS) {
+        m_EchoCache.removeFirst();
+    }
+
+    for (const auto& e : m_EchoCache) {
+        if (e.first == hash) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ClipboardSync::recordHash(uint64_t hash)
+{
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    m_EchoCache.enqueue(qMakePair(hash, now));
+    while (m_EchoCache.size() > ECHO_MAX) {
+        m_EchoCache.removeFirst();
+    }
+}
+
+uint64_t ClipboardSync::hashBytes(const QByteArray& bytes)
+{
+    // FNV-1a 64-bit. Cheap and good enough for echo suppression.
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (int i = 0; i < bytes.size(); ++i) {
+        h ^= static_cast<uint8_t>(bytes[i]);
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}

--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -6,6 +6,8 @@
 #include <QMetaObject>
 #include <QtEndian>
 
+#include <cstring>
+
 #include <SDL.h>
 
 #include <Limelight.h>
@@ -85,7 +87,7 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
     if (!decodeFrame(frame, kind, payload)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                     "ClipboardSync: discarding malformed inbound frame (%d bytes)",
-                    frame.size());
+                    static_cast<int>(frame.size()));
         return;
     }
 
@@ -162,7 +164,7 @@ void ClipboardSync::onLocalClipboardChanged()
         // or send failed; log once at debug level to avoid spam.
         SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
                      "ClipboardSync: LiSendClipboardData(%d bytes) -> %d",
-                     frame.size(), rc);
+                     static_cast<int>(frame.size()), rc);
     }
 }
 

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QMutex>
+#include <QPair>
+#include <QQueue>
+#include <cstdint>
+
+// ClipboardSync owns the bidirectional clipboard sync state for an active
+// streaming session against an AlkaidLab Sunshine fork host. It implements
+// the v1 wire format (u8 version=1, u8 kind, u32 token, u32 length, bytes
+// payload, little-endian) over Limelight control packet 0x5508
+// (LiSendClipboardData / ConnListenerClipboardData).
+//
+// Currently only kind=1 (UTF-8 text) is implemented in both directions.
+// Image / file payloads are accepted on the wire but ignored.
+//
+// Echo suppression: when we either write a payload to the local clipboard
+// (because the host pushed it) or send a payload to the host (because we
+// detected a local change), we record a (hash, timestamp_ms) pair into a
+// 16-entry deque with a 5 second TTL. Subsequent QClipboard::dataChanged
+// notifications for the same content are dropped, mirroring the Sunshine
+// GUI agent's logic so the two ends don't ping-pong.
+//
+// Threading:
+//   * Construct on the GUI thread.
+//   * start() / stop() must run on the GUI thread.
+//   * handleIncomingFrame() may be called from any thread (specifically the
+//     moonlight-common-c control receive thread). It marshals the payload
+//     onto the GUI thread via a queued metacall.
+class ClipboardSync : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum Kind : uint8_t {
+        KIND_TEXT = 1,
+        KIND_PNG  = 2,
+    };
+
+    static constexpr uint8_t WIRE_VERSION = 1;
+    static constexpr int     MAX_PAYLOAD  = 65535 - 10; // wire frame must fit u16 length
+    static constexpr int     ECHO_TTL_MS  = 5000;
+    static constexpr int     ECHO_MAX     = 16;
+
+    explicit ClipboardSync(QObject* parent = nullptr);
+    ~ClipboardSync() override;
+
+    // Start watching the local clipboard and accepting inbound payloads.
+    // Must be called on the GUI thread.
+    void start();
+
+    // Disconnect signals and stop processing both directions.
+    void stop();
+
+    // Called from the control receive thread when the host pushes a 0x5508
+    // payload. Buffer is only valid for the duration of the call; we copy.
+    void handleIncomingFrame(const char* data, int length);
+
+private slots:
+    // QClipboard::dataChanged -> emitted on GUI thread.
+    void onLocalClipboardChanged();
+
+    // Queued slot used by handleIncomingFrame() to deliver to GUI thread.
+    void onIncomingFrame(QByteArray frame);
+
+private:
+    bool encodeTextFrame(const QByteArray& utf8, QByteArray& outFrame) const;
+    bool decodeFrame(const QByteArray& frame,
+                     uint8_t& outKind,
+                     QByteArray& outPayload) const;
+
+    // Hash + TTL bookkeeping; not thread-safe, only touched from GUI thread.
+    bool seenRecently(uint64_t hash);
+    void recordHash(uint64_t hash);
+
+    static uint64_t hashBytes(const QByteArray& bytes);
+
+    bool m_Active = false;
+    QQueue<QPair<uint64_t, qint64>> m_EchoCache; // (hash, timestamp_ms)
+
+    // Guard against re-entering onLocalClipboardChanged from our own SDL write.
+    bool m_SuppressNextChange = false;
+};

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1,4 +1,5 @@
 #include "session.h"
+#include "clipboardsync.h"
 #include "settings/streamingpreferences.h"
 #include "streaming/streamutils.h"
 #include "backend/richpresencemanager.h"
@@ -67,7 +68,9 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
     Session::clRumbleTriggers,
     Session::clSetMotionEventState,
     Session::clSetControllerLED,
-    Session::clSetAdaptiveTriggers
+    Session::clSetAdaptiveTriggers,
+    nullptr, // resolutionChanged (unused on Qt client)
+    Session::clClipboardData
 };
 
 Session* Session::s_ActiveSession;
@@ -217,6 +220,17 @@ void Session::clSetHdrMode(bool enabled)
         }
         SDL_UnlockMutex(s_ActiveSession->m_DecoderLock);
     }
+}
+
+void Session::clClipboardData(const char* data, int length)
+{
+    Session* session = s_ActiveSession;
+    if (session == nullptr || session->m_ClipboardSync == nullptr) {
+        return;
+    }
+
+    // Marshals to GUI thread internally; safe to call from the recv thread.
+    session->m_ClipboardSync->handleIncomingFrame(data, length);
 }
 
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
@@ -584,12 +598,19 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_MenuCloseTicks(0),
       m_MicStream(nullptr)
 {
+    m_ClipboardSync = nullptr;
 }
 
 Session::~Session()
 {
     // NB: This may not get destroyed for a long time! Don't put any non-trivial cleanup here.
     // Use Session::exec() or DeferredSessionCleanupTask instead.
+
+    if (m_ClipboardSync != nullptr) {
+        m_ClipboardSync->stop();
+        delete m_ClipboardSync;
+        m_ClipboardSync = nullptr;
+    }
 
     SDL_DestroyMutex(m_DecoderLock);
 }
@@ -2047,6 +2068,14 @@ void Session::start()
 
     // We're now active
     s_ActiveSession = this;
+
+    // Construct the clipboard sync helper on the GUI thread before the
+    // control receive thread can possibly invoke clClipboardData(). It is
+    // started after a successful connection in clConnectionStatusUpdate.
+    if (m_ClipboardSync == nullptr) {
+        m_ClipboardSync = new ClipboardSync(this);
+        m_ClipboardSync->start();
+    }
 
     // Initialize the gamepad code with our preferences
     // NB: m_InputHandler must be initialize before starting the connection.

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -240,6 +240,9 @@ private:
     void clSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlags, uint8_t typeLeft, uint8_t typeRight, uint8_t *left, uint8_t *right);
 
     static
+    void clClipboardData(const char* data, int length);
+
+    static
     int arInit(int audioConfiguration,
                const POPUS_MULTISTREAM_CONFIGURATION opusConfig,
                void* arContext, int arFlags);
@@ -307,6 +310,7 @@ private:
     OverlayMenuButton* m_MenuButton; // Qt-based floating menu button
     OverlayToast* m_Toast;           // Qt-based toast notification
     Uint32 m_MenuCloseTicks;       // 菜单关闭时间戳（防抖）
+    class ClipboardSync* m_ClipboardSync; // Bidirectional clipboard sync (Sunshine 0x5508); nullptr when stream not active
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;


### PR DESCRIPTION
## Summary
Add bidirectional clipboard sync in Moonlight Qt over Limelight control packet `0x5508`.

## Changes
- Add `ClipboardSync` helper for the v1 clipboard wire frame:
  - `u8 version + u8 kind + u32 token(LE) + u32 length(LE) + payload`
- Support UTF-8 text clipboard sync in both directions.
- Marshal inbound control-stream clipboard frames onto the Qt GUI thread.
- Add echo suppression with a hash + TTL cache to avoid clipboard ping-pong.
- Wire the clipboard callback and lifecycle into `Session`.
- Add the new files to `app.pro`.

## Notes
- Current Qt client behavior is text-only (`kind=1`). Other kinds are ignored safely.
- The submodule dirty state is intentionally excluded from this PR.

## Verification
- Native self-test harness validated frame byte layout, encode/decode round trips, and `LiSendClipboardData` argument behavior.
- Sunshine bridge half-e2e probe accepted a v1 text frame through `/api/v1/clipboard/item`.
