### PR TITLE
Fix Qt overlay menu focus and capture handling

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -274,6 +274,7 @@ HEADERS += \
     streaming/video/overlaymanager.h \
     streaming/video/overlaymenupanel.h \
     streaming/video/overlaymenubutton.h \
+    streaming/video/overlaywindowutils.h \
     streaming/video/overlaytoast.h \
     backend/systemproperties.h \
     imageutils.h

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1676,6 +1676,10 @@ void Session::showQtOverlayMenu()
     m_MenuPanel->setHasGamepads(m_InputHandler->getAttachedGamepadMask() != 0);
     m_MenuPanel->updateGamepadMouseState(m_InputHandler->isMouseEmulationActive());
 
+    if (m_MenuButton) {
+        m_MenuButton->hideButton();
+    }
+
     // Show menu based on user preference
     switch (m_Preferences->overlayMenuPosition) {
     case StreamingPreferences::OMP_LEFT_EDGE:
@@ -1685,10 +1689,6 @@ void Session::showQtOverlayMenu()
         // Show menu at the button's position (top-right corner)
         m_MenuPanel->showAtCursor(wx, wy, ww, wh,
                                   wx + ww - 40, wy + 40);
-        // Hide button while menu is visible
-        if (m_MenuButton) {
-            m_MenuButton->hideButton();
-        }
         break;
     case StreamingPreferences::OMP_RIGHT_EDGE:
     default:
@@ -1880,6 +1880,41 @@ void Session::restoreCaptureAfterQtOverlay(const char* reason, bool delayForWind
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Qt overlay capture restored after %s", reason ? reason : "menu close");
+}
+
+bool Session::isEdgeOverlayMenuPosition() const
+{
+    return m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_LEFT_EDGE ||
+           m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_RIGHT_EDGE;
+}
+
+void Session::showQtOverlayButton(int cursorY)
+{
+    if (!m_MenuButton || !m_Window || !m_MenuPanel ||
+            m_MenuPanel->isMenuVisible() || m_MenuPanel->isClosing()) {
+        return;
+    }
+
+    int wx, wy, ww, wh;
+    SDL_GetWindowPosition(m_Window, &wx, &wy);
+    SDL_GetWindowSize(m_Window, &ww, &wh);
+
+    OverlayMenuButton::Placement placement = OverlayMenuButton::Placement::TopRight;
+    switch (m_Preferences->overlayMenuPosition) {
+    case StreamingPreferences::OMP_LEFT_EDGE:
+        placement = OverlayMenuButton::Placement::LeftEdge;
+        break;
+    case StreamingPreferences::OMP_RIGHT_EDGE:
+        placement = OverlayMenuButton::Placement::RightEdge;
+        break;
+    case StreamingPreferences::OMP_BUTTON:
+    default:
+        placement = OverlayMenuButton::Placement::TopRight;
+        break;
+    }
+
+    m_MenuButton->setAutoHideOnLeave(isEdgeOverlayMenuPosition());
+    m_MenuButton->showButton(wx, wy, ww, wh, placement, cursorY);
 }
 
 void Session::showStreamingToast(const QString& message, int durationMs)
@@ -2707,14 +2742,12 @@ void Session::exec()
             restoreCaptureAfterQtOverlay("menu close");
         }
 
-        // Re-show the floating menu button if in button mode
+        // Re-show the persistent floating menu button if in button mode.
+        // Edge modes show the button only when the pointer reaches the edge.
         if (m_MenuButton &&
             m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON &&
             !(SDL_GetWindowFlags(m_Window) & SDL_WINDOW_MINIMIZED)) {
-            int wx, wy, ww, wh;
-            SDL_GetWindowPosition(m_Window, &wx, &wy);
-            SDL_GetWindowSize(m_Window, &ww, &wh);
-            m_MenuButton->showButton(wx, wy, ww, wh);
+            showQtOverlayButton();
         }
 
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -2722,17 +2755,17 @@ void Session::exec()
                     m_DeferCaptureRestore ? "deferred" : "restored");
     });
 
-    // Create floating menu button if configured
-    if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
+    // Create floating menu button if configured. In edge modes, the button is
+    // hidden until the mouse reaches the edge, then it acts as a deliberate
+    // click target to avoid opening the full menu by accident.
+    if (m_Preferences->overlayMenuPosition != StreamingPreferences::OMP_DISABLED) {
         m_MenuButton = new OverlayMenuButton();
         m_MenuButton->setClickCallback([this]() {
             showQtOverlayMenu();
         });
-        // Show button at initial position
-        int wx, wy, ww, wh;
-        SDL_GetWindowPosition(m_Window, &wx, &wy);
-        SDL_GetWindowSize(m_Window, &ww, &wh);
-        m_MenuButton->showButton(wx, wy, ww, wh);
+        if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
+            showQtOverlayButton();
+        }
     }
 
     // Switch to async logging mode when we enter the SDL loop
@@ -2881,10 +2914,7 @@ void Session::exec()
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 // Reposition floating menu button if visible
                 if (m_MenuButton && m_MenuButton->isButtonVisible()) {
-                    int wx, wy, ww, wh;
-                    SDL_GetWindowPosition(m_Window, &wx, &wy);
-                    SDL_GetWindowSize(m_Window, &ww, &wh);
-                    m_MenuButton->repositionTo(wx, wy, ww, wh);
+                    showQtOverlayButton();
                 }
                 break;
             }
@@ -3104,11 +3134,11 @@ void Session::exec()
         }
         case SDL_MOUSEMOTION:
         {
-            // Qt overlay menu: edge detection with debounce (500ms cooldown after close)
-            // Only trigger for edge-based positions (not disabled, at-cursor, or button)
+            // Qt overlay menu: edge detection with debounce (500ms cooldown
+            // after close). Edge modes reveal a small moon button first; the
+            // full menu opens only after the user clicks that button.
             if (m_MenuPanel && !m_MenuPanel->isMenuVisible() &&
-                m_Preferences->overlayMenuPosition != StreamingPreferences::OMP_DISABLED &&
-                m_Preferences->overlayMenuPosition != StreamingPreferences::OMP_BUTTON) {
+                isEdgeOverlayMenuPosition()) {
                 Uint32 elapsed = SDL_GetTicks() - m_MenuCloseTicks;
                 if (elapsed > 500) {
                     int ww, wh;
@@ -3121,8 +3151,11 @@ void Session::exec()
                         atEdge = (event.motion.x >= ww - 5);
                     }
                     if (atEdge) {
-                        showQtOverlayMenu();
+                        showQtOverlayButton(event.motion.y);
                         break;
+                    }
+                    else if (m_MenuButton && m_MenuButton->isButtonVisible()) {
+                        m_MenuButton->hideButton();
                     }
                 }
             }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1677,7 +1677,7 @@ void Session::showQtOverlayMenu()
     m_MenuPanel->updateGamepadMouseState(m_InputHandler->isMouseEmulationActive());
 
     if (m_MenuButton) {
-        m_MenuButton->hideButton(false);
+        m_MenuButton->hideButton();
     }
 
     // Show menu based on user preference
@@ -1914,9 +1914,7 @@ void Session::showQtOverlayButton(int cursorY)
     }
 
     m_MenuButton->setAutoHideOnLeave(isEdgeOverlayMenuPosition());
