### PR TITLE
Fix Windows key (Win) stuck-down after shell intercepts KEYUP

### DIFF
--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -211,6 +211,14 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
     SDL_zero(m_LastTouchDownEvent);
     SDL_zero(m_LastTouchUpEvent);
     SDL_zero(m_TouchDownEvent);
+
+#ifdef Q_OS_WIN32
+    // Background watchdog: even if the user closed the Start menu via mouse
+    // and never produces a SDL KEYUP for VK_LWIN/VK_RWIN, this timer will
+    // notice the physical release within ~50 ms and synthesize the missing
+    // KEY_ACTION_UP to the host.
+    m_WinKeyWatchdogTimer = SDL_AddTimer(50, winKeyWatchdogCallback, this);
+#endif
 }
 
 SdlInputHandler::~SdlInputHandler()
@@ -234,6 +242,13 @@ SdlInputHandler::~SdlInputHandler()
     SDL_RemoveTimer(m_LeftButtonReleaseTimer);
     SDL_RemoveTimer(m_RightButtonReleaseTimer);
     SDL_RemoveTimer(m_DragTimer);
+
+#ifdef Q_OS_WIN32
+    if (m_WinKeyWatchdogTimer != 0) {
+        SDL_RemoveTimer(m_WinKeyWatchdogTimer);
+        m_WinKeyWatchdogTimer = 0;
+    }
+#endif
 
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_QuitSubSystem(SDL_INIT_HAPTIC);
@@ -292,6 +307,44 @@ void SdlInputHandler::raiseAllKeys()
     m_KeysDown.clear();
 }
 
+#ifdef Q_OS_WIN32
+// Synthesize a Win-key UP and clear it from m_KeysDown if the user has
+// physically released the key but the entry is still tracked (e.g. the
+// Windows shell swallowed the KEYUP event).
+static void reconcileStuckWinKey(SdlInputHandler* self, short vkCode)
+{
+    int physVk = (vkCode == 0x5B) ? VK_LWIN : VK_RWIN;
+    if ((GetAsyncKeyState(physVk) & 0x8000) != 0) {
+        // Still physically held - do nothing, the user really is holding it.
+        return;
+    }
+    if (!self->m_KeysDown.contains(vkCode)) {
+        return;
+    }
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Reconciling stuck Win key (vk=0x%X)", vkCode);
+    LiSendKeyboardEvent(vkCode, KEY_ACTION_UP, 0);
+    self->m_KeysDown.remove(vkCode);
+}
+
+void SdlInputHandler::pollWinKeyPhysicalState()
+{
+    if (m_KeysDown.contains(0x5B)) {
+        reconcileStuckWinKey(this, 0x5B);
+    }
+    if (m_KeysDown.contains(0x5C)) {
+        reconcileStuckWinKey(this, 0x5C);
+    }
+}
+
+static Uint32 winKeyWatchdogCallback(Uint32 /*interval*/, void* userdata)
+{
+    auto* self = static_cast<SdlInputHandler*>(userdata);
+    self->pollWinKeyPhysicalState();
+    return 50;  // re-arm at 20 Hz
+}
+#endif
+
 void SdlInputHandler::notifyMouseLeave()
 {
     // SDL on Windows doesn't send the mouse button up until the mouse re-enters the window
@@ -325,6 +378,15 @@ void SdlInputHandler::notifyFocusLost()
     // Raise all keys that are currently pressed. If we don't do this, certain keys
     // used in shortcuts that cause focus loss (such as Alt+Tab) may get stuck down.
     raiseAllKeys();
+
+#ifdef Q_OS_WIN32
+    // One-shot reconciliation for the Win keys: the shell often eats the
+    // KEYUP for VK_LWIN/VK_RWIN around the time focus changes. Even after
+    // raiseAllKeys() the host may still see them as down if the user pressed
+    // Win while keyboard capture was inactive (in which case m_KeysDown never
+    // recorded them - in that case this is a no-op for those keys).
+    pollWinKeyPhysicalState();
+#endif
 }
 
 void SdlInputHandler::notifyFocusGained()
@@ -335,6 +397,10 @@ void SdlInputHandler::notifyFocusGained()
     if (SDL_GetWindowWMInfo(m_Window, &info) && info.subsystem == SDL_SYSWM_WINDOWS) {
         ImmAssociateContext(info.info.win.window, NULL);
     }
+
+    // When we regain focus the user may have released the Win key while we
+    // didn't have focus. Force a reconciliation so the host state catches up.
+    pollWinKeyPhysicalState();
 #endif
 }
 

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -251,6 +251,13 @@ private:
     SDL_TimerID m_LongPressTimer;
     int m_StreamWidth;
     int m_StreamHeight;
