### PR TITLE
修复顶部状态条在一些情况下糊掉

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -1349,12 +1349,12 @@ bool D3D11VARenderer::createOverlayVertexBuffer(Overlay::OverlayType type, int w
     // and screen y=displayHeight maps to NDC y=1 (top of screen).
     if (type == Overlay::OverlayStatusUpdate) {
         // Bottom center
-        renderRect.x = (m_DisplayWidth - width) / 2.0f;
+        renderRect.x = (m_DisplayWidth - width) / 2;
         renderRect.y = 0;
     }
     else if (type == Overlay::OverlayDebug) {
         // Top center
-        renderRect.x = (m_DisplayWidth - width) / 2.0f;
+        renderRect.x = (m_DisplayWidth - width) / 2;
         renderRect.y = m_DisplayHeight - height;
     }
 

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -1349,12 +1349,12 @@ bool D3D11VARenderer::createOverlayVertexBuffer(Overlay::OverlayType type, int w
     // and screen y=displayHeight maps to NDC y=1 (top of screen).
     if (type == Overlay::OverlayStatusUpdate) {
         // Bottom center
-        renderRect.x = (m_DisplayWidth - width) / 2;
+        renderRect.x = (m_DisplayWidth - width) / 2; // 用整数除法把 overlay quad 对齐到整像素，避免半像素位置导致 bilinear blur
         renderRect.y = 0;
     }
     else if (type == Overlay::OverlayDebug) {
         // Top center
-        renderRect.x = (m_DisplayWidth - width) / 2;
+        renderRect.x = (m_DisplayWidth - width) / 2; // 用整数除法把 overlay quad 对齐到整像素，避免半像素位置导致 bilinear blur
         renderRect.y = m_DisplayHeight - height;
     }
 

--- a/app/streaming/video/overlaymanager.cpp
+++ b/app/streaming/video/overlaymanager.cpp
@@ -7,6 +7,32 @@
 
 using namespace Overlay;
 
+static void configureFontRendering(TTF_Font* font, bool isBold, bool isItalic)
+{
+    if (font == nullptr) {
+        return;
+    }
+
+    int style = TTF_STYLE_NORMAL;
+    if (isBold) {
+        style |= TTF_STYLE_BOLD;
+    }
+    if (isItalic) {
+        style |= TTF_STYLE_ITALIC;
+    }
+    TTF_SetFontStyle(font, style);
+
+    TTF_SetFontHinting(font, TTF_HINTING_NORMAL);
+
+    TTF_SetFontOutline(font, 0);
+
+    if (TTF_GetFontKerning != nullptr) {
+        TTF_SetFontKerning(font, 1);
+    }
+
+    TTF_SetFontWrappedAlign(font, TTF_WRAPPED_ALIGN_CENTER);
+}
+
 OverlayManager::OverlayManager() :
     m_Renderer(nullptr),
     m_FontData(Path::readDataFile("ModeSeven.ttf"))
@@ -327,31 +353,7 @@ TTF_Font* OverlayManager::getFontForStyle(OverlayType type, bool isBold, bool is
             return nullptr;
         }
         
-        // 设置字体样式
-        int style = TTF_STYLE_NORMAL;
-        if (isBold) style |= TTF_STYLE_BOLD;
-        if (isItalic) style |= TTF_STYLE_ITALIC;
-        TTF_SetFontStyle(*targetFont, style);
-        
-        // 启用字体平滑渲染设置
-        // 设置字体提示以改善渲染质量
-        TTF_SetFontHinting(*targetFont, TTF_HINTING_LIGHT);
-        
-        // 启用字体轮廓 (如果支持)
-        TTF_SetFontOutline(*targetFont, 0);
-        
-        // 设置字体距离 (字符间距)
-        // TTF_SetFontKerning(*targetFont, 1); // 启用字距调整
-        
-        // 额外的字体质量设置
-        // 设置字体样式优化
-        if (TTF_GetFontKerning != nullptr) {
-            // 如果支持字距调整，启用它以获得更好的字符间距
-            TTF_SetFontKerning(*targetFont, 1);
-        }
-        
-        // 设置字体包装对齐（用于多行文本）
-        TTF_SetFontWrappedAlign(*targetFont, TTF_WRAPPED_ALIGN_CENTER);
+        configureFontRendering(*targetFont, isBold, isItalic);
     }
     
     return *targetFont;
@@ -598,21 +600,7 @@ TTF_Font* OverlayManager::getFontForStyleAndSize(OverlayType type, bool isBold, 
         return getFontForStyle(type, isBold, isItalic);
     }
     
-    // 设置字体样式
-    int style = TTF_STYLE_NORMAL;
-    if (isBold) style |= TTF_STYLE_BOLD;
-    if (isItalic) style |= TTF_STYLE_ITALIC;
-    TTF_SetFontStyle(tempFont, style);
-    
-    // 应用字体平滑设置
-    TTF_SetFontHinting(tempFont, TTF_HINTING_LIGHT);
-    TTF_SetFontOutline(tempFont, 0);
-    
-    if (TTF_GetFontKerning != nullptr) {
-        TTF_SetFontKerning(tempFont, 1);
-    }
-    
-    TTF_SetFontWrappedAlign(tempFont, TTF_WRAPPED_ALIGN_CENTER);
+    configureFontRendering(tempFont, isBold, isItalic);
     
     return tempFont;
 }


### PR DESCRIPTION
修了顶部条条有的时候会糊掉以及subpixel的事情（但是subpixel倒是没看出啥效果）

before:
<img width="627" height="112" alt="7cd39c46-2aca-4957-906c-71865d132589" src="https://github.com/user-attachments/assets/7ccaac9a-e8a8-41ea-84be-6f1f14ac4f04" />
<img width="791" height="62" alt="image" src="https://github.com/user-attachments/assets/26706845-5d4c-48ae-bdbf-3e64e61a5943" />
after:
<img width="1365" height="55" alt="image" src="https://github.com/user-attachments/assets/207116a2-2ff9-4c50-908b-ed2ad87d9f32" />

