### PR TITLE
feat(clipboard): out-of-band blob transfer via KIND_REF (>60 KB)

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -1,12 +1,21 @@
 #include "clipboardsync.h"
+#include "backend/nvcomputer.h"
 
 #include <QBuffer>
 #include <QClipboard>
 #include <QDateTime>
 #include <QGuiApplication>
 #include <QImage>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QMetaObject>
 #include <QMimeData>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSslConfiguration>
+#include <QSslError>
+#include <QUrl>
 #include <QtEndian>
 
 #include <cstring>
@@ -15,8 +24,9 @@
 
 #include <Limelight.h>
 
-ClipboardSync::ClipboardSync(QObject* parent)
-    : QObject(parent)
+ClipboardSync::ClipboardSync(NvComputer* computer, QObject* parent)
+    : QObject(parent),
+      m_Computer(computer)
 {
     qRegisterMetaType<QByteArray>("QByteArray");
 }
@@ -121,29 +131,63 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
     }
 
     if (kind == KIND_PNG) {
-        QImage image;
-        if (!image.loadFromData(payload, "PNG") || image.isNull()) {
+        applyInboundPng(payload);
+        return;
+    }
+
+    if (kind == KIND_REF) {
+        // Payload is a small UTF-8 JSON descriptor: {"id":"...","mime":"...","size":N}.
+        QJsonParseError jerr{};
+        QJsonDocument doc = QJsonDocument::fromJson(payload, &jerr);
+        if (jerr.error != QJsonParseError::NoError || !doc.isObject()) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping inbound PNG payload (decode failed, %d bytes)",
-                        static_cast<int>(payload.size()));
+                        "ClipboardSync: dropping inbound REF with bad JSON (%s)",
+                        jerr.errorString().toUtf8().constData());
             return;
         }
-
-        QClipboard* cb = QGuiApplication::clipboard();
-        if (cb == nullptr) {
+        QJsonObject obj = doc.object();
+        QString id = obj.value(QStringLiteral("id")).toString();
+        QString mime = obj.value(QStringLiteral("mime")).toString();
+        qint64 size = static_cast<qint64>(obj.value(QStringLiteral("size")).toDouble(0));
+        if (id.isEmpty() || id.size() > 128) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping inbound REF with bad id length");
             return;
         }
-
-        // Hash the wire bytes (not the decoded pixels) so the echo we suppress
-        // matches what we'd re-encode if QClipboard hands the image straight back.
-        uint64_t hash = hashBytes(payload);
-        recordHash(hash);
-        m_SuppressNextChange = true;
-        cb->setImage(image);
+        if (size > MAX_BLOB_BYTES) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping inbound REF, declared size %lld exceeds %lld cap",
+                        static_cast<long long>(size), static_cast<long long>(MAX_BLOB_BYTES));
+            return;
+        }
+        fetchRefAndApply(id, mime);
         return;
     }
 
     // Unknown kind — ignore.
+}
+
+void ClipboardSync::applyInboundPng(const QByteArray& payload)
+{
+    QImage image;
+    if (!image.loadFromData(payload, "PNG") || image.isNull()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping inbound PNG payload (decode failed, %d bytes)",
+                    static_cast<int>(payload.size()));
+        return;
+    }
+
+    QClipboard* cb = QGuiApplication::clipboard();
+    if (cb == nullptr) {
+        return;
+    }
+
+    // Hash the wire bytes (not the decoded pixels) so the echo we suppress
+    // matches what we'd re-encode if QClipboard hands the image straight back.
+    uint64_t hash = hashBytes(payload);
+    recordHash(hash);
+    m_SuppressNextChange = true;
+    cb->setImage(image);
 }
 
 void ClipboardSync::onLocalClipboardChanged()
@@ -190,9 +234,22 @@ void ClipboardSync::onLocalClipboardChanged()
             }
 
             if (png.size() > MAX_PAYLOAD) {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "ClipboardSync: PNG payload %d B exceeds %d B single-packet cap, dropping",
-                            static_cast<int>(png.size()), MAX_PAYLOAD);
+                // Out-of-band path. Record the underlying PNG hash before
+                // upload so the echo we'll see when the host loops the REF
+                // back (and we fetch the same bytes) is suppressed.
+                if (png.size() > MAX_BLOB_BYTES) {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                "ClipboardSync: PNG payload %lld B exceeds %lld B blob cap, dropping",
+                                static_cast<long long>(png.size()),
+                                static_cast<long long>(MAX_BLOB_BYTES));
+                    return;
+                }
+                uint64_t hash = hashBytes(png);
+                if (seenRecently(hash)) {
+                    return;
+                }
+                recordHash(hash);
+                uploadAndSendRef(png, QStringLiteral("image/png"));
                 return;
             }
 
