### PR TITLE
Add Sunshine smart bitrate support

### DIFF
--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -558,6 +558,68 @@ NvHTTP::openConnectionToString(QUrl baseUrl,
     return ret;
 }
 
+bool
+NvHTTP::getAbrCapabilities(int* hostMaxBitrateKbps)
+{
+    QJsonObject response = openJsonConnectionToObject(m_BaseUrlHttps,
+                                                      "api/abr/capabilities",
+                                                      QJsonObject(),
+                                                      false,
+                                                      FAST_FAIL_TIMEOUT_MS,
+                                                      NvLogLevel::NVLL_ERROR);
+    if (hostMaxBitrateKbps != nullptr) {
+        *hostMaxBitrateKbps = response.value("hostMaxBitrate").toInt(0);
+    }
+
+    return response.value("supported").toBool(false);
+}
+
+QJsonObject
+NvHTTP::configureAbr(bool enabled,
+                     int minBitrateKbps,
+                     int maxBitrateKbps,
+                     QString mode,
+                     int timeoutMs)
+{
+    QJsonObject body;
+    body["enabled"] = enabled;
+    if (enabled) {
+        body["minBitrate"] = minBitrateKbps;
+        body["maxBitrate"] = maxBitrateKbps;
+        body["mode"] = mode;
+    }
+
+    return openJsonConnectionToObject(m_BaseUrlHttps,
+                                      "api/abr",
+                                      body,
+                                      true,
+                                      timeoutMs,
+                                      NvLogLevel::NVLL_ERROR);
+}
+
+QJsonObject
+NvHTTP::sendAbrFeedback(double packetLoss,
+                        double rttMs,
+                        double decodeFps,
+                        int droppedFrames,
+                        int currentBitrateKbps,
+                        int timeoutMs)
+{
+    QJsonObject body;
+    body["packetLoss"] = packetLoss;
+    body["rttMs"] = rttMs;
+    body["decodeFps"] = decodeFps;
+    body["droppedFrames"] = droppedFrames;
+    body["currentBitrate"] = currentBitrateKbps;
+
+    return openJsonConnectionToObject(m_BaseUrlHttps,
+                                      "api/abr/feedback",
+                                      body,
+                                      true,
+                                      timeoutMs,
+                                      NvLogLevel::NVLL_ERROR);
+}
+
 QNetworkReply*
 NvHTTP::openConnection(QUrl baseUrl,
                        QString command,
@@ -663,6 +725,123 @@ NvHTTP::openConnection(QUrl baseUrl,
             delete reply;
             throw exception;
         }
+    }
+
+    return reply;
+}
+
+QJsonObject
+NvHTTP::openJsonConnectionToObject(QUrl baseUrl,
+                                   QString command,
+                                   QJsonObject body,
+                                   bool post,
+                                   int timeoutMs,
+                                   NvLogLevel logLevel)
+{
+    QNetworkReply* reply = openJsonConnection(baseUrl, command, body, post, timeoutMs, logLevel);
+    QByteArray response = reply->readAll();
+    delete reply;
+
+    QJsonParseError parseError;
+    QJsonDocument document = QJsonDocument::fromJson(response, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
+        qWarning() << command << "JSON response parse failed:" << parseError.errorString();
+        throw GfeHttpResponseException(-1, "Malformed JSON response");
+    }
+
+    return document.object();
+}
+
+QNetworkReply*
+NvHTTP::openJsonConnection(QUrl baseUrl,
+                           QString command,
+                           QJsonObject body,
+                           bool post,
+                           int timeoutMs,
+                           NvLogLevel logLevel)
+{
+    // Port must be set
+    Q_ASSERT(baseUrl.port(0) != 0);
+
+    QUrl url(baseUrl);
+    url.setPath("/" + command);
+
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+    request.setSslConfiguration(IdentityManager::get()->getSslConfig());
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Disable HTTP/2 (GFE 3.22 doesn't like it) and Qt 6 enables it by default
+    request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+#endif
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 3, 0)
+    // Use fine-grained idle timeouts to avoid calling QNetworkAccessManager::clearAccessCache(),
+    // which tears down the NAM's global thread each time. We must not keep persistent connections
+    // or GFE will puke.
+    request.setAttribute(QNetworkRequest::ConnectionCacheExpiryTimeoutSecondsAttribute, 0);
+#endif
+
+    auto sslErrorsConnection = connect(m_Nam, &QNetworkAccessManager::sslErrors, this, &NvHTTP::handleSslErrors);
+    QNetworkReply* reply = post ?
+                m_Nam->post(request, QJsonDocument(body).toJson(QJsonDocument::Compact)) :
+                m_Nam->get(request);
+
+    QEventLoop loop;
+    connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, &loop, &QEventLoop::quit);
+    if (timeoutMs) {
+        QTimer::singleShot(timeoutMs, &loop, &QEventLoop::quit);
+    }
+    if (logLevel >= NvLogLevel::NVLL_VERBOSE) {
+        qInfo() << "Executing JSON request:" << url.toString();
+    }
+    loop.exec(QEventLoop::ExcludeUserInputEvents);
+
+    if (!reply->isFinished())
+    {
+        if (logLevel >= NvLogLevel::NVLL_ERROR) {
+            qWarning() << "Aborting timed out JSON request for" << url.toString();
+        }
+        reply->abort();
+    }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
+    m_Nam->clearAccessCache();
+#endif
+    disconnect(sslErrorsConnection);
+
+    if (reply->error() != QNetworkReply::NoError)
+    {
+        if (logLevel >= NvLogLevel::NVLL_ERROR) {
+            qWarning() << command << "JSON request failed with error:" << reply->error();
+        }
+
+        if (reply->error() == QNetworkReply::SslHandshakeFailedError) {
+            GfeHttpResponseException exception(401, "Server certificate mismatch");
+            delete reply;
+            throw exception;
+        }
+        else if (reply->error() == QNetworkReply::OperationCanceledError) {
+            QtNetworkReplyException exception(QNetworkReply::TimeoutError, "Request timed out");
+            delete reply;
+            throw exception;
+        }
+        else {
+            QtNetworkReplyException exception(reply->error(), reply->errorString());
+            delete reply;
+            throw exception;
+        }
+    }
+
+    int httpStatus = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (httpStatus >= 400) {
+        QString errorText = QString::fromUtf8(reply->readAll());
+        if (logLevel >= NvLogLevel::NVLL_ERROR) {
+            qWarning() << command << "JSON request failed with HTTP status" << httpStatus << errorText;
+        }
+        delete reply;
+        throw GfeHttpResponseException(httpStatus, errorText);
     }
 
     return reply;