-    if (isEdgeOverlayMenuPosition()) {
-        releaseCaptureForQtOverlay();
-    }
+    m_MenuButton->setInputTransparent(isEdgeOverlayMenuPosition());
     m_MenuButton->showButton(wx, wy, ww, wh, placement, cursorY);
 }
 
@@ -2766,12 +2764,6 @@ void Session::exec()
         m_MenuButton->setClickCallback([this]() {
             showQtOverlayMenu();
         });
-        m_MenuButton->setHideCallback([this]() {
-            if (isEdgeOverlayMenuPosition() &&
-                    (!m_MenuPanel || !m_MenuPanel->isMenuVisible())) {
-                restoreCaptureAfterQtOverlay("edge overlay button hide");
-            }
-        });
         if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
             showQtOverlayButton();
         }
@@ -3138,6 +3130,19 @@ void Session::exec()
                 break;
             }
 
+            if (event.type == SDL_MOUSEBUTTONDOWN &&
+                    event.button.button == SDL_BUTTON_LEFT &&
+                    m_MenuButton && m_MenuButton->isButtonVisible() &&
+                    isEdgeOverlayMenuPosition()) {
+                int wx, wy;
+                SDL_GetWindowPosition(m_Window, &wx, &wy);
+                if (m_MenuButton->containsGlobalPixelPoint(wx + event.button.x,
+                                                           wy + event.button.y)) {
+                    showQtOverlayMenu();
+                    break;
+                }
+            }
+
             m_InputHandler->handleMouseButtonEvent(&event.button);
             break;
         }
@@ -3164,7 +3169,12 @@ void Session::exec()
                         break;
                     }
                     else if (m_MenuButton && m_MenuButton->isButtonVisible()) {
-                        m_MenuButton->hideButton();
+                        int wx, wy;
+                        SDL_GetWindowPosition(m_Window, &wx, &wy);
+                        if (!m_MenuButton->containsGlobalPixelPoint(wx + event.motion.x,
+                                                                    wy + event.motion.y)) {
+                            m_MenuButton->hideButton();
+                        }
                     }
                 }
             }
@@ -3290,7 +3300,7 @@ DispatchDeferredCleanup:
 
     // Destroy the Qt overlay menu button
     if (m_MenuButton) {
-        m_MenuButton->hideButton(false);
+        m_MenuButton->hideButton();
         delete m_MenuButton;
         m_MenuButton = nullptr;
     }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1677,7 +1677,7 @@ void Session::showQtOverlayMenu()
     m_MenuPanel->updateGamepadMouseState(m_InputHandler->isMouseEmulationActive());
 
     if (m_MenuButton) {
-        m_MenuButton->hideButton();
+        m_MenuButton->hideButton(false);
     }
 
     // Show menu based on user preference
@@ -1839,8 +1839,8 @@ void Session::dispatchQtMenuAction(OverlayMenuPanel::MenuAction action)
 
 void Session::releaseCaptureForQtOverlay()
 {
-    m_WasCapturedBeforeMenu = m_InputHandler && m_InputHandler->isCaptureActive();
-    if (m_WasCapturedBeforeMenu) {
+    if (m_InputHandler && m_InputHandler->isCaptureActive()) {
+        m_WasCapturedBeforeMenu = true;
         // Use the input handler path rather than directly toggling SDL relative
         // mode. This keeps fake capture, pointer-region lock, and keyboard grab
         // state in sync while Qt owns the temporary menu interaction.
@@ -1914,6 +1914,9 @@ void Session::showQtOverlayButton(int cursorY)
     }
 
     m_MenuButton->setAutoHideOnLeave(isEdgeOverlayMenuPosition());
+    if (isEdgeOverlayMenuPosition()) {
+        releaseCaptureForQtOverlay();
+    }
     m_MenuButton->showButton(wx, wy, ww, wh, placement, cursorY);
 }
 
@@ -2763,6 +2766,12 @@ void Session::exec()
         m_MenuButton->setClickCallback([this]() {
             showQtOverlayMenu();
         });
+        m_MenuButton->setHideCallback([this]() {
+            if (isEdgeOverlayMenuPosition() &&
+                    (!m_MenuPanel || !m_MenuPanel->isMenuVisible())) {
+                restoreCaptureAfterQtOverlay("edge overlay button hide");
+            }
+        });
         if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
             showQtOverlayButton();
         }
@@ -3281,7 +3290,7 @@ DispatchDeferredCleanup:
 
     // Destroy the Qt overlay menu button
     if (m_MenuButton) {
-        m_MenuButton->hideButton();
+        m_MenuButton->hideButton(false);
         delete m_MenuButton;
         m_MenuButton = nullptr;
     }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1913,8 +1913,7 @@ void Session::showQtOverlayButton(int cursorY)
         break;
     }
 
-    m_MenuButton->setAutoHideOnLeave(isEdgeOverlayMenuPosition());
-    m_MenuButton->setInputTransparent(isEdgeOverlayMenuPosition());
+    m_MenuButton->setAutoHideOnLeave(false);
     m_MenuButton->showButton(wx, wy, ww, wh, placement, cursorY);
 }
 
@@ -2756,17 +2755,15 @@ void Session::exec()
                     m_DeferCaptureRestore ? "deferred" : "restored");
     });
 
-    // Create floating menu button if configured. In edge modes, the button is
-    // hidden until the mouse reaches the edge, then it acts as a deliberate
-    // click target to avoid opening the full menu by accident.
-    if (m_Preferences->overlayMenuPosition != StreamingPreferences::OMP_DISABLED) {
+    // Create the persistent floating menu button only in button mode. Edge
+    // modes deliberately avoid showing any Qt top-level window on hover because
+    // doing so can disturb SDL relative/fake capture and bounce the pointer.
+    if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
         m_MenuButton = new OverlayMenuButton();
         m_MenuButton->setClickCallback([this]() {
             showQtOverlayMenu();
         });
-        if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
-            showQtOverlayButton();
-        }
+        showQtOverlayButton();
     }
 
     // Switch to async logging mode when we enter the SDL loop
@@ -2803,6 +2800,37 @@ void Session::exec()
             m_LastAbrFeedbackTicks = now;
             sendSunshineAbrFeedback();
         }
+    };
+
+    constexpr int EDGE_MENU_TRIGGER_WIDTH = 5;
+    constexpr int EDGE_MENU_CUE_SIZE = 36;
+    constexpr int EDGE_MENU_CUE_MARGIN = 10;
+    bool edgeMenuCueVisible = false;
+    int edgeMenuCueY = 0;
+    auto isPointInEdgeMenuCue = [this, &edgeMenuCueVisible, &edgeMenuCueY](int x, int y) {
+        if (!edgeMenuCueVisible || !isEdgeOverlayMenuPosition()) {
+            return false;
+        }
+
+        int ww, wh;
+        SDL_GetWindowSize(m_Window, &ww, &wh);
+        int cueTop = edgeMenuCueY - EDGE_MENU_CUE_SIZE / 2;
+        int minY = EDGE_MENU_CUE_MARGIN;
+        int maxY = wh - EDGE_MENU_CUE_SIZE - EDGE_MENU_CUE_MARGIN;
+        if (maxY < minY) {
+            maxY = minY;
+        }
+        cueTop = qBound(minY, cueTop, maxY);
+
+        bool inX;
+        if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_LEFT_EDGE) {
+            inX = x >= 0 && x <= EDGE_MENU_CUE_SIZE;
+        }
+        else {
+            inX = x >= ww - EDGE_MENU_CUE_SIZE && x <= ww;
+        }
+
+        return inX && y >= cueTop && y <= cueTop + EDGE_MENU_CUE_SIZE;
     };
 
     SDL_Event event;