@@ -336,4 +393,148 @@ uint64_t ClipboardSync::hashBytes(const QByteArray& bytes)
         h *= 0x100000001b3ULL;
     }
     return h;
+}
+
+QNetworkAccessManager* ClipboardSync::nam()
+{
+    if (m_Nam == nullptr) {
+        m_Nam = new QNetworkAccessManager(this);
+        // Pin the host's self-signed cert exactly like NvHTTP does: ignore
+        // SSL errors only when the offending cert matches the pinned one.
+        connect(m_Nam, &QNetworkAccessManager::sslErrors, this,
+                [this](QNetworkReply* reply, const QList<QSslError>& errors) {
+                    if (m_Computer == nullptr || m_Computer->serverCert.isNull()) {
+                        return;
+                    }
+                    for (const QSslError& e : errors) {
+                        if (m_Computer->serverCert != e.certificate()) {
+                            return;
+                        }
+                    }
+                    reply->ignoreSslErrors(errors);
+                });
+    }
+    return m_Nam;
+}
+
+bool ClipboardSync::buildBlobUrl(const QString& tail, QUrl& outUrl) const
+{
+    if (m_Computer == nullptr || m_Computer->serverCert.isNull()) {
+        return false;
+    }
+    NvAddress addr = m_Computer->activeAddress;
+    uint16_t port = m_Computer->activeHttpsPort;
+    if (addr.isNull() || port == 0) {
+        return false;
+    }
+    QString host = addr.address();
+    if (host.contains(':')) {
+        host = QString("[%1]").arg(host); // bracketed IPv6
+    }
+    outUrl = QUrl(QString("https://%1:%2/api/v1/clipboard%3").arg(host).arg(port).arg(tail));
+    return outUrl.isValid();
+}
+
+void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& mime)
+{
+    QUrl url;
+    if (!buildBlobUrl(QStringLiteral("/blob"), url)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: cannot upload blob (no host context)");
+        return;
+    }
+
+    QNetworkRequest req(url);
+    req.setHeader(QNetworkRequest::ContentTypeHeader,
+                  QStringLiteral("application/octet-stream"));
+    req.setRawHeader("X-Clipboard-Mime", mime.toUtf8());
+    req.setSslConfiguration(QSslConfiguration::defaultConfiguration());
+
+    QNetworkReply* reply = nam()->post(req, payload);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, mime, payloadSize = payload.size()]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: blob upload failed: %s",
+                        reply->errorString().toUtf8().constData());
+            return;
+        }
+        QJsonParseError jerr{};
+        QJsonDocument doc = QJsonDocument::fromJson(reply->readAll(), &jerr);
+        if (jerr.error != QJsonParseError::NoError || !doc.isObject()) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: blob upload response not JSON: %s",
+                        jerr.errorString().toUtf8().constData());
+            return;
+        }
+        QString id = doc.object().value(QStringLiteral("id")).toString();
+        if (id.isEmpty()) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: blob upload response missing id");
+            return;
+        }
+
+        QJsonObject meta;
+        meta.insert(QStringLiteral("id"), id);
+        meta.insert(QStringLiteral("mime"), mime);
+        meta.insert(QStringLiteral("size"), static_cast<double>(payloadSize));
+        QByteArray json = QJsonDocument(meta).toJson(QJsonDocument::Compact);
+
+        QByteArray frame;
+        if (!encodeFrame(KIND_REF, json, frame)) {
+            return;
+        }
+        int rc = LiSendClipboardData(frame.constData(), frame.size());
+        if (rc != 0) {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "ClipboardSync: LiSendClipboardData(REF, %d bytes) -> %d",
+                         static_cast<int>(frame.size()), rc);
+        }
+    });
+}
+
+void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime)
+{
+    QUrl url;
+    if (!buildBlobUrl(QStringLiteral("/blob/") + id, url)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: cannot fetch blob (no host context)");
+        return;
+    }
+
+    QNetworkRequest req(url);
+    req.setSslConfiguration(QSslConfiguration::defaultConfiguration());
+
+    QNetworkReply* reply = nam()->get(req);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, mime]() {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: blob fetch failed: %s",
+                        reply->errorString().toUtf8().constData());
+            return;
+        }
+        QByteArray bytes = reply->readAll();
+        if (bytes.isEmpty()) {
+            return;
+        }
+        // Trust the REF descriptor's mime over Content-Type.
+        if (mime == QStringLiteral("image/png")) {
+            applyInboundPng(bytes);
+        } else if (mime.startsWith(QStringLiteral("text/"))) {
+            if (bytes.contains('\0')) {
+                return;
+            }
+            uint64_t hash = hashBytes(bytes);
+            recordHash(hash);
+            m_SuppressNextChange = true;
+            if (SDL_SetClipboardText(bytes.constData()) != 0) {
+                m_SuppressNextChange = false;
+            }
+        } else {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping fetched blob with unsupported mime '%s'",
+                        mime.toUtf8().constData());
+        }
+    });
 }

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -5,7 +5,13 @@
 #include <QMutex>
 #include <QPair>
 #include <QQueue>