--- a/app/backend/nvhttp.h
+++ b/app/backend/nvhttp.h
@@ -10,6 +10,7 @@
 #include <QUrl>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QJsonObject>
 #include <QVariant>
 
 class NvComputer;
@@ -143,6 +144,24 @@ public:
                            int timeoutMs,
                            NvLogLevel logLevel = NvLogLevel::NVLL_VERBOSE);
 
+    bool
+    getAbrCapabilities(int* hostMaxBitrateKbps = nullptr);
+
+    QJsonObject
+    configureAbr(bool enabled,
+                 int minBitrateKbps,
+                 int maxBitrateKbps,
+                 QString mode,
+                 int timeoutMs = 2000);
+
+    QJsonObject
+    sendAbrFeedback(double packetLoss,
+                    double rttMs,
+                    double decodeFps,
+                    int droppedFrames,
+                    int currentBitrateKbps,
+                    int timeoutMs = 2000);
+
     void setServerCert(QSslCertificate serverCert);
 
     void setAddress(NvAddress address);
@@ -202,6 +221,22 @@ private:
                    QString arguments,
                    int timeoutMs,
                    NvLogLevel logLevel);
+
+    QNetworkReply*
+    openJsonConnection(QUrl baseUrl,
+                       QString command,
+                       QJsonObject body,
+                       bool post,
+                       int timeoutMs,
+                       NvLogLevel logLevel);
+
+    QJsonObject
+    openJsonConnectionToObject(QUrl baseUrl,
+                               QString command,
+                               QJsonObject body,
+                               bool post,
+                               int timeoutMs,
+                               NvLogLevel logLevel = NvLogLevel::NVLL_VERBOSE);
 
     NvAddress m_Address;
     QNetworkAccessManager* m_Nam;

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -804,6 +804,23 @@ Flickable {
                     hoverEnabled: true
                 }
 