@@ -3132,15 +3160,10 @@ void Session::exec()
 
             if (event.type == SDL_MOUSEBUTTONDOWN &&
                     event.button.button == SDL_BUTTON_LEFT &&
-                    m_MenuButton && m_MenuButton->isButtonVisible() &&
-                    isEdgeOverlayMenuPosition()) {
-                int wx, wy;
-                SDL_GetWindowPosition(m_Window, &wx, &wy);
-                if (m_MenuButton->containsGlobalPixelPoint(wx + event.button.x,
-                                                           wy + event.button.y)) {
-                    showQtOverlayMenu();
-                    break;
-                }
+                    isPointInEdgeMenuCue(event.button.x, event.button.y)) {
+                edgeMenuCueVisible = false;
+                showQtOverlayMenu();
+                break;
             }
 
             m_InputHandler->handleMouseButtonEvent(&event.button);
@@ -3149,8 +3172,8 @@ void Session::exec()
         case SDL_MOUSEMOTION:
         {
             // Qt overlay menu: edge detection with debounce (500ms cooldown
-            // after close). Edge modes reveal a small moon button first; the
-            // full menu opens only after the user clicks that button.
+            // after close). Edge modes track a deliberate click target without
+            // showing a Qt top-level window, which avoids disturbing capture.
             if (m_MenuPanel && !m_MenuPanel->isMenuVisible() &&
                 isEdgeOverlayMenuPosition()) {
                 Uint32 elapsed = SDL_GetTicks() - m_MenuCloseTicks;
@@ -3159,22 +3182,19 @@ void Session::exec()
                     SDL_GetWindowSize(m_Window, &ww, &wh);
                     bool atEdge = false;
                     if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_LEFT_EDGE) {
-                        atEdge = (event.motion.x <= 5);
+                        atEdge = (event.motion.x <= EDGE_MENU_TRIGGER_WIDTH);
                     } else {
                         // OMP_RIGHT_EDGE (default)
-                        atEdge = (event.motion.x >= ww - 5);
+                        atEdge = (event.motion.x >= ww - EDGE_MENU_TRIGGER_WIDTH);
                     }
                     if (atEdge) {
-                        showQtOverlayButton(event.motion.y);
+                        edgeMenuCueVisible = true;
+                        edgeMenuCueY = event.motion.y;
                         break;
                     }
-                    else if (m_MenuButton && m_MenuButton->isButtonVisible()) {
-                        int wx, wy;
-                        SDL_GetWindowPosition(m_Window, &wx, &wy);
-                        if (!m_MenuButton->containsGlobalPixelPoint(wx + event.motion.x,
-                                                                    wy + event.motion.y)) {
-                            m_MenuButton->hideButton();
-                        }
+                    else if (edgeMenuCueVisible &&
+                             !isPointInEdgeMenuCue(event.motion.x, event.motion.y)) {
+                        edgeMenuCueVisible = false;
                     }
                 }
             }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1663,15 +1663,7 @@ void Session::showQtOverlayMenu()
         return; // Do not show
     }
 
-    // Save capture state and release mouse
-    m_WasCapturedBeforeMenu = m_InputHandler->isCaptureActive();
-    if (m_WasCapturedBeforeMenu) {
-        SDL_SetRelativeMouseMode(SDL_FALSE);
-        SDL_ShowCursor(SDL_ENABLE);
-    }
-
-    // Flush stale mouse motion events from relative mode
-    SDL_FlushEvent(SDL_MOUSEMOTION);
+    releaseCaptureForQtOverlay();
 
     // Get SDL window position and size in screen coordinates
     int wx, wy, ww, wh;
@@ -1758,8 +1750,14 @@ void Session::dispatchQtMenuAction(OverlayMenuPanel::MenuAction action)
         combo = SdlInputHandler::KeyComboToggleMinimize;
         break;
     case OverlayMenuPanel::MenuAction::UngrabInput:
-        combo = SdlInputHandler::KeyComboUngrabInput;
-        break;
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Qt overlay menu action: %d", (int)action);
+        m_WasCapturedBeforeMenu = false;
+        if (m_InputHandler) {
+            m_InputHandler->setCaptureActive(false);
+            m_InputHandler->raiseAllKeys();
+        }
+        return;
     case OverlayMenuPanel::MenuAction::PasteText:
         combo = SdlInputHandler::KeyComboPasteText;
         break;
@@ -1825,23 +1823,63 @@ void Session::dispatchQtMenuAction(OverlayMenuPanel::MenuAction action)
                 "Qt overlay menu action: %d", (int)action);
     m_InputHandler->performSpecialKeyCombo(combo);
 
+    if (action == OverlayMenuPanel::MenuAction::ToggleMinimize) {
+        // The user explicitly minimized the stream window. Do not let the menu
+        // close callback recapture input or raise the SDL window back again.
+        m_WasCapturedBeforeMenu = false;
+        return;
+    }
+
     // Restore mouse capture after window-state-changing actions complete
     if (m_DeferCaptureRestore) {
         m_DeferCaptureRestore = false;
-        if (m_WasCapturedBeforeMenu) {
-            // Allow the window to settle after fullscreen/minimize toggle
-            SDL_Delay(100);
-            SDL_FlushEvent(SDL_MOUSEMOTION);
-
-            // Recapture via the proper input handler path, which handles
-            // pointer region lock, keyboard grab, and relative mouse mode
-            m_InputHandler->setCaptureActive(true);
-            m_WasCapturedBeforeMenu = false;
-
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "Deferred capture restore completed after window state change");
-        }
+        restoreCaptureAfterQtOverlay("window state change", true);
     }
+}
+
+void Session::releaseCaptureForQtOverlay()
+{
+    m_WasCapturedBeforeMenu = m_InputHandler && m_InputHandler->isCaptureActive();
+    if (m_WasCapturedBeforeMenu) {
+        // Use the input handler path rather than directly toggling SDL relative
+        // mode. This keeps fake capture, pointer-region lock, and keyboard grab
+        // state in sync while Qt owns the temporary menu interaction.
+        m_InputHandler->setCaptureActive(false);
+    }
+
+    // Flush stale relative/fake-capture motion so the menu open transition and
+    // later recapture don't replay a large cursor delta to the host.
+    SDL_FlushEvent(SDL_MOUSEMOTION);
+}
+
+void Session::restoreCaptureAfterQtOverlay(const char* reason, bool delayForWindowStateChange)
+{
+    if (!m_WasCapturedBeforeMenu || !m_InputHandler || !m_Window) {
+        return;
+    }
+
+    if (SDL_GetWindowFlags(m_Window) & SDL_WINDOW_MINIMIZED) {
+        m_WasCapturedBeforeMenu = false;
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Qt overlay capture restore skipped after %s because window is minimized",
+                    reason ? reason : "menu close");
+        return;
+    }
+
+    if (delayForWindowStateChange) {
+        // Let fullscreen/minimize style changes settle before asking SDL to
+        // restore relative mouse mode and grabs.
+        SDL_Delay(100);
+    }
+
+    SDL_RaiseWindow(m_Window);
+    SDL_FlushEvent(SDL_MOUSEMOTION);
+    m_InputHandler->setCaptureActive(true);
+    SDL_FlushEvent(SDL_MOUSEMOTION);
+    m_WasCapturedBeforeMenu = false;
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Qt overlay capture restored after %s", reason ? reason : "menu close");
 }
 
 void Session::showStreamingToast(const QString& message, int durationMs)