+#include <QString>
 #include <cstdint>
+
+class NvComputer;
+class QNetworkAccessManager;
+class QNetworkReply;
+class QSslError;
 
 // ClipboardSync owns the bidirectional clipboard sync state for an active
 // streaming session against an AlkaidLab Sunshine fork host. It implements
@@ -13,9 +19,11 @@
 // payload, little-endian) over Limelight control packet 0x5508
 // (LiSendClipboardData / ConnListenerClipboardData).
 //
-// Supports kind=1 (UTF-8 text) and kind=2 (PNG image) in both directions.
+// Supports kind=1 (UTF-8 text), kind=2 (PNG image), and kind=3 (REF JSON
+// pointing to an out-of-band blob transferred over HTTPS via the Sunshine
+// /api/v1/clipboard/blob endpoints) in both directions. Payloads above the
+// 65 KB single-packet cap are switched to KIND_REF transparently.
 // File / other payloads are accepted on the wire but ignored.
-// Single-packet only (no chunking) — payloads above MAX_PAYLOAD are dropped.
 //
 // Echo suppression: when we either write a payload to the local clipboard
 // (because the host pushed it) or send a payload to the host (because we
@@ -38,17 +46,23 @@ public:
     enum Kind : uint8_t {
         KIND_TEXT = 1,
         KIND_PNG  = 2,
+        KIND_REF  = 3,
     };
 
     static constexpr uint8_t WIRE_VERSION = 1;
     static constexpr int     MAX_PAYLOAD  = 65535 - 10; // wire frame must fit u16 length
+    // Payload size at/above which we switch from inline KIND_TEXT/KIND_PNG to
+    // out-of-band blob transfer (KIND_REF). Leaves headroom under the wire cap.
+    static constexpr int     INLINE_THRESHOLD = 60000;
+    // Mirrors the service-side blob store cap (50 MiB).
+    static constexpr qint64  MAX_BLOB_BYTES   = 50LL * 1024 * 1024;
     static constexpr int     ECHO_TTL_MS  = 5000;
     static constexpr int     ECHO_MAX     = 16;
     // Mirror the Android client's cap (32 Mpx) so a stray full-screen capture
     // doesn't try to PNG-encode a 100 MB bitmap and stall the GUI thread.
     static constexpr qint64  MAX_IMAGE_PIXELS = 32LL * 1024 * 1024;
 
-    explicit ClipboardSync(QObject* parent = nullptr);
+    explicit ClipboardSync(NvComputer* computer = nullptr, QObject* parent = nullptr);
     ~ClipboardSync() override;
 
     // Start watching the local clipboard and accepting inbound payloads.
@@ -80,6 +94,17 @@ private:
     void recordHash(uint64_t hash);
 
     static uint64_t hashBytes(const QByteArray& bytes);
