### PR TITLE
ci: fix ARM64 portable shipping x64 Qt DLLs (0xc000007b)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,12 @@ jobs:
     - name: Build Windows arm64
       shell: cmd
       run: |
+        rem Force the ARM64 Qt bin to the front of PATH so that build-arch.bat's
+        rem `where qmake.bat` / `where qmake.exe` resolves to the cross-compiled
+        rem ARM64 Qt instead of the x64 Qt installed earlier in this job. Without
+        rem this, windeployqt would deploy x64 Qt DLLs into the ARM64 portable
+        rem package, producing 0xc000007b on launch (qiin2333/moonlight-qt#71).
+        set "PATH=%Qt6_DIR%\bin;%PATH%"
         copy /y scripts\appveyor\qmake.bat %Qt6_DIR%\bin\
         copy /y scripts\appveyor\qtpaths.bat %Qt6_DIR%\bin\
         copy /y scripts\appveyor\target_qt.conf %Qt6_DIR%\bin\


### PR DESCRIPTION
## 修复 #71

报告者 @JKL-AIVN 给出了非常详尽的诊断：`MoonlightPortable-arm64-6.2.70.zip` 里 30+ 个 Qt6 DLL 以及 `vcruntime140_1.dll` 都是 x64（`0x8664`），导致在 Snapdragon X Elite 等原生 ARM64 Windows 上启动即崩溃 `STATUS_INVALID_IMAGE_FORMAT`。

## 根因

`scripts/build-arch.bat` 通过 `where qmake[.bat|.exe]` 定位 Qt 的当前架构。CI 工作流里：

1. `Install Qt`（x64，jurplel/install-qt-action@v3）把 x64 Qt bin **加到 PATH 头部**
2. `Install Qt arm64`（jdpurcell/install-qt-action@v5）安装 ARM64 Qt 到独立目录、更新 `Qt6_DIR`，但**不会把 ARM64 bin 抢到 PATH 前面**
3. `Build Windows arm64` step 把自定义 `qmake.bat` 复制到 `%Qt6_DIR%\bin\`（ARM64 目录），但因为 PATH 上 x64 在前：
   - `where qmake.bat` 在 x64 bin 没找到（x64 install 不带这个 .bat 转发器）
   - 回退 `where qmake.exe` → **命中 x64 qmake.exe**
4. `QT_PATH` 被解析成 x64 路径 → `HOSTBIN_PATH`/`host-qtpaths.bat` 整套 ARM64 调度逻辑被绕过
5. `windeployqt.exe` 直接从 x64 Qt 安装解析依赖 → 把 x64 DLL 复制进 ARM64 portable 包

## 修复

在 `Build Windows arm64` step 的开头加一行：

```cmd
set "PATH=%Qt6_DIR%\bin;%PATH%"
```

这样 `where qmake.bat` 会先命中我们刚刚复制到 ARM64 bin 的转发脚本，整条链路按 `build-arch.bat` 设计的 ARM64 路径执行，windeployqt 部署正确的 ARM64 Qt DLLs。

## 验证

发布后 ARM64 portable zip 里 `Qt6Core.dll` 等应当再次显示为 `0xAA64`。报告者提供的 workaround（用 aqtinstall 拉 `win64_msvc2022_arm64_cross_compiled` 替换）可作为旧版用户的临时方案。

Fixes #71