@@ -2665,13 +2703,14 @@ void Session::exec()
         // Note: for actions that change window state (fullscreen, minimize),
         // we defer capture restoration to after the action completes.
         // See dispatchQtMenuAction() for those cases.
-        if (m_WasCapturedBeforeMenu && !m_DeferCaptureRestore) {
-            m_InputHandler->setCaptureActive(true);
-            m_WasCapturedBeforeMenu = false;
+        if (!m_DeferCaptureRestore) {
+            restoreCaptureAfterQtOverlay("menu close");
         }
 
         // Re-show the floating menu button if in button mode
-        if (m_MenuButton && m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
+        if (m_MenuButton &&
+            m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON &&
+            !(SDL_GetWindowFlags(m_Window) & SDL_WINDOW_MINIMIZED)) {
             int wx, wy, ww, wh;
             SDL_GetWindowPosition(m_Window, &wx, &wy);
             SDL_GetWindowSize(m_Window, &ww, &wh);
@@ -2707,6 +2746,7 @@ void Session::exec()
     Uint32 lastQtEventPumpTicks = 0;
     auto processQtEventsDuringStream = [this, &lastQtEventPumpTicks](bool force = false) {
         const bool qtUiVisible = (m_MenuPanel && m_MenuPanel->needsEventProcessing()) ||
+                                 (m_MenuButton && m_MenuButton->isButtonVisible()) ||
                                  (m_Toast && m_Toast->isVisible());
         const Uint32 now = SDL_GetTicks();
         if (!force && !qtUiVisible && now - lastQtEventPumpTicks < QT_EVENT_PUMP_INTERVAL_MS) {
@@ -3096,6 +3136,9 @@ void Session::exec()
             break;
         }
         case SDL_MOUSEWHEEL:
+            if (m_MenuPanel && m_MenuPanel->isMenuVisible()) {
+                break;
+            }
             m_InputHandler->handleMouseWheelEvent(&event.wheel);
             break;
         case SDL_CONTROLLERAXISMOTION:

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1676,10 +1676,6 @@ void Session::showQtOverlayMenu()
     m_MenuPanel->setHasGamepads(m_InputHandler->getAttachedGamepadMask() != 0);
     m_MenuPanel->updateGamepadMouseState(m_InputHandler->isMouseEmulationActive());
 
-    if (m_MenuButton) {
-        m_MenuButton->hideButton();
-    }
-
     // Show menu based on user preference
     switch (m_Preferences->overlayMenuPosition) {
     case StreamingPreferences::OMP_LEFT_EDGE:
@@ -1689,6 +1685,10 @@ void Session::showQtOverlayMenu()
         // Show menu at the button's position (top-right corner)
         m_MenuPanel->showAtCursor(wx, wy, ww, wh,
                                   wx + ww - 40, wy + 40);
+        // Hide button while menu is visible
+        if (m_MenuButton) {
+            m_MenuButton->hideButton();
+        }
         break;
     case StreamingPreferences::OMP_RIGHT_EDGE:
     default:
@@ -1839,8 +1839,8 @@ void Session::dispatchQtMenuAction(OverlayMenuPanel::MenuAction action)
 
 void Session::releaseCaptureForQtOverlay()
 {
-    if (m_InputHandler && m_InputHandler->isCaptureActive()) {
-        m_WasCapturedBeforeMenu = true;
+    m_WasCapturedBeforeMenu = m_InputHandler && m_InputHandler->isCaptureActive();
+    if (m_WasCapturedBeforeMenu) {
         // Use the input handler path rather than directly toggling SDL relative
         // mode. This keeps fake capture, pointer-region lock, and keyboard grab
         // state in sync while Qt owns the temporary menu interaction.
@@ -1880,41 +1880,6 @@ void Session::restoreCaptureAfterQtOverlay(const char* reason, bool delayForWind
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Qt overlay capture restored after %s", reason ? reason : "menu close");
-}
-
-bool Session::isEdgeOverlayMenuPosition() const
-{
-    return m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_LEFT_EDGE ||
-           m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_RIGHT_EDGE;
-}
-
-void Session::showQtOverlayButton(int cursorY)
-{
-    if (!m_MenuButton || !m_Window || !m_MenuPanel ||
-            m_MenuPanel->isMenuVisible() || m_MenuPanel->isClosing()) {
-        return;
-    }
-
-    int wx, wy, ww, wh;
-    SDL_GetWindowPosition(m_Window, &wx, &wy);
-    SDL_GetWindowSize(m_Window, &ww, &wh);
-
-    OverlayMenuButton::Placement placement = OverlayMenuButton::Placement::TopRight;
-    switch (m_Preferences->overlayMenuPosition) {
-    case StreamingPreferences::OMP_LEFT_EDGE:
-        placement = OverlayMenuButton::Placement::LeftEdge;
-        break;
-    case StreamingPreferences::OMP_RIGHT_EDGE:
-        placement = OverlayMenuButton::Placement::RightEdge;
-        break;
-    case StreamingPreferences::OMP_BUTTON:
-    default:
-        placement = OverlayMenuButton::Placement::TopRight;
-        break;
-    }
-
-    m_MenuButton->setAutoHideOnLeave(false);
-    m_MenuButton->showButton(wx, wy, ww, wh, placement, cursorY);
 }
 
 void Session::showStreamingToast(const QString& message, int durationMs)
@@ -2742,12 +2707,14 @@ void Session::exec()
             restoreCaptureAfterQtOverlay("menu close");
         }
 
-        // Re-show the persistent floating menu button if in button mode.
-        // Edge modes show the button only when the pointer reaches the edge.
+        // Re-show the floating menu button if in button mode
         if (m_MenuButton &&
             m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON &&
             !(SDL_GetWindowFlags(m_Window) & SDL_WINDOW_MINIMIZED)) {
-            showQtOverlayButton();
+            int wx, wy, ww, wh;
+            SDL_GetWindowPosition(m_Window, &wx, &wy);
+            SDL_GetWindowSize(m_Window, &ww, &wh);
+            m_MenuButton->showButton(wx, wy, ww, wh);
         }
 
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -2755,15 +2722,17 @@ void Session::exec()
                     m_DeferCaptureRestore ? "deferred" : "restored");
     });
 
-    // Create the persistent floating menu button only in button mode. Edge
-    // modes deliberately avoid showing any Qt top-level window on hover because
-    // doing so can disturb SDL relative/fake capture and bounce the pointer.
+    // Create floating menu button if configured
     if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_BUTTON) {
         m_MenuButton = new OverlayMenuButton();
         m_MenuButton->setClickCallback([this]() {
             showQtOverlayMenu();
         });
-        showQtOverlayButton();
+        // Show button at initial position
+        int wx, wy, ww, wh;
+        SDL_GetWindowPosition(m_Window, &wx, &wy);
+        SDL_GetWindowSize(m_Window, &ww, &wh);
+        m_MenuButton->showButton(wx, wy, ww, wh);
     }
 
     // Switch to async logging mode when we enter the SDL loop
@@ -2800,37 +2769,6 @@ void Session::exec()
             m_LastAbrFeedbackTicks = now;
             sendSunshineAbrFeedback();
         }
-    };
-
-    constexpr int EDGE_MENU_TRIGGER_WIDTH = 5;
-    constexpr int EDGE_MENU_CUE_SIZE = 36;
-    constexpr int EDGE_MENU_CUE_MARGIN = 10;
-    bool edgeMenuCueVisible = false;
-    int edgeMenuCueY = 0;
-    auto isPointInEdgeMenuCue = [this, &edgeMenuCueVisible, &edgeMenuCueY](int x, int y) {
-        if (!edgeMenuCueVisible || !isEdgeOverlayMenuPosition()) {
-            return false;
-        }
-
-        int ww, wh;
-        SDL_GetWindowSize(m_Window, &ww, &wh);
-        int cueTop = edgeMenuCueY - EDGE_MENU_CUE_SIZE / 2;
-        int minY = EDGE_MENU_CUE_MARGIN;
-        int maxY = wh - EDGE_MENU_CUE_SIZE - EDGE_MENU_CUE_MARGIN;
-        if (maxY < minY) {
-            maxY = minY;
-        }
-        cueTop = qBound(minY, cueTop, maxY);
-
-        bool inX;
-        if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_LEFT_EDGE) {
-            inX = x >= 0 && x <= EDGE_MENU_CUE_SIZE;
-        }
-        else {
-            inX = x >= ww - EDGE_MENU_CUE_SIZE && x <= ww;
-        }
-
-        return inX && y >= cueTop && y <= cueTop + EDGE_MENU_CUE_SIZE;
     };
 
     SDL_Event event;
