### PR TITLE
fix(ui): add background wallpaper toggle

### DIFF
--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -599,10 +599,12 @@ CenteredGridView {
     Image {
         id: backgroundImage
         anchors.fill: parent
+        visible: StreamingPreferences.enableBackgroundImage
         source: ""
         fillMode: Image.PreserveAspectCrop
         z: -2
         property string currentImageUrl: ""
+        property bool usingFallbackImage: false
         
         Settings {
             id: settings
@@ -611,18 +613,45 @@ CenteredGridView {
         }
         
         onStatusChanged: {
+            if (!StreamingPreferences.enableBackgroundImage) {
+                loadingIndicator.visible = false
+                return
+            }
+
             if (status === Image.Loading) {
                 loadingIndicator.visible = true
             } else if (status === Image.Ready) {
                 loadingIndicator.visible = false
             } else if (status === Image.Error) {
                 loadingIndicator.visible = false
-                getBackgroundImage() // 如果缓存图加载失败，尝试加载新图片
+                if (!usingFallbackImage) {
+                    getBackgroundImage()
+                } else {
+                    console.error("Fallback background image failed to load")
+                }
             }
         }
 
+        function toFileUrl(path) {
+            return "file:///" + path.replace(/\\/g, "/").replace(/^\/+/, "")
+        }
+
+        function clearBackgroundImage() {
+            loadingIndicator.visible = false
+            source = ""
+            currentImageUrl = ""
+            pcGrid.currentBgUrl = ""
+            usingFallbackImage = false
+        }
+
         function getBackgroundImage() {
+            if (!StreamingPreferences.enableBackgroundImage) {
+                clearBackgroundImage()
+                return
+            }
+
             loadingIndicator.visible = true
+            usingFallbackImage = false
             
             var cachePath = imageUtils.fetchAndSaveRandomBackground("https://img-api.pipw.top/")
             loadingIndicator.visible = false
@@ -637,43 +666,68 @@ CenteredGridView {
         function handleImageResponse(cachePath) {
             settings.cachedImagePath = cachePath
             console.log("handleImageResponse: " + cachePath)
-            var fileUrl = "file:///" + cachePath.replace(/\\/g, "/").replace(/^\/+/, "")
+            var fileUrl = toFileUrl(cachePath)
             source = ""
             source = fileUrl
             currentImageUrl = fileUrl
             pcGrid.currentBgUrl = fileUrl
+            usingFallbackImage = false
             settings.lastRefreshTime = Date.now()
         }
 
         function handleImageError(status) {
             console.error("Background image load failed:", status)
-            if (!source.toString().startsWith("file://")) {
-                source = "qrc:/res/gura.jpg"
+            loadingIndicator.visible = false
+
+            if (!StreamingPreferences.enableBackgroundImage) {
+                clearBackgroundImage()
+                return
             }
+
+            usingFallbackImage = true
+            currentImageUrl = ""
+            pcGrid.currentBgUrl = ""
+            source = "qrc:/res/gura.png"
         }
         
-        Component.onCompleted: {
-            // 先检查缓存图是否存在
+        function loadBackgroundImage() {
+            if (!StreamingPreferences.enableBackgroundImage) {
+                clearBackgroundImage()
+                return
+            }
+
             if (settings.cachedImagePath && imageUtils.fileExists(settings.cachedImagePath)) {
                 try {
-                    var fileUrl = "file:///" + settings.cachedImagePath.replace(/\\/g, "/").replace(/^\/+/, "");
-                    source = fileUrl;
-                    console.log("loadBackgroundImageFromCache: " + fileUrl);
-                    currentImageUrl = fileUrl;
-                    pcGrid.currentBgUrl = fileUrl;  // 初始化时同步属性
-                    
-                    // 检查是否需要刷新（如果上次刷新时间超过1小时）
-                    var oneHour = 60 * 60 * 1000 * 24 * 7;
-                    if (Date.now() - settings.lastRefreshTime > oneHour) {
-                        loadNewImageTimer.start();
+                    var fileUrl = toFileUrl(settings.cachedImagePath)
+                    source = fileUrl
+                    console.log("loadBackgroundImageFromCache: " + fileUrl)
+                    currentImageUrl = fileUrl
+                    pcGrid.currentBgUrl = fileUrl
+                    usingFallbackImage = false
+
+                    var oneWeek = 60 * 60 * 1000 * 24 * 7
+                    if (Date.now() - settings.lastRefreshTime > oneWeek) {
+                        loadNewImageTimer.start()
                     }
                 } catch (e) {
-                    console.log("fail loadBackgroundImageFromCache: " + e);
-                    getBackgroundImage();
+                    console.log("fail loadBackgroundImageFromCache: " + e)
+                    getBackgroundImage()
                 }
             } else {
-                // 如果没有缓存，立即获取新图片
-                getBackgroundImage();
+                getBackgroundImage()
+            }
+        }
+
+        Component.onCompleted: loadBackgroundImage()
+
+        Connections {
+            target: StreamingPreferences
+            function onEnableBackgroundImageChanged() {
+                if (StreamingPreferences.enableBackgroundImage) {
+                    backgroundImage.loadBackgroundImage()
+                } else {
+                    backgroundImage.clearBackgroundImage()
+                }
             }
         }
         
@@ -682,13 +736,16 @@ CenteredGridView {
             interval: 1000 // 延迟1秒加载新图片
             repeat: false
             onTriggered: {
-                backgroundImage.getBackgroundImage();
+                if (StreamingPreferences.enableBackgroundImage) {
+                    backgroundImage.getBackgroundImage()
+                }
             }
         }
     }
 
     DropArea {
         anchors.fill: parent
+        enabled: StreamingPreferences.enableBackgroundImage
         onEntered: function(drag) {
             drag.accept(Qt.LinkAction)
             dragBorder.visible = true
@@ -708,7 +765,7 @@ CenteredGridView {
                     
                     // 更新背景图
                     backgroundImage.source = filePath;
-                    currentImageUrl = filePath;
+                    backgroundImage.currentImageUrl = filePath;
                     pcGrid.currentBgUrl = filePath;  // 拖放时同步属性
                 } else {
                     errorDialog.text = qsTr("不支持的图片格式")
@@ -743,12 +800,13 @@ CenteredGridView {
     MouseArea {
         anchors.fill: parent
         acceptedButtons: Qt.RightButton
+        enabled: StreamingPreferences.enableBackgroundImage
         propagateComposedEvents: true
         z: -1  // 确保这个MouseArea位于PC条目之下
         
         onClicked: function(mouse) {
             if (mouse.button === Qt.RightButton) {
-                if (backgroundImage.currentImageUrl) {
+                if (StreamingPreferences.enableBackgroundImage && backgroundImage.currentImageUrl) {
                     console.log("右键菜单被触发")
                     backgroundContextMenu.popup()
                 }
@@ -794,7 +852,9 @@ CenteredGridView {
         interval: 200  // 延迟200毫秒
         repeat: false
         onTriggered: {
-            backgroundImage.getBackgroundImage()
+            if (StreamingPreferences.enableBackgroundImage) {
+                backgroundImage.getBackgroundImage()
+            }
         }
     }
 
@@ -858,7 +918,7 @@ CenteredGridView {
     
     Rectangle {
         anchors.fill: parent
-        color: Qt.rgba(0, 0, 0, 0.6)
+        color: StreamingPreferences.enableBackgroundImage ? Qt.rgba(0, 0, 0, 0.6) : "#303030"
         z: -1
     }
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -112,7 +112,8 @@ Flickable {
 
         Image {
             anchors.fill: parent
-            source: pcViewPage.currentBgUrl || "qrc:/res/gura.png"
+            visible: StreamingPreferences.enableBackgroundImage
+            source: visible ? (pcViewPage.currentBgUrl || "qrc:/res/gura.png") : ""
             opacity: 0.35
             fillMode: Image.PreserveAspectCrop
         }
@@ -1633,6 +1634,23 @@ Flickable {
                     onActivated : {
                         StreamingPreferences.uiDisplayMode = uiDisplayModeListModel.get(currentIndex).val
                     }
+                }
+
+                CheckBox {
+                    id: backgroundImageCheck
+                    width: parent.width
+                    hoverEnabled: true
+                    text: qsTr("Enable background wallpaper")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.enableBackgroundImage
+                    onCheckedChanged: {
+                        StreamingPreferences.enableBackgroundImage = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Download and display a wallpaper on the PC list and settings pages.")
                 }
 
                 CheckBox {

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -249,7 +249,7 @@ ApplicationWindow {
         z: 1
         
         background: Rectangle {
-            color: "transparent"
+            color: stackView.currentItem instanceof PcView ? Qt.rgba(0, 0, 0, 0.32) : "transparent"
         }
 
         Label {

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -70,6 +70,7 @@
 #define SER_OVERLAYMENUPOS "overlaymenuposition"
 #define SER_HDRMODE "hdrmode"
 #define SER_AUTOUPDATECHECK "autoupdatecheck"
+#define SER_BACKGROUNDIMAGE "backgroundimage"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -163,6 +164,7 @@ void StreamingPreferences::reload()
     overlayMenuPosition = static_cast<OverlayMenuPosition>(settings.value(SER_OVERLAYMENUPOS,
                                                            static_cast<int>(OverlayMenuPosition::OMP_RIGHT_EDGE)).toInt());
     autoUpdateCheck = settings.value(SER_AUTOUPDATECHECK, true).toBool();
+    enableBackgroundImage = settings.value(SER_BACKGROUNDIMAGE, true).toBool();
 
     streamResolutionScale = settings.value(SER_STREAMRESOLUTIONSCALE, false).toBool();
     streamResolutionScaleRatio = settings.value(SER_STREAMRESOLUTIONSCALERATIO, 100).toInt();
@@ -417,6 +419,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_MICROPHONE, enableMicrophone);
     settings.setValue(SER_OVERLAYMENUPOS, static_cast<int>(overlayMenuPosition));
     settings.setValue(SER_AUTOUPDATECHECK, autoUpdateCheck);
+    settings.setValue(SER_BACKGROUNDIMAGE, enableBackgroundImage);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -192,6 +192,7 @@ public:
     Q_PROPERTY(bool enableMicrophone MEMBER enableMicrophone NOTIFY enableMicrophoneChanged)
     Q_PROPERTY(OverlayMenuPosition overlayMenuPosition MEMBER overlayMenuPosition NOTIFY overlayMenuPositionChanged)
     Q_PROPERTY(bool autoUpdateCheck MEMBER autoUpdateCheck NOTIFY autoUpdateCheckChanged)
+    Q_PROPERTY(bool enableBackgroundImage MEMBER enableBackgroundImage NOTIFY enableBackgroundImageChanged)
 
     Q_INVOKABLE bool retranslate();
 
@@ -252,6 +253,7 @@ public:
     bool enableMicrophone;
     OverlayMenuPosition overlayMenuPosition;
     bool autoUpdateCheck;
+    bool enableBackgroundImage;
 
 signals:
     void displayModeChanged();
@@ -307,6 +309,7 @@ signals:
     void enableMicrophoneChanged();
     void overlayMenuPositionChanged();
     void autoUpdateCheckChanged();
+    void enableBackgroundImageChanged();
 
 private:
     explicit StreamingPreferences(QQmlEngine *qmlEngine);


### PR DESCRIPTION
﻿## 改了啥呢

- 给背景壁纸新增 `enableBackgroundImage` 偏好项，并保存到设置里
- 在设置页加了 `Enable background wallpaper` 开关
- 关闭壁纸后，PC 列表页不再加载/刷新/拖拽替换壁纸，也不会弹出壁纸右键菜单
- 壁纸不可用或关闭时改用稳定深色背景，避免按钮因为背景状态变得看不清

## 为啥要改

Closes #48

壁纸加载失败时，主界面的按钮会被背景状态影响到可见性；另外 issue 里也提到希望能直接关闭壁纸。现在给它一个开关，壁纸这点小脾气就被关进设置里啦。

## 验证

- `git diff --check`
- `qmllint app\\gui\\PcView.qml app\\gui\\SettingsView.qml app\\gui\\main.qml`，退出码 0；输出包含项目自定义 QML import 路径未配置导致的既有 warning
- VS 2022 + Qt 6.9.2 临时目录完整编译通过，产出 `Moonlight.exe`
- 脚本化断言 5 项通过：偏好属性、默认 true、设置页写入、关闭后停止加载、关闭后纯色背景 fallback