+                CheckBox {
+                    id: sunshineAbrCheck
+                    width: parent.width
+                    hoverEnabled: true
+                    text: qsTr("Smart bitrate with Sunshine")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.enableSunshineAbr
+                    onCheckedChanged: {
+                        StreamingPreferences.enableSunshineAbr = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 8000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Allows Sunshine to automatically adjust stream bitrate up to the selected video bitrate when the host supports ABR.")
+                }
+
                 Label {
                     width: parent.width
                     id: windowModeTitle

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -17,6 +17,7 @@
 #define SER_BITRATE "bitrate"
 
 #define SER_AUTOADJUSTBITRATE "autoadjustbitrate"
+#define SER_SUNSHINEABR "sunshineabr"
 #define SER_FULLSCREEN "fullscreen"
 #define SER_IGNORE_ASPECT_RATIO "ignoreaspectratio"
 #define SER_VSYNC "vsync"
@@ -145,6 +146,7 @@ void StreamingPreferences::reload()
     enableYUV444 = settings.value(SER_YUV444, false).toBool();
     bitrateKbps = settings.value(SER_BITRATE, getDefaultBitrate(width, height, fps, enableYUV444)).toInt();
     autoAdjustBitrate = settings.value(SER_AUTOADJUSTBITRATE, true).toBool();
+    enableSunshineAbr = settings.value(SER_SUNSHINEABR, false).toBool();
     ignoreAspectRatio = settings.value(SER_IGNORE_ASPECT_RATIO, true).toBool();
     enableVsync = settings.value(SER_VSYNC, true).toBool();
     gameOptimizations = settings.value(SER_GAMEOPTS, true).toBool();
@@ -364,6 +366,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_FPS, fps);
     settings.setValue(SER_BITRATE, bitrateKbps);
     settings.setValue(SER_AUTOADJUSTBITRATE, autoAdjustBitrate);
+    settings.setValue(SER_SUNSHINEABR, enableSunshineAbr);
     settings.setValue(SER_IGNORE_ASPECT_RATIO, ignoreAspectRatio);
     settings.setValue(SER_VSYNC, enableVsync);
     settings.setValue(SER_GAMEOPTS, gameOptimizations);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -142,6 +142,7 @@ public:
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
     Q_PROPERTY(int bitrateKbps MEMBER bitrateKbps NOTIFY bitrateChanged)
     Q_PROPERTY(bool autoAdjustBitrate MEMBER autoAdjustBitrate NOTIFY autoAdjustBitrateChanged)
+    Q_PROPERTY(bool enableSunshineAbr MEMBER enableSunshineAbr NOTIFY enableSunshineAbrChanged)
     Q_PROPERTY(bool ignoreAspectRatio MEMBER ignoreAspectRatio NOTIFY ignoreAspectRatioChanged)
     Q_PROPERTY(bool enableVsync MEMBER enableVsync NOTIFY enableVsyncChanged)
     Q_PROPERTY(bool gameOptimizations MEMBER gameOptimizations NOTIFY gameOptimizationsChanged)
@@ -200,6 +201,7 @@ public:
     int fps;
     int bitrateKbps;
     bool autoAdjustBitrate;
+    bool enableSunshineAbr;
     bool ignoreAspectRatio;
     bool enableVsync;
     bool gameOptimizations;
@@ -255,6 +257,7 @@ signals:
     void displayModeChanged();
     void bitrateChanged();
     void autoAdjustBitrateChanged();
+    void enableSunshineAbrChanged();
     void ignoreAspectRatioChanged();
     void enableVsyncChanged();
     void gameOptimizationsChanged();

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -42,6 +42,7 @@
 #include <QtEndian>
 #include <QCoreApplication>
 #include <QThreadPool>
+#include <QRunnable>
 #include <QSvgRenderer>
 #include <QPainter>
 #include <QImage>
@@ -75,6 +76,69 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
 
 Session* Session::s_ActiveSession;
 QSemaphore Session::s_ActiveSessionSemaphore(1);
+
+class AbrFeedbackTask : public QRunnable
+{
+public:
+    AbrFeedbackTask(NvAddress address,
+                    uint16_t httpsPort,
+                    QSslCertificate serverCert,
+                    QString uuid,
+                    double packetLoss,
+                    double rttMs,
+                    double decodeFps,
+                    int droppedFrames,
+                    std::shared_ptr<std::atomic_bool> inFlight,
+                    std::shared_ptr<std::atomic_int> currentBitrateKbps)
+        : m_Address(address),
+          m_HttpsPort(httpsPort),
+          m_ServerCert(serverCert),
+          m_Uuid(uuid),
+          m_PacketLoss(packetLoss),
+          m_RttMs(rttMs),
+          m_DecodeFps(decodeFps),
+          m_DroppedFrames(droppedFrames),
+          m_InFlight(inFlight),
+          m_CurrentBitrateKbps(currentBitrateKbps)
+    {
+    }
+
+    virtual void run() override
+    {
+        try {
+            NvHTTP http(m_Address, m_HttpsPort, m_ServerCert, nullptr, m_Uuid);
+            QJsonObject response = http.sendAbrFeedback(m_PacketLoss,
+                                                        m_RttMs,
+                                                        m_DecodeFps,
+                                                        m_DroppedFrames,
+                                                        m_CurrentBitrateKbps->load(),
+                                                        2000);
+
+            int newBitrate = response.value("newBitrate").toInt(0);
+            if (newBitrate > 0) {
+                m_CurrentBitrateKbps->store(newBitrate);
+                qInfo() << "Sunshine ABR adjusted bitrate to" << newBitrate << "Kbps:" << response.value("reason").toString();
+            }
+        }
+        catch (const std::exception& e) {
+            qWarning() << "Sunshine ABR feedback failed:" << e.what();
+        }
+
+        m_InFlight->store(false);
+    }
+
+private:
+    NvAddress m_Address;
+    uint16_t m_HttpsPort;
+    QSslCertificate m_ServerCert;
+    QString m_Uuid;
+    double m_PacketLoss;
+    double m_RttMs;
+    double m_DecodeFps;
+    int m_DroppedFrames;
+    std::shared_ptr<std::atomic_bool> m_InFlight;
+    std::shared_ptr<std::atomic_int> m_CurrentBitrateKbps;
+};
 
 void Session::clStageStarting(int stage)
 {
@@ -594,10 +658,15 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_MenuPanel(nullptr),
       m_DeferCaptureRestore(false),
       m_PendingMicToggle(false),
+            m_SunshineAbrEnabled(false),
+            m_LastAbrFeedbackTicks(0),
+            m_AbrFeedbackInFlight(std::make_shared<std::atomic_bool>(false)),
+            m_AbrCurrentBitrateKbps(std::make_shared<std::atomic_int>(0)),
       m_Toast(nullptr),
       m_MenuCloseTicks(0),
       m_MicStream(nullptr)
 {
+    memset(&m_LastAbrVideoStats, 0, sizeof(m_LastAbrVideoStats));
     m_ClipboardSync = nullptr;
 }
 
@@ -1821,6 +1890,8 @@ void Session::requestRuntimeBitrateChange(int bitrateKbps)
                     "Runtime bitrate change to %d kbps: %s",
                     bitrateKbps,
                     response.toUtf8().constData());
+
+        m_AbrCurrentBitrateKbps->store(bitrateKbps);
     }
     catch (const GfeHttpResponseException& e) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
