### PR TITLE
feat(clipboard): 双向 PNG 图片同步 (KIND_PNG=2)

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -1,9 +1,12 @@
 #include "clipboardsync.h"
 
+#include <QBuffer>
 #include <QClipboard>
 #include <QDateTime>
 #include <QGuiApplication>
+#include <QImage>
 #include <QMetaObject>
+#include <QMimeData>
 #include <QtEndian>
 
 #include <cstring>
@@ -42,7 +45,7 @@ void ClipboardSync::start()
 
     m_Active = true;
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "ClipboardSync: started (text-only, bidirectional)");
+                "ClipboardSync: started (text + PNG, bidirectional)");
 }
 
 void ClipboardSync::stop()
@@ -91,33 +94,56 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
         return;
     }
 
-    if (kind != KIND_TEXT) {
-        // Image / file kinds are not yet wired up on the Qt client.
+    if (kind == KIND_TEXT) {
+        // Validate UTF-8 by round-tripping through QString. Reject anything that
+        // contains an embedded NUL since SDL_SetClipboardText is C-string-based.
+        if (payload.contains('\0')) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping inbound text payload with embedded NUL");
+            return;
+        }
+
+        // Record hash *before* writing so the dataChanged echo we're about to
+        // trigger is suppressed.
+        uint64_t hash = hashBytes(payload);
+        recordHash(hash);
+        m_SuppressNextChange = true;
+
+        // SDL_SetClipboardText copies internally; payload is already null-safe
+        // because QByteArray's data() guarantees a trailing NUL.
+        if (SDL_SetClipboardText(payload.constData()) != 0) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: SDL_SetClipboardText failed: %s",
+                        SDL_GetError());
+            m_SuppressNextChange = false;
+        }
         return;
     }
 
-    // Validate UTF-8 by round-tripping through QString. Reject anything that
-    // contains an embedded NUL since SDL_SetClipboardText is C-string-based.
-    if (payload.contains('\0')) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: dropping inbound text payload with embedded NUL");
+    if (kind == KIND_PNG) {
+        QImage image;
+        if (!image.loadFromData(payload, "PNG") || image.isNull()) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping inbound PNG payload (decode failed, %d bytes)",
+                        static_cast<int>(payload.size()));
+            return;
+        }
+
+        QClipboard* cb = QGuiApplication::clipboard();
+        if (cb == nullptr) {
+            return;
+        }
+
+        // Hash the wire bytes (not the decoded pixels) so the echo we suppress
+        // matches what we'd re-encode if QClipboard hands the image straight back.
+        uint64_t hash = hashBytes(payload);
+        recordHash(hash);
+        m_SuppressNextChange = true;
+        cb->setImage(image);
         return;
     }
 
-    // Record hash *before* writing so the dataChanged echo we're about to
-    // trigger is suppressed.
-    uint64_t hash = hashBytes(payload);
-    recordHash(hash);
-    m_SuppressNextChange = true;
-
-    // SDL_SetClipboardText copies internally; payload is already null-safe
-    // because QByteArray's data() guarantees a trailing NUL.
-    if (SDL_SetClipboardText(payload.constData()) != 0) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: SDL_SetClipboardText failed: %s",
-                    SDL_GetError());
-        m_SuppressNextChange = false;
-    }
+    // Unknown kind — ignore.
 }
 
 void ClipboardSync::onLocalClipboardChanged()
