### PR TITLE
Client-driven dynamic resolution: match stream resolution to window size

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "moonlight-common-c/moonlight-common-c"]
 	path = moonlight-common-c/moonlight-common-c
-url = https://github.com/AsafMah/moonlight-common-c.git
+	url = https://github.com/AsafMah/moonlight-common-c.git
+	branch = feat/client-resolution-request
 [submodule "qmdnsengine/qmdnsengine"]
 	path = qmdnsengine/qmdnsengine
 	url = https://github.com/cgutman/qmdnsengine.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "moonlight-common-c/moonlight-common-c"]
 	path = moonlight-common-c/moonlight-common-c
-url=https://github.com/qiin2333/moonlight-common-c.git
+url = https://github.com/AsafMah/moonlight-common-c.git
 [submodule "qmdnsengine/qmdnsengine"]
 	path = qmdnsengine/qmdnsengine
 	url = https://github.com/cgutman/qmdnsengine.git

--- a/app/backend/nvcomputer.cpp
+++ b/app/backend/nvcomputer.cpp
@@ -61,6 +61,7 @@ NvComputer::NvComputer(QSettings& settings)
     this->pendingQuit = false;
     this->gpuModel = nullptr;
     this->isSupportedServerVersion = true;
+    this->supportsClientResolutionChange = false;
     this->externalPort = this->remoteAddress.port();
     this->activeHttpsPort = 0;
 }
@@ -214,6 +215,9 @@ NvComputer::NvComputer(NvHTTP& http, QString serverInfo)
     this->state = NvComputer::CS_ONLINE;
     this->pendingQuit = false;
     this->isSupportedServerVersion = CompatFetcher::isGfeVersionSupported(this->gfeVersion);
+    // AlkaidLab Sunshine fork advertises this tag when 0x5506 dynamic-parameter support is present.
+    // ASSUMPTION: tag name is "ClientResolutionChange"; must match the FoundationHost serverinfo emission.
+    this->supportsClientResolutionChange = NvHTTP::getXmlString(serverInfo, "ClientResolutionChange") == "1";
 }
 
 bool NvComputer::wake() const
@@ -628,6 +632,7 @@ bool NvComputer::update(const NvComputer& that)
     ASSIGN_IF_CHANGED(isNvidiaServerSoftware);
     ASSIGN_IF_CHANGED(maxLumaPixelsHEVC);
     ASSIGN_IF_CHANGED(gpuModel);
+    ASSIGN_IF_CHANGED(supportsClientResolutionChange);
     ASSIGN_IF_CHANGED_AND_NONNULL(serverCert);
     ASSIGN_IF_CHANGED_AND_NONEMPTY(displayModes);
 

--- a/app/backend/nvcomputer.h
+++ b/app/backend/nvcomputer.h
@@ -106,6 +106,10 @@ public:
     int serverCodecModeSupport;
     QString gpuModel;
     bool isSupportedServerVersion;
+    // True when the host advertised <ClientResolutionChange>1</ClientResolutionChange>
+    // in /serverinfo — indicates AlkaidLab Sunshine fork with 0x5506 support.
+    // ASSUMPTION: exact XML tag name is "ClientResolutionChange" (must match FoundationHost PR).
+    bool supportsClientResolutionChange;
 
     // Persisted traits
     NvAddress localAddress;

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -825,6 +825,23 @@ Flickable {
                     ToolTip.text: qsTr("Allows Sunshine to automatically adjust stream bitrate up to the selected video bitrate when the host supports ABR.")
                 }
 