@@ -1836,6 +1907,136 @@ void Session::requestRuntimeBitrateChange(int bitrateKbps)
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "Runtime bitrate change failed: unknown error");
     }
+}
+
+void Session::startSunshineAbr()
+{
+    m_SunshineAbrEnabled = false;
+
+    if (!m_Preferences->enableSunshineAbr || !m_Computer) {
+        return;
+    }
+
+    try {
+        NvHTTP http(m_Computer);
+
+        int hostMaxBitrate = 0;
+        if (!http.getAbrCapabilities(&hostMaxBitrate)) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Host does not advertise Sunshine ABR support");
+            return;
+        }
+
+        QJsonObject configResponse = http.configureAbr(true,
+                                                       0,
+                                                       m_Preferences->bitrateKbps,
+                                                       "balanced",
+                                                       2000);
+        if (!configResponse.value("success").toBool(false)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Sunshine ABR configure rejected by host");
+            return;
+        }
+
+        int initialBitrate = configResponse.value("initialBitrate").toInt(m_StreamConfig.bitrate);
+        m_AbrCurrentBitrateKbps->store(initialBitrate);
+        m_AbrFeedbackInFlight->store(false);
+
+        const RTP_VIDEO_STATS* videoStats = LiGetRTPVideoStats();
+        if (videoStats != nullptr) {
+            memcpy(&m_LastAbrVideoStats, videoStats, sizeof(m_LastAbrVideoStats));
+        }
+        else {
+            memset(&m_LastAbrVideoStats, 0, sizeof(m_LastAbrVideoStats));
+        }
+
+        m_LastAbrFeedbackTicks = SDL_GetTicks();
+        m_SunshineAbrEnabled = true;
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Sunshine ABR enabled: initial=%d Kbps, max=%d Kbps, hostMax=%d Kbps",
+                    initialBitrate,
+                    configResponse.value("maxBitrate").toInt(0),
+                    hostMaxBitrate);
+    }
+    catch (const std::exception& e) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Sunshine ABR unavailable: %s",
+                    e.what());
+    }
+    catch (...) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Sunshine ABR unavailable: unknown error");
+    }
+}
+
+void Session::stopSunshineAbr()
+{
+    if (!m_SunshineAbrEnabled || !m_Computer) {
+        m_SunshineAbrEnabled = false;
+        return;
+    }
+
+    m_SunshineAbrEnabled = false;
+
+    try {
+        NvHTTP http(m_Computer);
+        http.configureAbr(false, 0, 0, "balanced", 1000);
+    }
+    catch (const std::exception& e) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Sunshine ABR disable failed: %s",
+                    e.what());
+    }
+    catch (...) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Sunshine ABR disable failed: unknown error");
+    }
+}
+
+void Session::sendSunshineAbrFeedback()
+{
+    if (!m_SunshineAbrEnabled || !m_Computer) {
+        return;
+    }
+
+    if (m_AbrFeedbackInFlight->exchange(true)) {
+        return;
+    }
+
+    const RTP_VIDEO_STATS* videoStats = LiGetRTPVideoStats();
+    if (videoStats == nullptr) {
+        m_AbrFeedbackInFlight->store(false);
+        return;
+    }
+
+    const uint32_t deltaVideo = videoStats->packetCountVideo - m_LastAbrVideoStats.packetCountVideo;
+    const uint32_t deltaFec = videoStats->packetCountFec - m_LastAbrVideoStats.packetCountFec;
+    const uint32_t deltaFecFailed = videoStats->packetCountFecFailed - m_LastAbrVideoStats.packetCountFecFailed;
+    const uint32_t deltaOos = videoStats->packetCountOOS - m_LastAbrVideoStats.packetCountOOS;
+    const uint32_t deltaInvalid = videoStats->packetCountInvalid - m_LastAbrVideoStats.packetCountInvalid;
+    const uint32_t deltaFecInvalid = videoStats->packetCountFecInvalid - m_LastAbrVideoStats.packetCountFecInvalid;
+    memcpy(&m_LastAbrVideoStats, videoStats, sizeof(m_LastAbrVideoStats));
+
+    const uint64_t packetCount = static_cast<uint64_t>(deltaVideo) + deltaFec;
+    const uint64_t lossIndicators = static_cast<uint64_t>(deltaFecFailed) + deltaOos + deltaInvalid + deltaFecInvalid;
+    const double packetLoss = packetCount > 0 ? qMin(100.0, (static_cast<double>(lossIndicators) * 100.0) / packetCount) : 0.0;
+    const int droppedFrames = static_cast<int>(deltaFecFailed + deltaOos + deltaInvalid);
+
+    uint32_t rtt = 0;
+    uint32_t rttVariance = 0;
+    LiGetEstimatedRttInfo(&rtt, &rttVariance);
+
+    QThreadPool::globalInstance()->start(new AbrFeedbackTask(m_Computer->activeAddress,
+                                                             m_Computer->activeHttpsPort,
+                                                             m_Computer->serverCert,
+                                                             m_Computer->uuid,
+                                                             packetLoss,
+                                                             rtt,
+                                                             m_ActiveVideoFrameRate,
+                                                             droppedFrames,
+                                                             m_AbrFeedbackInFlight,
+                                                             m_AbrCurrentBitrateKbps));
 }
 
 void Session::notifyMouseEmulationMode(bool enabled)