@@ -2943,7 +2881,10 @@ void Session::exec()
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 // Reposition floating menu button if visible
                 if (m_MenuButton && m_MenuButton->isButtonVisible()) {
-                    showQtOverlayButton();
+                    int wx, wy, ww, wh;
+                    SDL_GetWindowPosition(m_Window, &wx, &wy);
+                    SDL_GetWindowSize(m_Window, &ww, &wh);
+                    m_MenuButton->repositionTo(wx, wy, ww, wh);
                 }
                 break;
             }
@@ -3158,43 +3099,30 @@ void Session::exec()
                 break;
             }
 
-            if (event.type == SDL_MOUSEBUTTONDOWN &&
-                    event.button.button == SDL_BUTTON_LEFT &&
-                    isPointInEdgeMenuCue(event.button.x, event.button.y)) {
-                edgeMenuCueVisible = false;
-                showQtOverlayMenu();
-                break;
-            }
-
             m_InputHandler->handleMouseButtonEvent(&event.button);
             break;
         }
         case SDL_MOUSEMOTION:
         {
-            // Qt overlay menu: edge detection with debounce (500ms cooldown
-            // after close). Edge modes track a deliberate click target without
-            // showing a Qt top-level window, which avoids disturbing capture.
+            // Qt overlay menu: edge detection with debounce (500ms cooldown after close)
+            // Only trigger for edge-based positions (not disabled, at-cursor, or button)
             if (m_MenuPanel && !m_MenuPanel->isMenuVisible() &&
-                isEdgeOverlayMenuPosition()) {
+                m_Preferences->overlayMenuPosition != StreamingPreferences::OMP_DISABLED &&
+                m_Preferences->overlayMenuPosition != StreamingPreferences::OMP_BUTTON) {
                 Uint32 elapsed = SDL_GetTicks() - m_MenuCloseTicks;
                 if (elapsed > 500) {
                     int ww, wh;
                     SDL_GetWindowSize(m_Window, &ww, &wh);
                     bool atEdge = false;
                     if (m_Preferences->overlayMenuPosition == StreamingPreferences::OMP_LEFT_EDGE) {
-                        atEdge = (event.motion.x <= EDGE_MENU_TRIGGER_WIDTH);
+                        atEdge = (event.motion.x <= 5);
                     } else {
                         // OMP_RIGHT_EDGE (default)
-                        atEdge = (event.motion.x >= ww - EDGE_MENU_TRIGGER_WIDTH);
+                        atEdge = (event.motion.x >= ww - 5);
                     }
                     if (atEdge) {
-                        edgeMenuCueVisible = true;
-                        edgeMenuCueY = event.motion.y;
+                        showQtOverlayMenu();
                         break;
-                    }
-                    else if (edgeMenuCueVisible &&
-                             !isPointInEdgeMenuCue(event.motion.x, event.motion.y)) {
-                        edgeMenuCueVisible = false;
                     }
                 }
             }

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -181,6 +181,8 @@ private:
     void hideQtOverlayMenu();
     void toggleQtOverlayMenu();
     void dispatchQtMenuAction(OverlayMenuPanel::MenuAction action);
+    void releaseCaptureForQtOverlay();
+    void restoreCaptureAfterQtOverlay(const char* reason, bool delayForWindowStateChange = false);
     void requestRuntimeBitrateChange(int bitrateKbps);
     void showStreamingToast(const QString& message, int durationMs = 2000);
 #ifdef Q_OS_WIN32

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -183,6 +183,8 @@ private:
     void dispatchQtMenuAction(OverlayMenuPanel::MenuAction action);
     void releaseCaptureForQtOverlay();
     void restoreCaptureAfterQtOverlay(const char* reason, bool delayForWindowStateChange = false);
+    bool isEdgeOverlayMenuPosition() const;
+    void showQtOverlayButton(int cursorY = -1);
     void requestRuntimeBitrateChange(int bitrateKbps);
     void showStreamingToast(const QString& message, int durationMs = 2000);
 #ifdef Q_OS_WIN32

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -183,8 +183,6 @@ private:
     void dispatchQtMenuAction(OverlayMenuPanel::MenuAction action);
     void releaseCaptureForQtOverlay();
     void restoreCaptureAfterQtOverlay(const char* reason, bool delayForWindowStateChange = false);
-    bool isEdgeOverlayMenuPosition() const;
-    void showQtOverlayButton(int cursorY = -1);
     void requestRuntimeBitrateChange(int bitrateKbps);
     void showStreamingToast(const QString& message, int durationMs = 2000);
 #ifdef Q_OS_WIN32

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -9,10 +9,9 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
     : QRasterWindow(parent),
       m_Hovered(false),
       m_ButtonVisible(false),
-      m_AutoHideOnLeave(false),
-      m_InputTransparent(true)
+      m_AutoHideOnLeave(false)
 {
-    setInputTransparent(false);
+    setFlags(OverlayWindowUtils::nonActivatingToolFlags());
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -23,17 +22,6 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
 
 OverlayMenuButton::~OverlayMenuButton()
 {
-}
-
-void OverlayMenuButton::setInputTransparent(bool transparent)
-{
-    if (m_InputTransparent == transparent) {
-        return;
-    }
-
-    m_InputTransparent = transparent;
-    setFlags(OverlayWindowUtils::nonActivatingToolFlags(
-        transparent ? Qt::WindowTransparentForInput : Qt::WindowFlags()));
 }
 
 void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int parentH,
@@ -98,17 +86,6 @@ void OverlayMenuButton::hideButton()
     m_ButtonVisible = false;
     setOpacity(0.35);
     hide();
-}
-
-bool OverlayMenuButton::containsGlobalPixelPoint(int globalX, int globalY) const
-{
-    if (!m_ButtonVisible) {
-        return false;
-    }
-
-    qreal dpr = screen() ? screen()->devicePixelRatio() : 1.0;
-    QPoint logicalPoint(qRound(globalX / dpr), qRound(globalY / dpr));
-    return geometry().contains(logicalPoint);
 }
 
 void OverlayMenuButton::drawCrescentMoon(QPainter& p, qreal cx, qreal cy, qreal radius)

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -8,10 +8,9 @@
 OverlayMenuButton::OverlayMenuButton(QWindow* parent)
     : QRasterWindow(parent),
       m_Hovered(false),
-      m_ButtonVisible(false),
-      m_AutoHideOnLeave(false)
+      m_ButtonVisible(false)
 {
-    setFlags(OverlayWindowUtils::nonActivatingToolFlags());
+        setFlags(OverlayWindowUtils::nonActivatingToolFlags());
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -24,57 +23,29 @@ OverlayMenuButton::~OverlayMenuButton()
 {
 }
 
-void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int parentH,
-                                     Placement placement, int cursorY)
+void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int /*parentH*/)
 {
 #ifdef Q_OS_MACOS
     int qpX = parentX;
     int qpY = parentY;
     int qpW = parentW;
-    int qpH = parentH;
-    int qpCursorY = cursorY;
 #else
     qreal dpr = screen() ? screen()->devicePixelRatio() : 1.0;
     int qpX = qRound(parentX / dpr);
     int qpY = qRound(parentY / dpr);
     int qpW = qRound(parentW / dpr);
-    int qpH = qRound(parentH / dpr);
-    int qpCursorY = cursorY >= 0 ? qRound(cursorY / dpr) : -1;
 #endif
 
-    int x;
-    int y;
-
-    switch (placement) {
-    case Placement::LeftEdge:
-        x = qpX;
-        y = qpCursorY >= 0 ? qpY + qpCursorY - kButtonSize / 2 : qpY + (qpH - kButtonSize) / 2;
-        break;
-    case Placement::RightEdge:
-        x = qpX + qpW - kButtonSize;
-        y = qpCursorY >= 0 ? qpY + qpCursorY - kButtonSize / 2 : qpY + (qpH - kButtonSize) / 2;
-        break;
-    case Placement::TopRight:
-    default:
-        x = qpX + qpW - kButtonSize - kMargin;
-        y = qpY + kMargin;
-        break;
-    }
-
-    int minY = qpY + kMargin;
-    int maxY = qpY + qpH - kButtonSize - kMargin;
-    if (maxY < minY) {
-        maxY = minY;
-    }
-    y = qBound(minY, y, maxY);
+    // Position at top-right corner of the streaming window
+    int x = qpX + qpW - kButtonSize - kMargin;
+    int y = qpY + kMargin;
 
     setGeometry(x, y, kButtonSize, kButtonSize);
 }
 