+                CheckBox {
+                    id: resolutionMatchWindowCheck
+                    width: parent.width
+                    hoverEnabled: true
+                    text: qsTr("Match stream resolution to window size")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.resolutionMatchWindow
+                    onCheckedChanged: {
+                        StreamingPreferences.resolutionMatchWindow = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 8000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Automatically send a resolution change request to the host when the streaming window is resized (windowed mode only). Requires a compatible Sunshine host.")
+                }
+
                 Label {
                     width: parent.width
                     id: windowModeTitle

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -70,6 +70,7 @@
 #define SER_OVERLAYMENUPOS "overlaymenuposition"
 #define SER_HDRMODE "hdrmode"
 #define SER_AUTOUPDATECHECK "autoupdatecheck"
+#define SER_RESMATCHWINDOW "resolutionmatchwindow"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -163,6 +164,7 @@ void StreamingPreferences::reload()
     overlayMenuPosition = static_cast<OverlayMenuPosition>(settings.value(SER_OVERLAYMENUPOS,
                                                            static_cast<int>(OverlayMenuPosition::OMP_RIGHT_EDGE)).toInt());
     autoUpdateCheck = settings.value(SER_AUTOUPDATECHECK, true).toBool();
+    resolutionMatchWindow = settings.value(SER_RESMATCHWINDOW, false).toBool();
 
     streamResolutionScale = settings.value(SER_STREAMRESOLUTIONSCALE, false).toBool();
     streamResolutionScaleRatio = settings.value(SER_STREAMRESOLUTIONSCALERATIO, 100).toInt();
@@ -417,6 +419,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_MICROPHONE, enableMicrophone);
     settings.setValue(SER_OVERLAYMENUPOS, static_cast<int>(overlayMenuPosition));
     settings.setValue(SER_AUTOUPDATECHECK, autoUpdateCheck);
+    settings.setValue(SER_RESMATCHWINDOW, resolutionMatchWindow);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -192,6 +192,7 @@ public:
     Q_PROPERTY(bool enableMicrophone MEMBER enableMicrophone NOTIFY enableMicrophoneChanged)
     Q_PROPERTY(OverlayMenuPosition overlayMenuPosition MEMBER overlayMenuPosition NOTIFY overlayMenuPositionChanged)
     Q_PROPERTY(bool autoUpdateCheck MEMBER autoUpdateCheck NOTIFY autoUpdateCheckChanged)
+    Q_PROPERTY(bool resolutionMatchWindow MEMBER resolutionMatchWindow NOTIFY resolutionMatchWindowChanged)
 
     Q_INVOKABLE bool retranslate();
 
@@ -250,8 +251,8 @@ public:
     int customScreenMode;
     int customVddScreenMode;
     bool enableMicrophone;
-    OverlayMenuPosition overlayMenuPosition;
     bool autoUpdateCheck;
+    bool resolutionMatchWindow;
 
 signals:
     void displayModeChanged();
@@ -307,6 +308,7 @@ signals:
     void enableMicrophoneChanged();
     void overlayMenuPositionChanged();
     void autoUpdateCheckChanged();
+    void resolutionMatchWindowChanged();
 
 private:
     explicit StreamingPreferences(QQmlEngine *qmlEngine);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -251,6 +251,7 @@ public:
     int customScreenMode;
     int customVddScreenMode;
     bool enableMicrophone;
+    OverlayMenuPosition overlayMenuPosition;
     bool autoUpdateCheck;
     bool resolutionMatchWindow;
 

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -276,6 +276,13 @@ void SdlInputHandler::setWindow(SDL_Window *window)
 #endif
 }
 