@@ -134,6 +160,59 @@ void ClipboardSync::onLocalClipboardChanged()
     QClipboard* cb = QGuiApplication::clipboard();
     if (cb == nullptr) {
         return;
+    }
+
+    const QMimeData* mime = cb->mimeData();
+
+    // Image takes precedence — some applications attach a fallback text label
+    // (file path, alt text) alongside the bitmap; we want the picture, not the
+    // path. Matches moonlight-android's ClipboardSyncManager ordering.
+    if (mime != nullptr && mime->hasImage()) {
+        QImage image = qvariant_cast<QImage>(mime->imageData());
+        if (!image.isNull()) {
+            const qint64 pixels = static_cast<qint64>(image.width()) * image.height();
+            if (pixels <= 0 || pixels > MAX_IMAGE_PIXELS) {
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                            "ClipboardSync: image too large (%dx%d), dropping",
+                            image.width(), image.height());
+                return;
+            }
+
+            QByteArray png;
+            png.reserve(64 * 1024);
+            QBuffer buf(&png);
+            buf.open(QIODevice::WriteOnly);
+            if (!image.save(&buf, "PNG") || png.isEmpty()) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "ClipboardSync: PNG encode failed (%dx%d)",
+                            image.width(), image.height());
+                return;
+            }
+
+            if (png.size() > MAX_PAYLOAD) {
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                            "ClipboardSync: PNG payload %d B exceeds %d B single-packet cap, dropping",
+                            static_cast<int>(png.size()), MAX_PAYLOAD);
+                return;
+            }
+
+            uint64_t hash = hashBytes(png);
+            if (seenRecently(hash)) {
+                return;
+            }
+            recordHash(hash);
+
+            QByteArray frame;
+            if (encodeFrame(KIND_PNG, png, frame)) {
+                int rc = LiSendClipboardData(frame.constData(), frame.size());
+                if (rc != 0) {
+                    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                                 "ClipboardSync: LiSendClipboardData(PNG, %d bytes) -> %d",
+                                 static_cast<int>(frame.size()), rc);
+                }
+            }
+            return;
+        }
     }
 
     QString text = cb->text();
@@ -154,7 +233,7 @@ void ClipboardSync::onLocalClipboardChanged()
     recordHash(hash);
 
     QByteArray frame;
-    if (!encodeTextFrame(utf8, frame)) {
+    if (!encodeFrame(KIND_TEXT, utf8, frame)) {
         return;
     }
 
@@ -163,32 +242,32 @@ void ClipboardSync::onLocalClipboardChanged()
         // Negative return = no active session, host doesn't support clipboard,
         // or send failed; log once at debug level to avoid spam.
         SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                     "ClipboardSync: LiSendClipboardData(%d bytes) -> %d",
+                     "ClipboardSync: LiSendClipboardData(text, %d bytes) -> %d",
                      static_cast<int>(frame.size()), rc);
     }
 }
 