@@ -2133,6 +2334,7 @@ bool Session::startConnectionAsync()
     }
 
     emit connectionStarted();
+    startSunshineAbr();
     if (m_Preferences->enableMicrophone) {
         // Use the deferred mic toggle mechanism instead of QueuedConnection to avoid
         // heap corruption when creating QAudioSource within nested event loops (processEvents).
@@ -2516,8 +2718,23 @@ void Session::exec()
                                         : QEventLoop::ExcludeUserInputEvents);
     };
 
+    constexpr Uint32 ABR_FEEDBACK_INTERVAL_MS = 3000;
+    auto processSunshineAbrFeedback = [this]() {
+        if (!m_SunshineAbrEnabled) {
+            return;
+        }
+
+        const Uint32 now = SDL_GetTicks();
+        if (now - m_LastAbrFeedbackTicks >= ABR_FEEDBACK_INTERVAL_MS) {
+            m_LastAbrFeedbackTicks = now;
+            sendSunshineAbrFeedback();
+        }
+    };
+
     SDL_Event event;
     for (;;) {
+        processSunshineAbrFeedback();
+
 #if SDL_VERSION_ATLEAST(2, 0, 18) && !defined(STEAM_LINK)
         // SDL 2.0.18 has a proper wait event implementation that uses platform
         // support to block on events rather than polling on Windows, macOS, X11,
@@ -2531,6 +2748,7 @@ void Session::exec()
         if (!SDL_WaitEventTimeout(&event, 1000)) {
             presence.runCallbacks();
             processQtEventsDuringStream(true);
+            processSunshineAbrFeedback();
             continue;
         }
 #else
@@ -2548,6 +2766,7 @@ void Session::exec()
 #endif
             presence.runCallbacks();
             processQtEventsDuringStream();
+            processSunshineAbrFeedback();
             continue;
         }
 #endif