+void SdlInputHandler::updateStreamDimensions(int streamWidth, int streamHeight)
+{
+    m_StreamWidth = streamWidth;
+    m_StreamHeight = streamHeight;
+}
+
+
 void SdlInputHandler::raiseAllKeys()
 {
     if (m_KeysDown.isEmpty()) {

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -152,6 +152,11 @@ public:
 
     void updatePointerRegionLock();
 
+    // Called on the main thread after a dynamic resolution change so that absolute
+    // mouse/touch mapping and the pointer-region lock use the correct aspect ratio.
+    void updateStreamDimensions(int streamWidth, int streamHeight);
+
+
     static
     QString getUnmappedGamepads();
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -36,6 +36,7 @@
 #define SDL_CODE_GAMECONTROLLER_SET_MOTION_EVENT_STATE 103
 #define SDL_CODE_GAMECONTROLLER_SET_CONTROLLER_LED 104
 #define SDL_CODE_GAMECONTROLLER_SET_ADAPTIVE_TRIGGERS 105
+#define SDL_CODE_RESOLUTION_CHANGED 106
 
 #include <openssl/rand.h>
 
@@ -359,7 +360,7 @@ void Session::clResolutionChanged(uint32_t width, uint32_t height)
 {
     // Called by moonlight-common-c on the control-stream receive thread when the host
     // echoes back a resolution-change confirm (0x5507) or pushes a host-initiated change.
-    // We clear the in-flight gate so the debounce loop can send the next queued request.
+    // Marshal to the session/main thread via SDL event so decoder recreation runs there.
     Session* session = s_ActiveSession;
     if (session == nullptr) {
         return;
@@ -367,7 +368,13 @@ void Session::clResolutionChanged(uint32_t width, uint32_t height)
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Host confirmed resolution change: %ux%u", width, height);
-    session->m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+
+    SDL_Event resEvent = {};
+    resEvent.type = SDL_USEREVENT;
+    resEvent.user.code = SDL_CODE_RESOLUTION_CHANGED;
+    resEvent.user.data1 = (void*)(uintptr_t)width;
+    resEvent.user.data2 = (void*)(uintptr_t)height;
+    SDL_PushEvent(&resEvent);
 }
 
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
@@ -2369,6 +2376,7 @@ void updateHostConnectionInfoFromServerInfo(const QString& serverInfo,
     QString refreshedCodecSupport = NvHTTP::getXmlString(serverInfo, "ServerCodecModeSupport");
     QString refreshedAppVersion = NvHTTP::getXmlString(serverInfo, "appversion");
     QString refreshedGfeVersion = NvHTTP::getXmlString(serverInfo, "GfeVersion");
+    QString refreshedClientResChange = NvHTTP::getXmlString(serverInfo, "ClientResolutionChange");
 
     if (!refreshedCodecSupport.isEmpty()) {
         int refreshedServerCodecModeSupport = refreshedCodecSupport.toInt();
@@ -2397,6 +2405,18 @@ void updateHostConnectionInfoFromServerInfo(const QString& serverInfo,
     QWriteLocker lock(&computer->lock);
     computer->serverCodecModeSupport = snapshot->serverCodecModeSupport;
     computer->currentGameId = snapshot->currentGameId;
+
+    if (!refreshedClientResChange.isEmpty()) {
+        bool newVal = (refreshedClientResChange == "1");
+        if (newVal != computer->supportsClientResolutionChange) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Host ClientResolutionChange capability changed after %s: %d -> %d",
+                        resumingSession ? "resume" : "launch",
+                        (int)computer->supportsClientResolutionChange,
+                        (int)newVal);
+        }
+        computer->supportsClientResolutionChange = newVal;
+    }
 
     if (!snapshot->appVersion.isEmpty()) {
         computer->appVersion = snapshot->appVersion;
@@ -2990,18 +3010,22 @@ void Session::exec()
     constexpr Uint32 RESOLUTION_REQUEST_TIMEOUT_MS = 2000;
     Uint32 m_ResolutionRequestSentTicks = 0;
     auto processResolutionDebounce = [this, &m_ResolutionRequestSentTicks]() {
-        if (m_ResizeDebounceTargetTicks == 0) {
-            return;
-        }
-
         const Uint32 now = SDL_GetTicks();
 
-        // Clear stale in-flight gate if host did not respond within the timeout.
+        // Timeout check runs unconditionally so a stale in-flight gate is cleared
+        // even after the debounce target has already been consumed (i.e. when
+        // m_ResizeDebounceTargetTicks == 0 after a prior send).
         if (m_ResolutionRequestInFlight.load(std::memory_order_acquire) &&
+                m_ResolutionRequestSentTicks != 0 &&
                 now - m_ResolutionRequestSentTicks >= RESOLUTION_REQUEST_TIMEOUT_MS) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "Client-driven resolution: in-flight timeout, unblocking gate");
             m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+        }
+
+        // Nothing pending — nothing more to do.
+        if (m_ResizeDebounceTargetTicks == 0) {
+            return;
         }
 
         // Debounce has not yet settled.
@@ -3009,19 +3033,28 @@ void Session::exec()
             return;
         }
 
-        // Debounce settled. Consume so we don't re-fire next iteration.
-        m_ResizeDebounceTargetTicks = 0;
-
-        // Suppress if a previous request is still in-flight.
+        // If a previous request is still in-flight, keep the desired size queued
+        // by re-arming the debounce at a short retry interval rather than dropping it.
         if (m_ResolutionRequestInFlight.load(std::memory_order_acquire)) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "Client-driven resolution: skipping send, previous request in-flight");
+                        "Client-driven resolution: in-flight, re-queuing resize for later");
+            m_ResizeDebounceTargetTicks = now + 200;
             return;
         }
 
+        // Debounce settled and no request in-flight. Consume the pending resize.
+        m_ResizeDebounceTargetTicks = 0;
+
         // Read physical pixel size (HiDPI-aware).
         int physW = 0, physH = 0;
+#if SDL_VERSION_ATLEAST(2, 26, 0)
         SDL_GetWindowSizeInPixels(m_Window, &physW, &physH);
+#else
+        // SDL < 2.26: SDL_GetWindowSizeInPixels is unavailable; fall back to the
+        // logical window size. HiDPI scaling will not be accounted for, but the
+        // request is still useful on normal-DPI displays.
+        SDL_GetWindowSize(m_Window, &physW, &physH);
+#endif
         if (physW <= 0 || physH <= 0) {
             return; // window not ready
         }
@@ -3142,6 +3175,33 @@ void Session::exec()
                 m_InputHandler->setAdaptiveTriggers((uint16_t)(uintptr_t)event.user.data1,
                                                     (DualSenseOutputReport *)event.user.data2);
                 break;
