### PR TITLE
Fix portable auto update install flow

### DIFF
--- a/app/backend/portableupdateinstaller.cpp
+++ b/app/backend/portableupdateinstaller.cpp
@@ -5,7 +5,6 @@
 #include <QDateTime>
 #include <QDir>
 #include <QFile>
-#include <QFileInfo>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QProcess>
@@ -28,8 +27,7 @@ bool PortableUpdateInstaller::supportsInAppUpdate() const
 {
 #if defined(Q_OS_WIN32)
     return isPortableInstall() &&
-            !getPortableUpdaterExecutable().isEmpty() &&
-            hasLikelyWritableInstallDir();
+            !getPortableUpdaterExecutable().isEmpty();
 #else
     return false;
 #endif
@@ -137,15 +135,6 @@ QString PortableUpdateInstaller::getPortableUpdaterExecutable() const
 #endif
 }
 
-bool PortableUpdateInstaller::hasLikelyWritableInstallDir() const
-{
-#if defined(Q_OS_WIN32)
-    return QFileInfo(Path::getPortableRootDir()).isWritable();
-#else
-    return false;
-#endif
-}
-
 bool PortableUpdateInstaller::ensureWritableInstallDir(QString& errorMessage) const
 {
 #if defined(Q_OS_WIN32)
@@ -153,7 +142,7 @@ bool PortableUpdateInstaller::ensureWritableInstallDir(QString& errorMessage) co
     probeFile.setAutoRemove(true);
 
     if (!probeFile.open()) {
-        errorMessage = tr("The current Moonlight folder is not writable. Move the portable build to a writable location or run it with sufficient permissions.");
+        errorMessage = tr("The current Moonlight folder is not writable. Move the portable build to a writable location, run Moonlight with sufficient permissions, or download and install the update manually.");
         return false;
     }
 
@@ -360,7 +349,7 @@ void PortableUpdateInstaller::handlePortableUpdateDownloadFinished()
               << "-ExePath" << exePath;
 
     if (updaterExecutable.isEmpty() ||
-            !QProcess::startDetached(updaterExecutable, arguments, m_PortableUpdateWorkspace)) {
+            !QProcess::startDetached(updaterExecutable, arguments, installDir)) {
         resetPortableUpdateState(true);
         emit onPortableUpdateFailed(tr("Unable to launch the portable updater."));
         return;

--- a/app/backend/portableupdateinstaller.h
+++ b/app/backend/portableupdateinstaller.h
@@ -28,7 +28,6 @@ private slots:
 private:
     bool isPortableInstall() const;
     QString getPortableUpdaterExecutable() const;
-    bool hasLikelyWritableInstallDir() const;
     bool ensureWritableInstallDir(QString& errorMessage) const;
     QString createPortableUpdateWorkspace() const;
     QString materializePortableUpdateScript(const QString& workspace) const;

--- a/app/deploy/windows/install-portable-update.ps1
+++ b/app/deploy/windows/install-portable-update.ps1
@@ -8,6 +8,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $extractDir = Join-Path $WorkspaceDir 'extract'
 $backupDir = Join-Path $WorkspaceDir 'backup'
+$workspaceFullPath = [System.IO.Path]::GetFullPath($WorkspaceDir).TrimEnd('\', '/')
 
 function Get-RequiredFreeBytes {
     param([string]$ArchivePath)
@@ -66,8 +67,11 @@ function Get-ReplacedItems {
     param([string]$Path)
 
     Get-ChildItem -LiteralPath $Path -Force | Where-Object {
+        $itemFullPath = [System.IO.Path]::GetFullPath($_.FullName).TrimEnd('\', '/')
+
         $_.Name -ne 'Moonlight Game Streaming Project' -and
-        $_.Name -notlike 'Moonlight-*.log'
+        $_.Name -notlike 'Moonlight-*.log' -and
+        ![string]::Equals($itemFullPath, $workspaceFullPath, [System.StringComparison]::OrdinalIgnoreCase)
     }
 }
 
@@ -123,16 +127,22 @@ catch {
     $_ | Out-File -LiteralPath $logPath -Append -Encoding utf8
 }
 finally {
+    try {
+        Set-Location -LiteralPath $InstallDir
+    }
+    catch {
+    }
+
     if (Test-Path -LiteralPath $extractDir) {
-        Remove-Item -LiteralPath $extractDir -Recurse -Force
+        Remove-Item -LiteralPath $extractDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     if ($backupDir -and (Test-Path -LiteralPath $backupDir)) {
-        Remove-Item -LiteralPath $backupDir -Recurse -Force
+        Remove-Item -LiteralPath $backupDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 
-    $workspaceDir = Split-Path -LiteralPath $ZipPath -Parent
+    $workspaceDir = [System.IO.Path]::GetDirectoryName($ZipPath)
     if (Test-Path -LiteralPath $workspaceDir) {
-        Remove-Item -LiteralPath $workspaceDir -Recurse -Force
+        Remove-Item -LiteralPath $workspaceDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 }


### PR DESCRIPTION
## 改了啥呢

- 调整 portable 应用内更新的支持判断：不再因为目录看起来不可写就直接退回打开浏览器。
- 点击更新后仍然会做真实写入 probe，不可写时弹出明确提示，告诉用户可以移动目录、用足够权限运行，或手动下载安装。
- 修复 portable 更新脚本替换文件时把自己的 `MoonlightPortableUpdate-*` 工作目录也当成旧文件处理的问题。
- 修复 Windows PowerShell 5.1 下 `Split-Path -LiteralPath ... -Parent` 的参数集冲突，收尾清理也不会把已经完成的安装变成失败日志。

## 为啥要改

下载完成后自动安装失败，根因是更新工作目录就在安装目录里，脚本枚举待替换文件时会把自己的工作区也卷进去。哼，杂鱼状态管理，明明只是临时工还想被备份走。

另一个闭环问题是目录不可写时用户体验不清晰：之前 `supportsInAppUpdate()` 把可写性也算进支持条件，导致 portable 用户可能被直接带去浏览器，不知道自动更新为什么没走。

## 验证

- `cmd /c build\qmake_and_build.bat`，通过，`BUILD_EXIT=0`。
- `powershell.exe -NoProfile -Command "[scriptblock]::Create((Get-Content -Raw -LiteralPath 'app\deploy\windows\install-portable-update.ps1')) | Out-Null; 'script-parse-ok'"`，通过。
- 用临时 portable 目录和临时 ZIP 模拟更新脚本：新文件落位、旧文件移走、没有 `Moonlight-update-error.log`、临时工作目录成功删除。