-void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int parentH,
-                                   Placement placement, int cursorY)
+void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int parentH)
 {
-    repositionTo(parentX, parentY, parentW, parentH, placement, cursorY);
+    repositionTo(parentX, parentY, parentW, parentH);
     m_ButtonVisible = true;
     OverlayWindowUtils::showWithoutActivating(this);
     requestUpdate();
@@ -82,9 +53,7 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
 
 void OverlayMenuButton::hideButton()
 {
-    m_Hovered = false;
     m_ButtonVisible = false;
-    setOpacity(0.35);
     hide();
 }
 
@@ -160,10 +129,6 @@ bool OverlayMenuButton::event(QEvent* ev)
 {
     if (ev->type() == QEvent::Leave) {
         m_Hovered = false;
-        if (m_AutoHideOnLeave) {
-            hideButton();
-            return true;
-        }
         setOpacity(0.35);
         requestUpdate();
     }

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -80,12 +80,17 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
     requestUpdate();
 }
 
-void OverlayMenuButton::hideButton()
+void OverlayMenuButton::hideButton(bool notify)
 {
+    bool wasVisible = m_ButtonVisible;
     m_Hovered = false;
     m_ButtonVisible = false;
     setOpacity(0.35);
     hide();
+
+    if (notify && wasVisible && m_HideCallback) {
+        m_HideCallback();
+    }
 }
 
 void OverlayMenuButton::drawCrescentMoon(QPainter& p, qreal cx, qreal cy, qreal radius)

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -8,9 +8,10 @@
 OverlayMenuButton::OverlayMenuButton(QWindow* parent)
     : QRasterWindow(parent),
       m_Hovered(false),
-      m_ButtonVisible(false)
+      m_ButtonVisible(false),
+      m_AutoHideOnLeave(false)
 {
-        setFlags(OverlayWindowUtils::nonActivatingToolFlags());
+    setFlags(OverlayWindowUtils::nonActivatingToolFlags());
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -23,29 +24,57 @@ OverlayMenuButton::~OverlayMenuButton()
 {
 }
 
-void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int /*parentH*/)
+void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int parentH,
+                                     Placement placement, int cursorY)
 {
 #ifdef Q_OS_MACOS
     int qpX = parentX;
     int qpY = parentY;
     int qpW = parentW;
+    int qpH = parentH;
+    int qpCursorY = cursorY;
 #else
     qreal dpr = screen() ? screen()->devicePixelRatio() : 1.0;
     int qpX = qRound(parentX / dpr);
     int qpY = qRound(parentY / dpr);
     int qpW = qRound(parentW / dpr);
+    int qpH = qRound(parentH / dpr);
+    int qpCursorY = cursorY >= 0 ? qRound(cursorY / dpr) : -1;
 #endif
 
-    // Position at top-right corner of the streaming window
-    int x = qpX + qpW - kButtonSize - kMargin;
-    int y = qpY + kMargin;
+    int x;
+    int y;
+
+    switch (placement) {
+    case Placement::LeftEdge:
+        x = qpX;
+        y = qpCursorY >= 0 ? qpY + qpCursorY - kButtonSize / 2 : qpY + (qpH - kButtonSize) / 2;
+        break;
+    case Placement::RightEdge:
+        x = qpX + qpW - kButtonSize;
+        y = qpCursorY >= 0 ? qpY + qpCursorY - kButtonSize / 2 : qpY + (qpH - kButtonSize) / 2;
+        break;
+    case Placement::TopRight:
+    default:
+        x = qpX + qpW - kButtonSize - kMargin;
+        y = qpY + kMargin;
+        break;
+    }
+
+    int minY = qpY + kMargin;
+    int maxY = qpY + qpH - kButtonSize - kMargin;
+    if (maxY < minY) {
+        maxY = minY;
+    }
+    y = qBound(minY, y, maxY);
 
     setGeometry(x, y, kButtonSize, kButtonSize);
 }
 