+            case SDL_CODE_RESOLUTION_CHANGED:
+            {
+                // Marshalled from clResolutionChanged (control-stream receive thread).
+                // Update active stream dimensions, clear the in-flight gate, then trigger
+                // decoder recreation so the new resolution takes effect immediately.
+                int newW = (int)(uintptr_t)event.user.data1;
+                int newH = (int)(uintptr_t)event.user.data2;
+
+                SDL_LockMutex(m_DecoderLock);
+                m_ActiveVideoWidth = newW;
+                m_ActiveVideoHeight = newH;
+                SDL_UnlockMutex(m_DecoderLock);
+
+                // Clear in-flight gate so the debounce loop can queue the next request.
+                m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                            "Applying host resolution change: %dx%d — recreating decoder",
+                            newW, newH);
+
+                // Synthesise an SDL_RENDER_DEVICE_RESET to reuse the existing decoder
+                // recreation path (lines below in SDL_RENDER_DEVICE_RESET case).
+                SDL_Event resetEvent = {};
+                resetEvent.type = SDL_RENDER_DEVICE_RESET;
+                SDL_PushEvent(&resetEvent);
+                break;
+            }
             default:
                 SDL_assert(false);
             }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -70,7 +70,7 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
     Session::clSetMotionEventState,
     Session::clSetControllerLED,
     Session::clSetAdaptiveTriggers,
-    nullptr, // resolutionChanged (unused on Qt client)
+    Session::clResolutionChanged,
     Session::clClipboardData
 };
 
@@ -353,6 +353,21 @@ void Session::clClipboardData(const char* data, int length)
 
     // Marshals to GUI thread internally; safe to call from the recv thread.
     session->m_ClipboardSync->handleIncomingFrame(data, length);
+}
+
+void Session::clResolutionChanged(uint32_t width, uint32_t height)
+{
+    // Called by moonlight-common-c on the control-stream receive thread when the host
+    // echoes back a resolution-change confirm (0x5507) or pushes a host-initiated change.
+    // We clear the in-flight gate so the debounce loop can send the next queued request.
+    Session* session = s_ActiveSession;
+    if (session == nullptr) {
+        return;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Host confirmed resolution change: %ux%u", width, height);
+    session->m_ResolutionRequestInFlight.store(false, std::memory_order_release);
 }
 
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
@@ -728,7 +743,9 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
             m_AbrCurrentBitrateKbps(std::make_shared<std::atomic_int>(0)),
       m_Toast(nullptr),
       m_MenuCloseTicks(0),
-      m_MicStream(nullptr)
+      m_MicStream(nullptr),
+      m_ResizeDebounceTargetTicks(0),
+      m_ResolutionRequestInFlight(false)
 {
     memset(&m_LastAbrVideoStats, 0, sizeof(m_LastAbrVideoStats));
     m_ClipboardSync = nullptr;
@@ -2969,9 +2986,68 @@ void Session::exec()
         }
     };
 
