### PR TITLE
Forward media/volume keys (WM_APPCOMMAND) to host on Windows

### DIFF
--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -215,6 +215,12 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
 
 SdlInputHandler::~SdlInputHandler()
 {
+#ifdef Q_OS_WIN32
+    // Remove the WM_APPCOMMAND message hook installed in setWindow(). It
+    // captures "this", so it must be cleared before we're destroyed.
+    SDL_SetWindowsMessageHook(nullptr, nullptr);
+#endif
+
     for (int i = 0; i < MAX_GAMEPADS; i++) {
         if (m_GamepadState[i].mouseEmulationTimer != 0) {
             Session::get()->notifyMouseEmulationMode(false);
@@ -272,8 +278,78 @@ void SdlInputHandler::setWindow(SDL_Window *window)
     if (SDL_GetWindowWMInfo(m_Window, &info) && info.subsystem == SDL_SYSWM_WINDOWS) {
         ImmAssociateContext(info.info.win.window, NULL);
     }
+
+    // Media transport keys (play/pause, stop, next/prev) and volume keys are
+    // delivered by Windows as WM_APPCOMMAND messages rather than WM_KEYDOWN, so
+    // SDL never produces a key event for them and handleKeyEvent() never sees
+    // them. Install a Win32 message hook to capture WM_APPCOMMAND and forward
+    // the equivalent VK_MEDIA_*/VK_VOLUME_* code to the host ourselves.
+    SDL_SetWindowsMessageHook(SdlInputHandler::windowsMessageHook, this);
 #endif
 }
+
+#ifdef Q_OS_WIN32
+void SdlInputHandler::windowsMessageHook(void* userdata, void* hWnd, unsigned int message, Uint64 wParam, Sint64 lParam)
+{
+    Q_UNUSED(hWnd);
+    Q_UNUSED(wParam);
+
+    if (message != WM_APPCOMMAND) {
+        return;
+    }
+
+    auto me = reinterpret_cast<SdlInputHandler*>(userdata);
+
+    // Only forward media keys while we're actively sending input to the host,
+    // so the user's local media keys keep working when they've released capture.
+    if (me == nullptr || !me->isCaptureActive()) {
+        return;
+    }
+
+    short keyCode;
+    switch (GET_APPCOMMAND_LPARAM((LPARAM)lParam)) {
+    case APPCOMMAND_MEDIA_PLAY_PAUSE:
+        keyCode = VK_MEDIA_PLAY_PAUSE;
+        break;
+    case APPCOMMAND_MEDIA_PLAY:
+        keyCode = VK_MEDIA_PLAY_PAUSE;
+        break;
+    case APPCOMMAND_MEDIA_PAUSE:
+        keyCode = VK_MEDIA_PLAY_PAUSE;
+        break;
+    case APPCOMMAND_MEDIA_STOP:
+        keyCode = VK_MEDIA_STOP;
+        break;
+    case APPCOMMAND_MEDIA_NEXTTRACK:
+        keyCode = VK_MEDIA_NEXT_TRACK;
+        break;
+    case APPCOMMAND_MEDIA_PREVIOUSTRACK:
+        keyCode = VK_MEDIA_PREV_TRACK;
+        break;
+    case APPCOMMAND_VOLUME_MUTE:
+        keyCode = VK_VOLUME_MUTE;
+        break;
+    case APPCOMMAND_VOLUME_DOWN:
+        keyCode = VK_VOLUME_DOWN;
+        break;
+    case APPCOMMAND_VOLUME_UP:
+        keyCode = VK_VOLUME_UP;
+        break;
+    default:
+        // Not a key we forward; let Windows handle it normally.
+        return;
+    }
+
+    // WM_APPCOMMAND is a single discrete event (no separate key-up), so we
+    // synthesize a press and release. We send the raw VK code with the
+    // non-normalized flag so the host injects it directly rather than trying to
+    // re-interpret it against the keyboard layout (these keys have no scancode).
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Forwarding WM_APPCOMMAND media key: 0x%x", keyCode);
+    LiSendKeyboardEvent2(0x8000 | keyCode, KEY_ACTION_DOWN, 0, SS_KBE_FLAG_NON_NORMALIZED);
+    LiSendKeyboardEvent2(0x8000 | keyCode, KEY_ACTION_UP, 0, SS_KBE_FLAG_NON_NORMALIZED);
+}
+#endif
 
 void SdlInputHandler::raiseAllKeys()
 {

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -215,6 +215,13 @@ private:
     static
     Uint32 dragTimerCallback(Uint32 interval, void* param);
 
+#ifdef Q_OS_WIN32
+    // SDL Win32 message hook used to capture WM_APPCOMMAND (consumer-control
+    // "media" keys) which Windows does not deliver as WM_KEYDOWN events.
+    static
+    void windowsMessageHook(void* userdata, void* hWnd, unsigned int message, Uint64 wParam, Sint64 lParam);
+#endif
+
     SDL_Window* m_Window;
     bool m_MultiController;
     bool m_GamepadMouse;


### PR DESCRIPTION
## Problem

Media transport keys (Play/Pause, Stop, Next, Previous) and the Volume keys do nothing when streaming to a Windows host. They are silently dropped on the client.

**Root cause:** On Windows these are HID *consumer-control* usages. The OS delivers them as `WM_APPCOMMAND` messages, **not** as `WM_KEYDOWN`. SDL therefore never produces an `SDL_KEYDOWN` event for them, so `SdlInputHandler::handleKeyEvent()` never runs and there is nothing to forward. (If a key does reach the big scancode switch in `keyboard.cpp`, media keys fall into `default:` and are logged as `Unhandled button event` and dropped.) The "Always send scancodes" option doesn't help, since it only re-encodes keys that already entered the SDL keyboard pipeline.

This matches the upstream report [moonlight-qt#1254](https://github.com/moonlight-stream/moonlight-qt/issues/1254).

## Fix

Install an SDL Win32 message hook (`SDL_SetWindowsMessageHook`) in `setWindow()` that intercepts `WM_APPCOMMAND` and forwards the matching `VK_MEDIA_*` / `VK_VOLUME_*` code to the host.

- Sent via `LiSendKeyboardEvent2()` with `SS_KBE_FLAG_NON_NORMALIZED`, so the host injects the virtual-key directly instead of trying to re-interpret it against the keyboard layout (these keys have no meaningful scancode). The matching host (Sunshine / Sunshine-Foundation) already injects these VKs correctly.
- A press/release pair is synthesized because `WM_APPCOMMAND` is a single discrete event with no key-up.
- Only forwarded while `isCaptureActive()`, so the user's **local** media keys keep working when capture is released.
- Hook is torn down in the destructor (it captures `this`).

Windows-only; everything is under `#ifdef Q_OS_WIN32`. No protocol or host changes required.

## Keys handled
`MEDIA_PLAY_PAUSE` / `PLAY` / `PAUSE`, `MEDIA_STOP`, `MEDIA_NEXTTRACK`, `MEDIA_PREVIOUSTRACK`, `VOLUME_MUTE`, `VOLUME_DOWN`, `VOLUME_UP`.

## Testing notes
- I was not able to run a full Qt/SDL build locally, so please rely on CI for compile verification. The change uses only symbols already present in the translation unit (`LiSendKeyboardEvent2`, `SS_KBE_FLAG_NON_NORMALIZED`, `KEY_ACTION_*`) plus standard Win32 (`<Windows.h>`, already included) and SDL2 (`SDL_SetWindowsMessageHook`) APIs, and mirrors the existing Win32 block in `setWindow()`.

## Known limitation / possible follow-up
`SDL_SetWindowsMessageHook` can only observe messages, not mark them handled, so the local machine may also act on the media key while the Moonlight window is focused. Fully suppressing local handling would require subclassing the window proc and returning `TRUE` for `WM_APPCOMMAND`; left out of this PR to keep it minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