+
+    // Out-of-band blob helpers. Both run on the GUI thread; the
+    // QNetworkAccessManager event-loop callbacks land back on the GUI thread.
+    bool buildBlobUrl(const QString& tail, QUrl& outUrl) const;
+    QNetworkAccessManager* nam();
+    void uploadAndSendRef(const QByteArray& payload, const QString& mime);
+    void fetchRefAndApply(const QString& id, const QString& mime);
+    void applyInboundPng(const QByteArray& payload);
+
+    NvComputer* m_Computer = nullptr;
+    QNetworkAccessManager* m_Nam = nullptr;
 
     bool m_Active = false;
     QQueue<QPair<uint64_t, qint64>> m_EchoCache; // (hash, timestamp_ms)

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -2073,7 +2073,7 @@ void Session::start()
     // control receive thread can possibly invoke clClipboardData(). It is
     // started after a successful connection in clConnectionStatusUpdate.
     if (m_ClipboardSync == nullptr) {
-        m_ClipboardSync = new ClipboardSync(this);
+        m_ClipboardSync = new ClipboardSync(m_Computer, this);
         m_ClipboardSync->start();
     }
 


### PR DESCRIPTION
## Summary

When PNG payloads exceed the single-packet wire ceiling (~65 KB), upload them to the host's `/api/v1/clipboard/blob` endpoint over HTTPS and emit a `KIND_REF=3` frame whose payload is a small JSON descriptor:

```json
{"id":"<uuid>","mime":"image/png","size":12345}
```

Inbound `KIND_REF` frames are dereferenced (HTTPS GET) then applied as if they had arrived inline.

## Why

PR #74 (PNG sync) caps payloads at the single-packet wire limit, so screenshots / large images get silently dropped. This PR lifts the practical cap to 50 MiB by routing big payloads out-of-band, while keeping small payloads on the realtime control channel.

## Architecture

| Layer | Role |
|---|---|
| moonlight-common-c | Dumb byte forwarder; just publishes `LI_CLIPBOARD_KIND_REF=3` constant |
| Sunshine `clipboard_bridge` (C++) | Dumb byte forwarder, unchanged |
| Sunshine `/api/v1/clipboard/blob` (C++) | Dumb blob storage (50 MiB / 200 MiB / 60 s TTL) |
| Sunshine GUI agent (Rust) | Smart: detects large outbound, uploads, sends REF; on inbound REF, fetches |
| **Moonlight Qt (this PR)** | Smart: same logic on the client side |

The wire protocol stays version 1; KIND_REF is just a new `kind` byte, JSON descriptor in the payload slot.

## Changes

- `app/streaming/clipboardsync.h`/`.cpp`:
  - Add `KIND_REF=3` to wire kind enum.
  - `ClipboardSync` now takes `NvComputer*` so it can reuse the pinned-cert HTTPS infrastructure (mirrors `NvHTTP::handleSslErrors`: ignore SSL errors only when the offending cert matches `m_Computer->serverCert`).
  - `INLINE_THRESHOLD = 60_000` (headroom under 65 525 wire cap).
  - `MAX_BLOB_BYTES = 50 MiB` (matches service-side blob store cap).
  - `uploadAndSendRef` POSTs to `/api/v1/clipboard/blob` with `X-Clipboard-Mime` header, parses returned `{id}`, emits REF frame via `LiSendClipboardData`.
  - `fetchRefAndApply` GETs `/api/v1/clipboard/blob/<id>` then dispatches to `applyInboundPng` or text path based on the REF mime.
  - Echo suppression hashes the underlying PNG bytes before upload, so REF loop-backs are still suppressed.
  - Lazy `QNetworkAccessManager` member; QT event loop drives the callbacks back onto the GUI thread.
- `app/streaming/session.cpp`: pass `m_Computer` to `ClipboardSync` ctor.
- Submodule bump `moonlight-common-c` `80f2408` → `b8e0854` (qiin2333/moonlight-common-c PR #8 — `LI_CLIPBOARD_KIND_REF` constant).

## Build

Qt Debug build (MSVC 2022, Qt 6.9.2): clean (`nmake` exit 0). Moonlight.exe linked.

## Pairs with

- foundation-sunshine PR #633 (blob endpoints)
- sunshine-control-panel PR #33 (Rust agent KIND_REF)
- moonlight-common-c PR #8 (`LI_CLIPBOARD_KIND_REF` constant)

## Stacked on

PR #74 (PNG sync). Merge order: #74 → this. Diff shown here is the delta against #74's branch.