+    // In-flight timeout: if the host does not echo a resolutionChanged within 2 s, unblock the gate.
+    constexpr Uint32 RESOLUTION_REQUEST_TIMEOUT_MS = 2000;
+    Uint32 m_ResolutionRequestSentTicks = 0;
+    auto processResolutionDebounce = [this, &m_ResolutionRequestSentTicks]() {
+        if (m_ResizeDebounceTargetTicks == 0) {
+            return;
+        }
+
+        const Uint32 now = SDL_GetTicks();
+
+        // Clear stale in-flight gate if host did not respond within the timeout.
+        if (m_ResolutionRequestInFlight.load(std::memory_order_acquire) &&
+                now - m_ResolutionRequestSentTicks >= RESOLUTION_REQUEST_TIMEOUT_MS) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Client-driven resolution: in-flight timeout, unblocking gate");
+            m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+        }
+
+        // Debounce has not yet settled.
+        if ((int)(now - m_ResizeDebounceTargetTicks) < 0) {
+            return;
+        }
+
+        // Debounce settled. Consume so we don't re-fire next iteration.
+        m_ResizeDebounceTargetTicks = 0;
+
+        // Suppress if a previous request is still in-flight.
+        if (m_ResolutionRequestInFlight.load(std::memory_order_acquire)) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Client-driven resolution: skipping send, previous request in-flight");
+            return;
+        }
+
+        // Read physical pixel size (HiDPI-aware).
+        int physW = 0, physH = 0;
+        SDL_GetWindowSizeInPixels(m_Window, &physW, &physH);
+        if (physW <= 0 || physH <= 0) {
+            return; // window not ready
+        }
+
+        // Round to even (encoder requirement) and clamp to minimum.
+        physW = qMax(256, physW & ~1);
+        physH = qMax(256, physH & ~1);
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Client-driven resolution: requesting %dx%d from host", physW, physH);
+
+        int ret = LiSendResolutionChangeRequest((unsigned int)physW, (unsigned int)physH);
+        if (ret == 0) {
+            m_ResolutionRequestInFlight.store(true, std::memory_order_release);
+            m_ResolutionRequestSentTicks = SDL_GetTicks();
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Client-driven resolution: LiSendResolutionChangeRequest returned %d", ret);
+        }
+    };
+
     SDL_Event event;
     for (;;) {
         processSunshineAbrFeedback();
+        processResolutionDebounce();
 
 #if SDL_VERSION_ATLEAST(2, 0, 18) && !defined(STEAM_LINK)
         // SDL 2.0.18 has a proper wait event implementation that uses platform
@@ -3100,6 +3176,16 @@ void Session::exec()
             case SDL_WINDOWEVENT_MOVED:
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 syncQtOverlayWindowsWithSdlWindowState();
+                // Arm debounce for client-driven resolution if the feature is active.
+                // Gate: pref enabled, host capability advertised, NOT in exclusive fullscreen.
+                // Exclusive fullscreen: (windowFlags & FULLSCREEN_DESKTOP) == FULLSCREEN (0x1).
+                // Windowed and borderless-desktop-fullscreen both pass (only exclusive is skipped).
+                if (m_Preferences->resolutionMatchWindow &&
+                        m_Computer->supportsClientResolutionChange &&
+                        (SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN) {
+                    // Debounce: reset fire time on each resize; fires 400 ms after the last event.
+                    m_ResizeDebounceTargetTicks = SDL_GetTicks() + 400;
+                }
                 break;
             }
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -752,7 +752,10 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_MenuCloseTicks(0),
       m_MicStream(nullptr),
       m_ResizeDebounceTargetTicks(0),
-      m_ResolutionRequestInFlight(false)
+      m_ResolutionRequestInFlight(false),
+      m_ResolutionRequestOutstandingW(0),
+      m_ResolutionRequestOutstandingH(0),
+      m_ResolutionChangeAppliedTicks(0)
 {
     memset(&m_LastAbrVideoStats, 0, sizeof(m_LastAbrVideoStats));
     m_ClipboardSync = nullptr;
@@ -2406,7 +2409,10 @@ void updateHostConnectionInfoFromServerInfo(const QString& serverInfo,
     computer->serverCodecModeSupport = snapshot->serverCodecModeSupport;
     computer->currentGameId = snapshot->currentGameId;
 
-    if (!refreshedClientResChange.isEmpty()) {
+    // Fix #15: always derive and assign, even when the tag is absent in the refresh response
+    // (empty → false), so a host that drops the tag clears the capability instead of keeping
+    // a stale true from the connection-time parse.
+    {
         bool newVal = (refreshedClientResChange == "1");
         if (newVal != computer->supportsClientResolutionChange) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -3021,6 +3027,8 @@ void Session::exec()
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "Client-driven resolution: in-flight timeout, unblocking gate");
             m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+            m_ResolutionRequestOutstandingW = 0;
+            m_ResolutionRequestOutstandingH = 0;
         }
 
         // Nothing pending — nothing more to do.
@@ -3070,11 +3078,90 @@ void Session::exec()
         if (ret == 0) {
             m_ResolutionRequestInFlight.store(true, std::memory_order_release);
             m_ResolutionRequestSentTicks = SDL_GetTicks();
+            m_ResolutionRequestOutstandingW = physW;
+            m_ResolutionRequestOutstandingH = physH;
         }
         else {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "Client-driven resolution: LiSendResolutionChangeRequest returned %d", ret);
         }
+    };
+
+    // Shared decoder recreation helper — caller must hold m_DecoderLock on entry and on
+    // successful return; on failure returns false (caller must unlock + goto cleanup).
+    // Mirrors the SDL_RENDER_DEVICE_RESET path exactly, enabling SDL_CODE_RESOLUTION_CHANGED
+    // to perform an atomic swap (Fix #8) without duplicating the logic.
+    auto recreateDecoder = [&]() -> bool {
+        // Destroy the old decoder while the lock is held so drSubmitDecodeUnit cannot
+        // submit frames to it after the dimensions have been updated.
+        delete m_VideoDecoder;
+        m_VideoDecoder = nullptr;
+
+        // Insert a barrier to discard any additional window events
+        // that could cause the renderer to be recreated again.
+        // We don't use SDL_FlushEvent() here because it could cause
+        // important events to be lost.
+        flushWindowEvents();
+
+        // Update the window display mode based on our current monitor
+        // NB: Avoid a useless modeset by only doing this if it changed.
+        if (currentDisplayIndex != SDL_GetWindowDisplayIndex(m_Window)) {
+            currentDisplayIndex = SDL_GetWindowDisplayIndex(m_Window);
+            updateOptimalWindowDisplayMode();
+        }
+
+        // Now that the old decoder is dead, flush any events it may
+        // have queued to reset itself (if this reset was the result
+        // of device loss or an internal error).
+        SDL_PumpEvents();
+        SDL_FlushEvent(SDL_RENDER_DEVICE_RESET);
+
+        {
+            // If the stream exceeds the display refresh rate (plus some slack),
+            // forcefully disable V-sync to allow the stream to render faster
+            // than the display.
+            int displayHz = StreamUtils::getDisplayRefreshRate(m_Window);
+            bool enableVsync = m_Preferences->enableVsync;
+            if (displayHz + 5 < m_StreamConfig.fps) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "Disabling V-sync because refresh rate limit exceeded");
+                enableVsync = false;
+            }
+
+            // Choose a new decoder (hopefully the same one, but possibly
+            // not if a GPU was removed or something).
+            if (!chooseDecoder(m_Preferences->videoDecoderSelection,
+                               m_Window, m_ActiveVideoFormat, m_ActiveVideoWidth,
+                               m_ActiveVideoHeight, m_ActiveVideoFrameRate,
+                               enableVsync,
+                               enableVsync && m_Preferences->framePacing,
+                               m_Preferences->videoEnhancement,
+                               m_Preferences->ignoreAspectRatio,
+                               false,
+                               s_ActiveSession->m_VideoDecoder)) {
+                return false;
+            }
+
+            // As of SDL 2.0.12, SDL_RecreateWindow() doesn't carry over mouse capture
+            // or mouse hiding state to the new window. By capturing after the decoder
+            // is set up, this ensures the window re-creation is already done.
+            if (needsPostDecoderCreationCapture) {
+                m_InputHandler->setCaptureActive(true);
+                needsPostDecoderCreationCapture = false;
+            }
+        }
+
+        // Request an IDR frame to complete the reset
+        LiRequestIdrFrame();
+
+        // Set HDR mode. We may miss the callback if we're in the middle
+        // of recreating our decoder at the time the HDR transition happens.
+        m_VideoDecoder->setHdrMode(LiGetCurrentHostDisplayHdrMode());
+
+        // After a window resize, we need to reset the pointer lock region
+        m_InputHandler->updatePointerRegionLock();
+
+        return true;
     };
 
     SDL_Event event;