@@ -3019,6 +3238,7 @@ DispatchDeferredCleanup:
     // Destroy the decoder, since this must be done on the main thread
     // NB: This must happen before LiStopConnection() for pull-based
     // decoders.
+    stopSunshineAbr();
     SDL_LockMutex(m_DecoderLock);
     delete m_VideoDecoder;
     m_VideoDecoder = nullptr;

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -3,6 +3,9 @@
 #include <QSemaphore>
 #include <QQuickWindow>
 
+#include <atomic>
+#include <memory>
+
 #include <Limelight.h>
 #include <opus_multistream.h>
 #include "settings/streamingpreferences.h"
@@ -262,6 +265,10 @@ private:
     void startMicrophone();
     void stopMicrophone();
 
+    void startSunshineAbr();
+    void stopSunshineAbr();
+    void sendSunshineAbrFeedback();
+
     static
     int drSubmitDecodeUnit(PDECODE_UNIT du);
 
@@ -306,6 +313,11 @@ private:
     bool m_WasCapturedBeforeMenu;  // 菜单打开前鼠标是否处于捕获状态
     bool m_DeferCaptureRestore;    // 延迟恢复鼠标捕获（全屏切换等）
     bool m_PendingMicToggle;       // 延迟麦克风切换（避免堆损坏）
+    bool m_SunshineAbrEnabled;
+    Uint32 m_LastAbrFeedbackTicks;
+    RTP_VIDEO_STATS m_LastAbrVideoStats;
+    std::shared_ptr<std::atomic_bool> m_AbrFeedbackInFlight;
+    std::shared_ptr<std::atomic_int> m_AbrCurrentBitrateKbps;
     OverlayMenuPanel* m_MenuPanel; // Qt-based overlay menu window
     OverlayMenuButton* m_MenuButton; // Qt-based floating menu button
     OverlayToast* m_Toast;           // Qt-based toast notification


### PR DESCRIPTION
Adds optional client-side support for Sunshine's ABR (adaptive bitrate) API.

Summary:
- Add JSON GET/POST helpers in `NvHTTP` for Sunshine ABR endpoints.
- Add a `Smart bitrate with Sunshine` streaming preference and settings UI toggle.
- Configure ABR after stream startup with the selected video bitrate as the max cap.
- Send periodic feedback using Limelight RTP stats and RTT, while avoiding blocking the SDL loop.
- Disable ABR on session cleanup and keep manual runtime bitrate changes in sync with ABR state.

Validation:
- Built successfully with Qt 6.9.2/MSVC 2022 via `nmake -f Makefile release` in `build/build-x64-release`.

Related: Sunshine issue #688 / server-side ABR work.