### PR TITLE
fix(clipboard): align blob cap to 64 MiB and harden REF size validation

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -160,7 +160,7 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
                         static_cast<long long>(size), static_cast<long long>(MAX_BLOB_BYTES));
             return;
         }
-        fetchRefAndApply(id, mime);
+        fetchRefAndApply(id, mime, size);
         return;
     }
 
@@ -493,7 +493,7 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
     });
 }
 
-void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime)
+void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qint64 advertisedSize)
 {
     QUrl url;
     if (!buildBlobUrl(QStringLiteral("/blob/") + id, url)) {
@@ -506,7 +506,7 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime)
     req.setSslConfiguration(QSslConfiguration::defaultConfiguration());
 
     QNetworkReply* reply = nam()->get(req);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, mime]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, mime, advertisedSize]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
@@ -516,6 +516,23 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime)
         }
         QByteArray bytes = reply->readAll();
         if (bytes.isEmpty()) {
+            return;
+        }
+        // Defense: cap actual download size in case the server lied about
+        // advertised size or QNAM streamed past the declared length.
+        if (bytes.size() > MAX_BLOB_BYTES) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping fetched blob, actual size %lld exceeds %lld cap",
+                        static_cast<long long>(bytes.size()),
+                        static_cast<long long>(MAX_BLOB_BYTES));
+            return;
+        }
+        // Hard-fail on advertised/actual mismatch when REF declared a size.
+        if (advertisedSize > 0 && bytes.size() != advertisedSize) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "ClipboardSync: dropping fetched blob, size mismatch (got %lld, advertised %lld)",
+                        static_cast<long long>(bytes.size()),
+                        static_cast<long long>(advertisedSize));
             return;
         }
         // Trust the REF descriptor's mime over Content-Type.

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -54,8 +54,9 @@ public:
     // Payload size at/above which we switch from inline KIND_TEXT/KIND_PNG to
     // out-of-band blob transfer (KIND_REF). Leaves headroom under the wire cap.
     static constexpr int     INLINE_THRESHOLD = 60000;
-    // Mirrors the service-side blob store cap (50 MiB).
-    static constexpr qint64  MAX_BLOB_BYTES   = 50LL * 1024 * 1024;
+    // Mirrors the cross-client cap (64 MiB) shared with the Android and
+    // HarmonyOS clients. The service-side blob store accepts up to this much.
+    static constexpr qint64  MAX_BLOB_BYTES   = 64LL * 1024 * 1024;
     static constexpr int     ECHO_TTL_MS  = 5000;
     static constexpr int     ECHO_MAX     = 16;
     // Mirror the Android client's cap (32 Mpx) so a stray full-screen capture
@@ -100,7 +101,7 @@ private:
     bool buildBlobUrl(const QString& tail, QUrl& outUrl) const;
     QNetworkAccessManager* nam();
     void uploadAndSendRef(const QByteArray& payload, const QString& mime);
-    void fetchRefAndApply(const QString& id, const QString& mime);
+    void fetchRefAndApply(const QString& id, const QString& mime, qint64 advertisedSize);
     void applyInboundPng(const QByteArray& payload);
 
     NvComputer* m_Computer = nullptr;


### PR DESCRIPTION
## 背景

跨端剪贴板 blob 通道（KIND_REF）已在 Android、HarmonyOS、Qt 三端实现。本次审计发现 Qt 与另外两端在 **客户端侧防御** 上不一致，本 PR 把高 ROI 的差异补齐。

## 改动

- **MAX_BLOB_BYTES 50 → 64 MiB**：与 Android/HarmonyOS 客户端跨端一致。
- **下载后 actual size 上限校验**：防服务端 advertised size 撒谎或 QNAM 流过头导致内存膨胀。
- **advertised vs actual size mismatch 硬失败**：当 REF 声明了 size>0，下载完成后字节数必须严格匹配，否则丢弃。与另外两端策略一致。

## 不影响互通

旧版服务端不发 KIND_REF，inbound REF 路径不会被触发；新增上限只在客户端侧拒收。**本 PR 不改变线协议**。

## 验证

- MSVC2022 / Qt 6.9.2 Debug 构建通过（`BUILD_EXIT_CODE=0`）
- moc_clipboardsync.cpp 重新生成无错