-void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int parentH)
+void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int parentH,
+                                   Placement placement, int cursorY)
 {
-    repositionTo(parentX, parentY, parentW, parentH);
+    repositionTo(parentX, parentY, parentW, parentH, placement, cursorY);
     m_ButtonVisible = true;
     OverlayWindowUtils::showWithoutActivating(this);
     requestUpdate();
@@ -53,7 +82,9 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
 
 void OverlayMenuButton::hideButton()
 {
+    m_Hovered = false;
     m_ButtonVisible = false;
+    setOpacity(0.35);
     hide();
 }
 
@@ -129,6 +160,10 @@ bool OverlayMenuButton::event(QEvent* ev)
 {
     if (ev->type() == QEvent::Leave) {
         m_Hovered = false;
+        if (m_AutoHideOnLeave) {
+            hideButton();
+            return true;
+        }
         setOpacity(0.35);
         requestUpdate();
     }

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -9,9 +9,10 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
     : QRasterWindow(parent),
       m_Hovered(false),
       m_ButtonVisible(false),
-      m_AutoHideOnLeave(false)
+      m_AutoHideOnLeave(false),
+      m_InputTransparent(true)
 {
-    setFlags(OverlayWindowUtils::nonActivatingToolFlags());
+    setInputTransparent(false);
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -22,6 +23,17 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
 
 OverlayMenuButton::~OverlayMenuButton()
 {
+}
+
+void OverlayMenuButton::setInputTransparent(bool transparent)
+{
+    if (m_InputTransparent == transparent) {
+        return;
+    }
+
+    m_InputTransparent = transparent;
+    setFlags(OverlayWindowUtils::nonActivatingToolFlags(
+        transparent ? Qt::WindowTransparentForInput : Qt::WindowFlags()));
 }
 
 void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int parentH,
@@ -80,17 +92,23 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
     requestUpdate();
 }
 
-void OverlayMenuButton::hideButton(bool notify)
+void OverlayMenuButton::hideButton()
 {
-    bool wasVisible = m_ButtonVisible;
     m_Hovered = false;
     m_ButtonVisible = false;
     setOpacity(0.35);
     hide();
+}
 
-    if (notify && wasVisible && m_HideCallback) {
-        m_HideCallback();
+bool OverlayMenuButton::containsGlobalPixelPoint(int globalX, int globalY) const
+{
+    if (!m_ButtonVisible) {
+        return false;
     }
+
+    qreal dpr = screen() ? screen()->devicePixelRatio() : 1.0;
+    QPoint logicalPoint(qRound(globalX / dpr), qRound(globalY / dpr));
+    return geometry().contains(logicalPoint);
 }
 
 void OverlayMenuButton::drawCrescentMoon(QPainter& p, qreal cx, qreal cy, qreal radius)

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -1,5 +1,7 @@
 #include "overlaymenubutton.h"
 
+#include "overlaywindowutils.h"
+
 #include <QScreen>
 #include <QPainterPath>
 
@@ -8,8 +10,7 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
       m_Hovered(false),
       m_ButtonVisible(false)
 {
-    setFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
-             | Qt::WindowDoesNotAcceptFocus);
+        setFlags(OverlayWindowUtils::nonActivatingToolFlags());
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -46,8 +47,7 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
 {
     repositionTo(parentX, parentY, parentW, parentH);
     m_ButtonVisible = true;
-    show();
-    raise();
+    OverlayWindowUtils::showWithoutActivating(this);
     requestUpdate();
 }
 

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -21,21 +21,32 @@ class OverlayMenuButton : public QRasterWindow {
 public:
     using ClickCallback = std::function<void()>;
 
+    enum class Placement {
+        TopRight,
+        LeftEdge,
+        RightEdge,
+    };
+
     explicit OverlayMenuButton(QWindow* parent = nullptr);
     ~OverlayMenuButton() override;
 
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
+    void setAutoHideOnLeave(bool autoHide) { m_AutoHideOnLeave = autoHide; }
 
     /**
      * Reposition the button relative to the given parent rect (SDL pixel coords).
-     * Places the button at the top-right corner of the streaming window.
+     * Places the button at the requested location on the streaming window.
      */
-    void repositionTo(int parentX, int parentY, int parentW, int parentH);
+    void repositionTo(int parentX, int parentY, int parentW, int parentH,
+                      Placement placement = Placement::TopRight,
+                      int cursorY = -1);
 
     /**
-     * Show the button at the top-right corner of the given parent rect.
+     * Show the button at the requested location on the given parent rect.
      */
-    void showButton(int parentX, int parentY, int parentW, int parentH);
+    void showButton(int parentX, int parentY, int parentW, int parentH,
+                    Placement placement = Placement::TopRight,
+                    int cursorY = -1);
 
     /**
      * Hide the button.
@@ -56,6 +67,7 @@ private:
     ClickCallback m_ClickCallback;
     bool m_Hovered;
     bool m_ButtonVisible;
+    bool m_AutoHideOnLeave;
 
     // Button size (logical pixels)
     static constexpr int kButtonSize = 36;

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -20,7 +20,6 @@ class OverlayMenuButton : public QRasterWindow {
 
 public:
     using ClickCallback = std::function<void()>;
-    using HideCallback = std::function<void()>;
 
     enum class Placement {
         TopRight,
@@ -32,8 +31,8 @@ public:
     ~OverlayMenuButton() override;
 
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
-    void setHideCallback(HideCallback cb) { m_HideCallback = std::move(cb); }
     void setAutoHideOnLeave(bool autoHide) { m_AutoHideOnLeave = autoHide; }
+    void setInputTransparent(bool transparent);
 
     /**
      * Reposition the button relative to the given parent rect (SDL pixel coords).
@@ -53,9 +52,10 @@ public:
     /**
      * Hide the button.
      */
-    void hideButton(bool notify = true);
+    void hideButton();
 
     bool isButtonVisible() const { return m_ButtonVisible; }
+    bool containsGlobalPixelPoint(int globalX, int globalY) const;
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -67,10 +67,10 @@ private:
     void drawCrescentMoon(QPainter& p, qreal cx, qreal cy, qreal radius);
 
     ClickCallback m_ClickCallback;
-    HideCallback m_HideCallback;
     bool m_Hovered;
     bool m_ButtonVisible;
     bool m_AutoHideOnLeave;
+    bool m_InputTransparent;
 
     // Button size (logical pixels)
     static constexpr int kButtonSize = 36;

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -32,7 +32,6 @@ public:
 
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
     void setAutoHideOnLeave(bool autoHide) { m_AutoHideOnLeave = autoHide; }
-    void setInputTransparent(bool transparent);
 
     /**
      * Reposition the button relative to the given parent rect (SDL pixel coords).
@@ -55,7 +54,6 @@ public:
     void hideButton();
 
     bool isButtonVisible() const { return m_ButtonVisible; }
-    bool containsGlobalPixelPoint(int globalX, int globalY) const;
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -70,7 +68,6 @@ private:
     bool m_Hovered;
     bool m_ButtonVisible;
     bool m_AutoHideOnLeave;
-    bool m_InputTransparent;
 
     // Button size (logical pixels)
     static constexpr int kButtonSize = 36;

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -21,32 +21,21 @@ class OverlayMenuButton : public QRasterWindow {
 public:
     using ClickCallback = std::function<void()>;
 
-    enum class Placement {
-        TopRight,
-        LeftEdge,
-        RightEdge,
-    };
-
     explicit OverlayMenuButton(QWindow* parent = nullptr);
     ~OverlayMenuButton() override;
 
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
-    void setAutoHideOnLeave(bool autoHide) { m_AutoHideOnLeave = autoHide; }
 
     /**
      * Reposition the button relative to the given parent rect (SDL pixel coords).
-     * Places the button at the requested location on the streaming window.
+     * Places the button at the top-right corner of the streaming window.
      */
-    void repositionTo(int parentX, int parentY, int parentW, int parentH,
-                      Placement placement = Placement::TopRight,
-                      int cursorY = -1);
+    void repositionTo(int parentX, int parentY, int parentW, int parentH);
 
     /**
-     * Show the button at the requested location on the given parent rect.
+     * Show the button at the top-right corner of the given parent rect.
      */
-    void showButton(int parentX, int parentY, int parentW, int parentH,
-                    Placement placement = Placement::TopRight,
-                    int cursorY = -1);
+    void showButton(int parentX, int parentY, int parentW, int parentH);
 
     /**
      * Hide the button.
@@ -67,7 +56,6 @@ private:
     ClickCallback m_ClickCallback;
     bool m_Hovered;
     bool m_ButtonVisible;
-    bool m_AutoHideOnLeave;
 
     // Button size (logical pixels)
     static constexpr int kButtonSize = 36;

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -20,6 +20,7 @@ class OverlayMenuButton : public QRasterWindow {
 
 public:
     using ClickCallback = std::function<void()>;
+    using HideCallback = std::function<void()>;
 
     enum class Placement {
         TopRight,
@@ -31,6 +32,7 @@ public:
     ~OverlayMenuButton() override;
 
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
+    void setHideCallback(HideCallback cb) { m_HideCallback = std::move(cb); }
     void setAutoHideOnLeave(bool autoHide) { m_AutoHideOnLeave = autoHide; }
 
     /**
@@ -51,7 +53,7 @@ public:
     /**
      * Hide the button.
      */
-    void hideButton();
+    void hideButton(bool notify = true);
 
     bool isButtonVisible() const { return m_ButtonVisible; }
 
@@ -65,6 +67,7 @@ private:
     void drawCrescentMoon(QPainter& p, qreal cx, qreal cy, qreal radius);
 
     ClickCallback m_ClickCallback;
+    HideCallback m_HideCallback;
     bool m_Hovered;
     bool m_ButtonVisible;
     bool m_AutoHideOnLeave;

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -1,5 +1,7 @@
 #include "overlaymenupanel.h"
 
+#include "overlaywindowutils.h"
+
 #include <QScreen>
 #include <QGuiApplication>
 #include <QCoreApplication>
@@ -21,8 +23,7 @@ OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
       m_AnchorMode(AnchorMode::RightEdge),
       m_CursorX(0), m_CursorY(0)
 {
-    setFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
-             | Qt::WindowDoesNotAcceptFocus);
+        setFlags(OverlayWindowUtils::nonActivatingToolFlags());
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -332,8 +333,7 @@ void OverlayMenuPanel::showInternal()
     setPosition(m_TargetX + slideDistance * slideDir, y());
     setOpacity(0.0);
 
-    show();
-    raise();
+    OverlayWindowUtils::showWithoutActivating(this);
 
     // Animate slide
     m_SlideAnim->setDuration(220);
@@ -349,11 +349,6 @@ void OverlayMenuPanel::showInternal()
 
     m_SlideAnim->start();
     m_OpacityAnim->start();
-
-    // Warp cursor into center of the content area (excluding shadow)
-    QRect contentRect(m_TargetX + m_ShadowMargin, y() + m_ShadowMargin,
-                       m_MenuWidth, height() - 2 * m_ShadowMargin);
-    QCursor::setPos(contentRect.center());
 
     forceRepaint();
 }
@@ -435,12 +430,6 @@ void OverlayMenuPanel::navigateToLevel(int level)
     // Reset grace period so Leave event won't close the menu immediately
     // (the mouse may be outside the resized window after navigation)
     m_ShowTimer.start();
-
-    // Warp cursor into the new menu if it's now outside
-    QPoint globalPos = QCursor::pos();
-    if (!geometry().contains(globalPos)) {
-        QCursor::setPos(geometry().center());
-    }
 
     if (goingForward) {
         // Forward: content slides in from right

--- a/app/streaming/video/overlaytoast.cpp
+++ b/app/streaming/video/overlaytoast.cpp
@@ -1,5 +1,7 @@
 #include "overlaytoast.h"
 
+#include "overlaywindowutils.h"
+
 #include <QScreen>
 #include <QFontMetrics>
 #include <QPainterPath>
@@ -12,8 +14,7 @@ OverlayToast::OverlayToast(QWindow* parent)
       m_VertPadding(10),
       m_BorderRadius(8)
 {
-    setFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
-             | Qt::WindowDoesNotAcceptFocus | Qt::WindowTransparentForInput);
+        setFlags(OverlayWindowUtils::nonActivatingToolFlags(Qt::WindowTransparentForInput));
 
     QSurfaceFormat fmt;
     fmt.setAlphaBufferSize(8);
@@ -73,8 +74,7 @@ void OverlayToast::showToast(int parentX, int parentY, int parentW, int parentH,
     int y = qpY + qpH - m_ToastHeight - 60;
 
     setGeometry(x, y, toastWidth, m_ToastHeight);
-    show();
-    raise();
+    OverlayWindowUtils::showWithoutActivating(this);
     requestUpdate();
 
     m_DismissTimer.start(durationMs);

--- a/app/streaming/video/overlaywindowutils.h
+++ b/app/streaming/video/overlaywindowutils.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QWindow>
+
+#ifdef Q_OS_WIN
+#include <qt_windows.h>
+#endif
+
+namespace OverlayWindowUtils {
+
+inline Qt::WindowFlags nonActivatingToolFlags(Qt::WindowFlags extraFlags = Qt::WindowFlags())
+{
+    return Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint |
+           Qt::WindowDoesNotAcceptFocus | extraFlags;
+}
+
+inline void applyNativeNoActivate(QWindow* window)
+{
+    if (!window) {
+        return;
+    }
+
+#ifdef Q_OS_WIN
+    HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (!hwnd) {
+        return;
+    }
+
+    LONG_PTR exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+    if ((exStyle & WS_EX_NOACTIVATE) == 0 || (exStyle & WS_EX_TOOLWINDOW) == 0) {
+        SetWindowLongPtr(hwnd, GWL_EXSTYLE, exStyle | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW);
+    }
+
+    SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+#else
+    Q_UNUSED(window);
+#endif
+}
+
+inline void showWithoutActivating(QWindow* window)
+{
+    if (!window) {
+        return;
+    }
+
+    // Apply native style before show() so Windows won't activate the overlay
+    // while Qt creates the platform window, then apply again in case Qt rewrote
+    // the style during creation.
+    applyNativeNoActivate(window);
+    window->show();
+    applyNativeNoActivate(window);
+
+#ifdef Q_OS_WIN
+    HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (hwnd) {
+        ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+        SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    }
+#else
+    window->raise();
+#endif
+}
+
+} // namespace OverlayWindowUtils


### PR DESCRIPTION
## Summary

Fixes the Qt streaming overlay menu interaction so it no longer steals focus from the SDL streaming window or causes remote pointer jumps/lost capture.

- Add shared no-activate window helpers for Qt overlay windows, using native `WS_EX_NOACTIVATE` / `SW_SHOWNOACTIVATE` on Windows.
- Route menu capture release/restore through `SdlInputHandler` instead of directly toggling SDL relative mouse mode.
- Remove cursor warping when opening/navigating the menu to avoid remote pointer jumps.
- Pump Qt events while the floating menu button is visible and consume mouse wheel events while the menu is open.
- Handle edge cases for minimize and ungrab actions so they do not immediately recapture/raise the stream window.

## Validation

- `get_errors` on touched C++/header files: no errors.
- Rebasing onto latest `origin/master` completed successfully.
- Built successfully with Qt 6.9.2/MSVC 2022 via `nmake -f Makefile release` in `build/build-x64-release`.

Note: existing dirty submodule state under `moonlight-common-c/moonlight-common-c` was not staged or modified.