+
+    // Win-key stuck-key watchdog (Win32 only; 0 on other platforms).
+    // The Windows shell frequently swallows KEYUP for VK_LWIN / VK_RWIN,
+    // so we poll the physical key state to reconcile m_KeysDown with reality.
+    SDL_TimerID m_WinKeyWatchdogTimer = 0;
+    void pollWinKeyPhysicalState();
+
     bool m_AbsoluteMouseMode;
     bool m_AbsoluteTouchMode;
     bool m_DisabledTouchFeedback;

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -375,12 +375,25 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 break;
             case SDL_SCANCODE_LGUI:
                 if (!isSystemKeyCaptureActive()) {
+                    // The Win key was swallowed by the shell, but we still
+                    // want m_KeysDown to reflect physical state so the
+                    // raiseAllKeys() / Win-key watchdog can clean up later.
+                    if (event->state == SDL_PRESSED) {
+                        m_KeysDown.insert(0x5B);
+                    } else {
+                        m_KeysDown.remove(0x5B);
+                    }
                     return;
                 }
                 keyCode = m_SwapWinAltKeys ? 0xA4 : 0x5B;
                 break;
             case SDL_SCANCODE_RGUI:
                 if (!isSystemKeyCaptureActive()) {
+                    if (event->state == SDL_PRESSED) {
+                        m_KeysDown.insert(0x5C);
+                    } else {
+                        m_KeysDown.remove(0x5C);
+                    }
                     return;
                 }
                 keyCode = m_SwapWinAltKeys ? 0xA5 : 0x5C;


### PR DESCRIPTION
## Problem

When the user presses the Windows key while a moonlight-qt stream is
active, the Windows shell (Start Menu / Sticky Keys / Win-key filter)
frequently swallows both the KEYDOWN and the matching KEYUP events, or
returns them out of order relative to SDL's keyboard grab state.

The visible symptom: every subsequent keystroke arrives at the host with
the **Win modifier** bit set (e.g. pressing  opens the Start-menu
search overlay instead of typing the letter ), until the stream is
restarted.

## Repro

Two scripts are attached in the PR body comments:

* epro_client.py (client-side, pure stdlib, ctypes + SendInput):
  presses VK_LWIN, releases it, dismisses any Start menu, then sends
  the test keystroke . Verifies physical key state at each step.
* monitor_host_keys.py (host-side, needs pip install pynput):
  prints every key the host receives, including the live modifier set.

Before this patch:
  `
  [HH:MM:SS] DOWN  LWIN       mods=[-]
  [HH:MM:SS] UP    LWIN       mods=[-]
  [HH:MM:SS] DOWN  A          mods=[LWIN]      <-- BUG: LWIN never cleared
  `
After this patch:
  `
  [HH:MM:SS] DOWN  LWIN       mods=[-]
  [HH:MM:SS] UP    LWIN       mods=[-]
  [HH:MM:SS] DOWN  A          mods=[-]         <-- LWIN properly cleared
  `

## Fix

Two-layer fix, Windows-only (the watchdog is compiled out on other
platforms):

1. keyboard.cpp \handleKeyEvent\: when SDL_SCANCODE_LGUI /
   SDL_SCANCODE_RGUI is dropped because isSystemKeyCaptureActive()
   is false, still update m_KeysDown so that aiseAllKeys() (called
   on focus loss) can correctly emit a synthetic UP if the key was
   previously sent.

2. input.cpp: add a 20 Hz SDL_AddTimer watchdog that polls the
   physical key state via GetAsyncKeyState(). If the user has
   physically released VK_LWIN / VK_RWIN but the entry is still in
   m_KeysDown, synthesize the missing KEY_ACTION_UP to the host
   and remove the entry. One-shot reconciliation is also triggered
   from 
otifyFocusLost / 
otifyFocusGained for immediate
   recovery.

## Files changed

| File | Lines | What |
|---|---|---|
| pp/streaming/input/input.h | +7 | watchdog timer member + pollWinKeyPhysicalState() decl |
| pp/streaming/input/input.cpp | +66 | watchdog static helpers + member fn + constructor/destructor wiring + focus-loss/gain hook |
| pp/streaming/input/keyboard.cpp | +13 | keep m_KeysDown consistent for swallowed Win-key events |

Total: 3 files, +86 / -0.

## Backwards compatibility

* No API changes, no new public symbols.
* No behavior change on non-Windows builds.
* No measurable CPU impact: 20 Hz GetAsyncKeyState is negligible.
* Win-key delivery semantics for users who *do* have keyboard capture
  enabled are unchanged.