-bool ClipboardSync::encodeTextFrame(const QByteArray& utf8, QByteArray& outFrame) const
+bool ClipboardSync::encodeFrame(uint8_t kind, const QByteArray& payload, QByteArray& outFrame) const
 {
-    if (utf8.size() > MAX_PAYLOAD) {
+    if (payload.size() > MAX_PAYLOAD) {
         return false;
     }
 
     outFrame.clear();
-    outFrame.reserve(10 + utf8.size());
+    outFrame.reserve(10 + payload.size());
 
     // u8 version
     outFrame.append(static_cast<char>(WIRE_VERSION));
     // u8 kind
-    outFrame.append(static_cast<char>(KIND_TEXT));
+    outFrame.append(static_cast<char>(kind));
     // u32 token (LE) - we don't generate tokens client-side; 0 is accepted.
     quint32 tokenLE = qToLittleEndian<quint32>(0);
     outFrame.append(reinterpret_cast<const char*>(&tokenLE), sizeof(tokenLE));
     // u32 length (LE)
-    quint32 lenLE = qToLittleEndian<quint32>(static_cast<quint32>(utf8.size()));
+    quint32 lenLE = qToLittleEndian<quint32>(static_cast<quint32>(payload.size()));
     outFrame.append(reinterpret_cast<const char*>(&lenLE), sizeof(lenLE));
     // bytes payload
-    outFrame.append(utf8);
+    outFrame.append(payload);
     return true;
 }
 

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -13,8 +13,9 @@
 // payload, little-endian) over Limelight control packet 0x5508
 // (LiSendClipboardData / ConnListenerClipboardData).
 //
-// Currently only kind=1 (UTF-8 text) is implemented in both directions.
-// Image / file payloads are accepted on the wire but ignored.
+// Supports kind=1 (UTF-8 text) and kind=2 (PNG image) in both directions.
+// File / other payloads are accepted on the wire but ignored.
+// Single-packet only (no chunking) — payloads above MAX_PAYLOAD are dropped.
 //
 // Echo suppression: when we either write a payload to the local clipboard
 // (because the host pushed it) or send a payload to the host (because we
@@ -43,6 +44,9 @@ public:
     static constexpr int     MAX_PAYLOAD  = 65535 - 10; // wire frame must fit u16 length
     static constexpr int     ECHO_TTL_MS  = 5000;
     static constexpr int     ECHO_MAX     = 16;
+    // Mirror the Android client's cap (32 Mpx) so a stray full-screen capture
+    // doesn't try to PNG-encode a 100 MB bitmap and stall the GUI thread.
+    static constexpr qint64  MAX_IMAGE_PIXELS = 32LL * 1024 * 1024;
 
     explicit ClipboardSync(QObject* parent = nullptr);
     ~ClipboardSync() override;
@@ -66,7 +70,7 @@ private slots:
     void onIncomingFrame(QByteArray frame);
 
 private:
-    bool encodeTextFrame(const QByteArray& utf8, QByteArray& outFrame) const;
+    bool encodeFrame(uint8_t kind, const QByteArray& payload, QByteArray& outFrame) const;
     bool decodeFrame(const QByteArray& frame,
                      uint8_t& outKind,
                      QByteArray& outPayload) const;


### PR DESCRIPTION
## What

为 `ClipboardSync` 加上 PNG 图片的双向同步，对齐 moonlight-android 端的 `ClipboardSyncManager` 设计（kind=2 PNG，单包传输）。

## Why

- 之前 `clipboardsync` 仅文本 (`KIND_TEXT`)：`outFrame.append(KIND_TEXT)` 写死，入站 `if (kind != KIND_TEXT) return;` 直接丢
- moonlight-android 在 `feat/clipboard-sync` 分支已经把同一套 0x5508 opaque transport 接到 PNG（commit 6fc02b3f "feat(clipboard): Sunshine clipboard sync (text + PNG)"）
- 我们的 Sunshine fork 已支持 PNG 透传，差 Qt 客户端这条腿

## How

### 出站 (`onLocalClipboardChanged`)
- `mimeData->hasImage()` 优先于 text（截图常带文件路径 alt-label）
- `QImage::save("PNG")` 重新编码，**32 Mpx 像素上限** + **65525 字节单包上限**（与 Android 一致），超限丢弃并 log
- 回声抑制复用现有 FNV-1a hash deque，对 PNG 字节直接算

### 入站 (`onIncomingFrame`)
- `KIND_PNG` payload → `QImage::loadFromData("PNG")` → `QClipboard::setImage()`
- 写入前 `recordHash` + `m_SuppressNextChange` 抑制自身触发的 `dataChanged`

### Wire / 协议
- 帧格式不变（v1: u8 ver, u8 kind, u32 token LE, u32 len LE, bytes）
- `encodeTextFrame()` → 通用 `encodeFrame(kind, payload)`

### Submodule
- `moonlight-common-c` bump 到 `qiin2333/mic` HEAD (`80f2408`)，引入 opaque 0x5508 transport

## Trade-offs / 不做

- **不分片**：单包 ≤ 65525 B（PNG 编码后），大图直接丢。和 Android 端策略一致，避免 touch core lib 协议
- **不分独立 image/text 开关**：保持现有单一全局开关；Android 端拆开是因为系统授权颗粒，Qt 桌面无此约束
- **不持久化到磁盘**：Qt `QClipboard::setImage` 直接吃 `QImage`，不像 Android 需要 FileProvider URI

## Test

- ✅ Debug build (Qt 6.9.2 / MSVC 2022 x64)：`nmake` 干净通过，`moc_clipboardsync.cpp` 重新生成
- 待验证：实机起会话往返 copy/paste 截图

## Files

- `app/streaming/clipboardsync.h`: `MAX_IMAGE_PIXELS`, 注释更新, `encodeFrame` 重命名
- `app/streaming/clipboardsync.cpp`: 入站 PNG 分支、出站 image 优先、helpers
- `moonlight-common-c`: `4a096f2` → `80f2408` (qiin2333/mic head)