@@ -3178,28 +3265,49 @@ void Session::exec()
             case SDL_CODE_RESOLUTION_CHANGED:
             {
                 // Marshalled from clResolutionChanged (control-stream receive thread).
-                // Update active stream dimensions, clear the in-flight gate, then trigger
-                // decoder recreation so the new resolution takes effect immediately.
                 int newW = (int)(uintptr_t)event.user.data1;
                 int newH = (int)(uintptr_t)event.user.data2;
 
-                SDL_LockMutex(m_DecoderLock);
-                m_ActiveVideoWidth = newW;
-                m_ActiveVideoHeight = newH;
-                SDL_UnlockMutex(m_DecoderLock);
-
-                // Clear in-flight gate so the debounce loop can queue the next request.
-                m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+                // Fix #9: only acknowledge our outstanding client request when the echoed
+                // size matches exactly.  A mismatch means this is a host-initiated change —
+                // still apply the decoder swap, but leave the in-flight gate so the
+                // debounce can complete for the real outstanding request.
+                if (m_ResolutionRequestInFlight.load(std::memory_order_acquire) &&
+                        newW == m_ResolutionRequestOutstandingW &&
+                        newH == m_ResolutionRequestOutstandingH) {
+                    m_ResolutionRequestInFlight.store(false, std::memory_order_release);
+                    m_ResolutionRequestOutstandingW = 0;
+                    m_ResolutionRequestOutstandingH = 0;
+                }
 
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                             "Applying host resolution change: %dx%d — recreating decoder",
                             newW, newH);
 
-                // Synthesise an SDL_RENDER_DEVICE_RESET to reuse the existing decoder
-                // recreation path (lines below in SDL_RENDER_DEVICE_RESET case).
-                SDL_Event resetEvent = {};
-                resetEvent.type = SDL_RENDER_DEVICE_RESET;
-                SDL_PushEvent(&resetEvent);
+                // Fix #11: update input handler's cached stream dimensions on the main thread
+                // before the decoder swap so absolute mouse/touch mapping and the pointer-region
+                // lock immediately use the new aspect ratio.
+                m_InputHandler->updateStreamDimensions(newW, newH);
+
+                // Fix #8: hold m_DecoderLock across the dim-update + decoder swap so that
+                // drSubmitDecodeUnit cannot submit a new-size frame to the stale decoder.
+                // (drSubmitDecodeUnit uses TryLock and returns DR_OK when locked, so it is safe.)
+                SDL_LockMutex(m_DecoderLock);
+                m_ActiveVideoWidth = newW;
+                m_ActiveVideoHeight = newH;
+                if (!recreateDecoder()) {
+                    SDL_UnlockMutex(m_DecoderLock);
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                                 "Failed to recreate decoder after resolution change");
+                    emit displayLaunchError(tr("Unable to initialize video decoder. Please check your streaming settings and try again."));
+                    goto DispatchDeferredCleanup;
+                }
+
+                // Fix #16: record when this resolution change was applied so the SIZE_CHANGED
+                // debounce gate suppresses spurious events from the SDL_CreateRenderer call.
+                m_ResolutionChangeAppliedTicks = SDL_GetTicks();
+
+                SDL_UnlockMutex(m_DecoderLock);
                 break;
             }
             default:
@@ -3237,12 +3345,18 @@ void Session::exec()
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 syncQtOverlayWindowsWithSdlWindowState();
                 // Arm debounce for client-driven resolution if the feature is active.
-                // Gate: pref enabled, host capability advertised, NOT in exclusive fullscreen.
-                // Exclusive fullscreen: (windowFlags & FULLSCREEN_DESKTOP) == FULLSCREEN (0x1).
-                // Windowed and borderless-desktop-fullscreen both pass (only exclusive is skipped).
+                // Gate: pref enabled, host capability advertised, windowed mode only
+                // (both exclusive fullscreen 0x1 and borderless 0x1001 are excluded).
                 if (m_Preferences->resolutionMatchWindow &&
                         m_Computer->supportsClientResolutionChange &&
-                        (SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN) {
+                        // Fix #10: (flags & FULLSCREEN_DESKTOP) == 0 excludes both exclusive
+                        // fullscreen (0x1) and borderless/desktop fullscreen (0x1001), keeping
+                        // the feature windowed-only as intended.
+                        (SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == 0 &&
+                        // Fix #16: suppress re-arming for a short window after applying a
+                        // host resolution change so spurious SIZE_CHANGED events emitted by
+                        // SDL_CreateRenderer do not bounce back as a new outbound request.
+                        SDL_GetTicks() - m_ResolutionChangeAppliedTicks >= 500) {
                     // Debounce: reset fire time on each resize; fires 400 ms after the last event.
                     m_ResizeDebounceTargetTicks = SDL_GetTicks() + 400;
                 }
@@ -3360,76 +3474,13 @@ void Session::exec()
 
             SDL_LockMutex(m_DecoderLock);
 
-            // Destroy the old decoder
-            delete m_VideoDecoder;
-
-            // Insert a barrier to discard any additional window events
-            // that could cause the renderer to be and recreated again.
-            // We don't use SDL_FlushEvent() here because it could cause
-            // important events to be lost.
-            flushWindowEvents();
-
-            // Update the window display mode based on our current monitor
-            // NB: Avoid a useless modeset by only doing this if it changed.
-            if (currentDisplayIndex != SDL_GetWindowDisplayIndex(m_Window)) {
-                currentDisplayIndex = SDL_GetWindowDisplayIndex(m_Window);
-                updateOptimalWindowDisplayMode();
+            if (!recreateDecoder()) {
+                SDL_UnlockMutex(m_DecoderLock);
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                             "Failed to recreate decoder after reset");
+                emit displayLaunchError(tr("Unable to initialize video decoder. Please check your streaming settings and try again."));
+                goto DispatchDeferredCleanup;
             }
-
-            // Now that the old decoder is dead, flush any events it may
-            // have queued to reset itself (if this reset was the result
-            // of device loss or an internal error).
-            SDL_PumpEvents();
-            SDL_FlushEvent(SDL_RENDER_DEVICE_RESET);
-
-            {
-                // If the stream exceeds the display refresh rate (plus some slack),
-                // forcefully disable V-sync to allow the stream to render faster
-                // than the display.
-                int displayHz = StreamUtils::getDisplayRefreshRate(m_Window);
-                bool enableVsync = m_Preferences->enableVsync;
-                if (displayHz + 5 < m_StreamConfig.fps) {
-                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                                "Disabling V-sync because refresh rate limit exceeded");
-                    enableVsync = false;
-                }
-
-                // Choose a new decoder (hopefully the same one, but possibly
-                // not if a GPU was removed or something).
-                if (!chooseDecoder(m_Preferences->videoDecoderSelection,
-                                   m_Window, m_ActiveVideoFormat, m_ActiveVideoWidth,
-                                   m_ActiveVideoHeight, m_ActiveVideoFrameRate,
-                                   enableVsync,
-                                   enableVsync && m_Preferences->framePacing,
-                                   m_Preferences->videoEnhancement,
-                                   m_Preferences->ignoreAspectRatio,
-                                   false,
-                                   s_ActiveSession->m_VideoDecoder)) {
-                    SDL_UnlockMutex(m_DecoderLock);
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                                 "Failed to recreate decoder after reset");
-                    emit displayLaunchError(tr("Unable to initialize video decoder. Please check your streaming settings and try again."));
-                    goto DispatchDeferredCleanup;
-                }
-
-                // As of SDL 2.0.12, SDL_RecreateWindow() doesn't carry over mouse capture
-                // or mouse hiding state to the new window. By capturing after the decoder
-                // is set up, this ensures the window re-creation is already done.
-                if (needsPostDecoderCreationCapture) {
-                    m_InputHandler->setCaptureActive(true);
-                    needsPostDecoderCreationCapture = false;
-                }
-            }
-
-            // Request an IDR frame to complete the reset
-            LiRequestIdrFrame();
-
-            // Set HDR mode. We may miss the callback if we're in the middle
-            // of recreating our decoder at the time the HDR transition happens.
-            m_VideoDecoder->setHdrMode(LiGetCurrentHostDisplayHdrMode());
-
-            // After a window resize, we need to reset the pointer lock region
-            m_InputHandler->updatePointerRegionLock();
 
             SDL_UnlockMutex(m_DecoderLock);
             break;

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -347,6 +347,14 @@ private:
     // m_ResolutionRequestInFlight is cleared by clResolutionChanged or a short timeout.
     Uint32 m_ResizeDebounceTargetTicks;
     std::atomic_bool m_ResolutionRequestInFlight;
+    // Outstanding requested dimensions (Fix #9): set on send, zeroed on timeout or echo match.
+    // SDL_CODE_RESOLUTION_CHANGED only clears m_ResolutionRequestInFlight when the echoed
+    // size equals these, preventing a stale echo from cancelling a newer outstanding request.
+    int m_ResolutionRequestOutstandingW;
+    int m_ResolutionRequestOutstandingH;
+    // Timestamp of the last host-echo decoder reset (Fix #16): used to suppress spurious
+    // debounce re-arms from SIZE_CHANGED events emitted by SDL_CreateRenderer.
+    Uint32 m_ResolutionChangeAppliedTicks;
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -255,6 +255,9 @@ private:
     void clClipboardData(const char* data, int length);
 
     static
+    void clResolutionChanged(uint32_t width, uint32_t height);
+
+    static
     int arInit(int audioConfiguration,
                const POPUS_MULTISTREAM_CONFIGURATION opusConfig,
                void* arContext, int arFlags);
@@ -338,6 +341,12 @@ private:
     OverlayToast* m_Toast;           // Qt-based toast notification
     Uint32 m_MenuCloseTicks;       // 菜单关闭时间戳（防抖）
     class ClipboardSync* m_ClipboardSync; // Bidirectional clipboard sync (Sunshine 0x5508); nullptr when stream not active
+
+    // Client-driven resolution: debounce timestamp (0 = no pending resize), in-flight gate.
+    // m_ResizeDebounceTargetTicks is the SDL_GetTicks() value at which the debounce fires.
+    // m_ResolutionRequestInFlight is cleared by clResolutionChanged or a short timeout.
+    Uint32 m_ResizeDebounceTargetTicks;
+    std::atomic_bool m_ResolutionRequestInFlight;
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;


### PR DESCRIPTION
## Summary

Adds an opt-in "Match stream resolution to window size" feature: in windowed mode, resizing the Moonlight window requests a matching stream resolution from a compatible host, and host-driven resolution changes recreate the decoder at the new size. Closes qiin2333/moonlight-qt#103 (a more complete follow-up to #84).

## What it does

- **New pref** `resolutionMatchWindow` (default off) with QML toggle and persistence.
- **Capability parse**: reads `<ClientResolutionChange>` from `/serverinfo` into `NvComputer` (constructor + the launch/resume refresh path).
- **Resize → request**: `SDL_WINDOWEVENT_SIZE_CHANGED` arms a 400 ms debounce (gated on the pref, the host capability, and *not* fullscreen — both exclusive and borderless excluded); on settle it reads the physical-pixel size (`SDL_GetWindowSizeInPixels`, guarded for SDL < 2.26), even-rounds, clamps, and calls `LiSendResolutionChangeRequest`. In-flight requests are tracked with the outstanding width/height and a 2 s timeout so a stale/late echo can't cancel a newer request, and a resize while in-flight is re-queued rather than dropped.
- **Apply (receive)**: the `resolutionChanged` callback marshals to the main thread and recreates the decoder **atomically** — the shared `recreateDecoder` path runs synchronously under `m_DecoderLock`, so no new-size frame can reach the old decoder. The input handler's cached stream dimensions are updated so absolute mouse/touch mapping stays correct.
- Bumps the `moonlight-common-c` submodule to the branch that adds `LiSendResolutionChangeRequest`.

## Dependency

- common-c API: qiin2333/moonlight-common-c#10 — this PR's submodule is temporarily pinned at that fork branch; re-point to the merged commit once #10 lands.
- Host side: AlkaidLab/foundation-sunshine (issue AlkaidLab/foundation-sunshine#728).

## Testing

Reviewed across two independent adversarial + correctness passes; all findings addressed. **Not built here** (no local Qt6/SDL/ffmpeg toolchain) — static review only. Recommended gate: a maintainer build + a live windowed-resize test against a compatible Foundation host, including a HiDPI display (the SDL 2.26+ pixel API) and confirming the decoder recreation path. Note the `SDL_GetWindowSizeInPixels` guard falls back to logical size on SDL < 2.26.

Opened by a regular contributor (AsafMah).
