### PR TITLE
feat(file-transfer): accept host file offers

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -5,6 +5,9 @@
 #include <QBuffer>
 #include <QClipboard>
 #include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QImage>
 #include <QJsonDocument>
@@ -15,8 +18,10 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QRegularExpression>
+#include <QSharedPointer>
 #include <QSslConfiguration>
 #include <QSslError>
+#include <QStandardPaths>
 #include <QUrl>
 #include <QtEndian>
 
@@ -73,6 +78,12 @@ bool looksLikePngBytes(const QByteArray& bytes)
     static const unsigned char kMagic[8] = { 0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a };
     return bytes.size() >= 8
             && memcmp(bytes.constData(), kMagic, sizeof(kMagic)) == 0;
+}
+
+bool isValidOfferId(const QString& id)
+{
+    static const QRegularExpression idRegex(QStringLiteral("^[a-f0-9]{64}$"));
+    return idRegex.match(id).hasMatch();
 }
 }
 
@@ -192,6 +203,11 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
             return;
         }
         fetchRefAndApply(id, mime, size);
+        return;
+    }
+
+    if (kind == KIND_FILE_OFFER) {
+        fetchFileOffer(payload);
         return;
     }
 
@@ -750,7 +766,7 @@ QNetworkAccessManager* ClipboardSync::nam()
     return m_Nam;
 }
 
-bool ClipboardSync::buildBlobUrl(const QString& tail, QUrl& outUrl) const
+bool ClipboardSync::buildApiUrl(const QString& path, QUrl& outUrl) const
 {
     if (m_Computer == nullptr || m_Computer->serverCert.isNull()) {
         return false;
@@ -764,8 +780,13 @@ bool ClipboardSync::buildBlobUrl(const QString& tail, QUrl& outUrl) const
     if (host.contains(':')) {
         host = QString("[%1]").arg(host); // bracketed IPv6
     }
-    outUrl = QUrl(QString("https://%1:%2/api/v1/clipboard%3").arg(host).arg(port).arg(tail));
+    outUrl = QUrl(QString("https://%1:%2%3").arg(host).arg(port).arg(path));
     return outUrl.isValid();
+}
+
+bool ClipboardSync::buildBlobUrl(const QString& tail, QUrl& outUrl) const
+{
+    return buildApiUrl(QStringLiteral("/api/v1/clipboard") + tail, outUrl);
 }
 
 void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& mime)
@@ -827,6 +848,223 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
                          static_cast<int>(frame.size()), rc);
         }
     });
+}
+
+QString ClipboardSync::sanitizeFileName(const QString& name)
+{
+    QString out = QFileInfo(name).fileName().trimmed();
+    out.replace(QRegularExpression(QStringLiteral("[\\\\/:*?\"<>|\\x00-\\x1F]")), QStringLiteral("_"));
+    while (out.endsWith(QLatin1Char('.')) || out.endsWith(QLatin1Char(' '))) {
+        out.chop(1);
+    }
+    if (out.isEmpty()) {
+        out = QStringLiteral("download");
+    }
+
+    const QString upper = out.toUpper();
+    static const QStringList reserved {
+        QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"), QStringLiteral("NUL"),
+        QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"), QStringLiteral("COM4"),
+        QStringLiteral("COM5"), QStringLiteral("COM6"), QStringLiteral("COM7"), QStringLiteral("COM8"),
+        QStringLiteral("COM9"), QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
+        QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"), QStringLiteral("LPT7"),
+        QStringLiteral("LPT8"), QStringLiteral("LPT9")
+    };
+    if (reserved.contains(upper)) {
+        out.prepend(QLatin1Char('_'));
+    }
+
+    if (out.size() > 180) {
+        out = out.left(180);
+        while (out.endsWith(QLatin1Char('.')) || out.endsWith(QLatin1Char(' '))) {
+            out.chop(1);
+        }
+    }
+    return out.isEmpty() ? QStringLiteral("download") : out;
+}
+
+QString ClipboardSync::uniqueDownloadPath(const QString& fileName)
+{
+    QString baseDir = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    if (baseDir.isEmpty()) {
+        baseDir = QDir::homePath();
+    }
+
+    QDir dir(baseDir);
+    dir.mkpath(QStringLiteral("Sunshine Transfers"));
+    dir.cd(QStringLiteral("Sunshine Transfers"));
+
+    const QFileInfo info(fileName);
+    QString stem = info.completeBaseName();
+    QString suffix = info.completeSuffix();
+    if (stem.isEmpty()) {
+        stem = QStringLiteral("download");
+    }
+
+    for (int i = 0; i < 1000; ++i) {
+        QString candidate;
+        if (i == 0) {
+            candidate = fileName;
+        }
+        else if (suffix.isEmpty()) {
+            candidate = QStringLiteral("%1 (%2)").arg(stem).arg(i);
+        }
+        else {
+            candidate = QStringLiteral("%1 (%2).%3").arg(stem).arg(i).arg(suffix);
+        }
+
+        const QString path = dir.filePath(candidate);
+        if (!QFileInfo::exists(path) && !QFileInfo::exists(path + QStringLiteral(".part"))) {
+            return path;
+        }
+    }
+
+    return dir.filePath(QStringLiteral("%1-%2").arg(stem).arg(QDateTime::currentMSecsSinceEpoch()));
+}
+
+void ClipboardSync::fetchFileOffer(const QByteArray& payload)
+{
+    QJsonParseError jerr{};
+    QJsonDocument doc = QJsonDocument::fromJson(payload, &jerr);
+    if (jerr.error != QJsonParseError::NoError || !doc.isObject()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping file offer with bad JSON (%s)",
+                    jerr.errorString().toUtf8().constData());
+        return;
+    }
+
+    const QJsonObject obj = doc.object();
+    const QString type = obj.value(QStringLiteral("type")).toString();
+    const QString id = obj.value(QStringLiteral("id")).toString();
+    const QString name = sanitizeFileName(obj.value(QStringLiteral("name")).toString());
+    const qint64 size = static_cast<qint64>(obj.value(QStringLiteral("size")).toDouble(-1));
+    const QString downloadUrl = obj.value(QStringLiteral("download_url")).toString();
+    const QString expectedPath = QStringLiteral("/api/v1/file-transfer/") + id;
+
+    if (!type.isEmpty() && type != QStringLiteral("file")) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping unsupported file offer type '%s'",
+                    type.toUtf8().constData());
+        return;
+    }
+    if (!isValidOfferId(id)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping file offer with invalid id");
+        return;
+    }
+    if (size < 0 || size > MAX_FILE_TRANSFER_BYTES) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping file offer size %lld (cap %lld)",
+                    static_cast<long long>(size),
+                    static_cast<long long>(MAX_FILE_TRANSFER_BYTES));
+        return;
+    }
+    if (!downloadUrl.isEmpty() && downloadUrl != expectedPath) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: dropping file offer with unexpected download_url");
+        return;
+    }
+
+    downloadFileOffer(id, name, size, expectedPath);
+}
+
+void ClipboardSync::downloadFileOffer(const QString& id,
+                                      const QString& name,
+                                      qint64 advertisedSize,
+                                      const QString& downloadPath)
+{
+    QUrl url;
+    if (!buildApiUrl(downloadPath, url)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: cannot download file offer (no host context)");
+        return;
+    }
+
+    const QString finalPath = uniqueDownloadPath(name);
+    const QString partPath = finalPath + QStringLiteral(".part");
+    QFile::remove(partPath);
+
+    QNetworkRequest req(url);
+    req.setSslConfiguration(IdentityManager::get()->getSslConfig());
+
+    QNetworkReply* reply = nam()->get(req);
+    QFile* file = new QFile(partPath, reply);
+    if (!file->open(QIODevice::WriteOnly)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "ClipboardSync: cannot open file transfer target '%s': %s",
+                    partPath.toUtf8().constData(),
+                    file->errorString().toUtf8().constData());
+        reply->abort();
+        reply->deleteLater();
+        return;
+    }
+
+    auto bytesWritten = QSharedPointer<qint64>::create(0);
+    auto writeFailed = QSharedPointer<bool>::create(false);
+
+    connect(reply, &QNetworkReply::readyRead, this,
+            [reply, file, bytesWritten, writeFailed]() {
+                const QByteArray chunk = reply->readAll();
+                if (chunk.isEmpty()) {
+                    return;
+                }
+                if (*bytesWritten + chunk.size() > ClipboardSync::MAX_FILE_TRANSFER_BYTES) {
+                    *writeFailed = true;
+                    reply->abort();
+                    return;
+                }
+                const qint64 n = file->write(chunk);
+                if (n != chunk.size()) {
+                    *writeFailed = true;
+                    reply->abort();
+                    return;
+                }
+                *bytesWritten += n;
+            });
+
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, file, finalPath, partPath, name, id, advertisedSize, bytesWritten, writeFailed]() {
+                const QNetworkReply::NetworkError err = reply->error();
+                const QString errString = reply->errorString();
+                if (!file->flush()) {
+                    *writeFailed = true;
+                }
+                file->close();
+
+                bool ok = err == QNetworkReply::NoError && !*writeFailed;
+                if (ok && advertisedSize >= 0 && *bytesWritten != advertisedSize) {
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                "ClipboardSync: file transfer size mismatch for %s (got %lld, advertised %lld)",
+                                name.toUtf8().constData(),
+                                static_cast<long long>(*bytesWritten),
+                                static_cast<long long>(advertisedSize));
+                    ok = false;
+                }
+
+                if (ok) {
+                    ok = QFile::rename(partPath, finalPath);
+                }
+
+                if (ok) {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                "ClipboardSync: downloaded file offer %s (%lld bytes, id=%s) to %s",
+                                name.toUtf8().constData(),
+                                static_cast<long long>(*bytesWritten),
+                                id.toUtf8().constData(),
+                                finalPath.toUtf8().constData());
+                }
+                else {
+                    QFile::remove(partPath);
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                "ClipboardSync: file transfer failed for %s: %s",
+                                name.toUtf8().constData(),
+                                err == QNetworkReply::NoError
+                                    ? "local write/rename failed"
+                                    : errString.toUtf8().constData());
+                }
+
+                reply->deleteLater();
+            });
 }
 
 void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qint64 advertisedSize)

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -7,6 +7,7 @@
 #include <QQueue>
 #include <QString>
 #include <QStringList>
+#include <QUrl>
 #include <cstdint>
 
 class NvComputer;
@@ -22,11 +23,12 @@ class QSslError;
 // payload, little-endian) over Limelight control packet 0x5508
 // (LiSendClipboardData / ConnListenerClipboardData).
 //
-// Supports kind=1 (UTF-8 text), kind=2 (PNG image), and kind=3 (REF JSON
+// Supports kind=1 (UTF-8 text), kind=2 (PNG image), kind=3 (REF JSON
 // pointing to an out-of-band blob transferred over HTTPS via the Sunshine
-// /api/v1/clipboard/blob endpoints) in both directions. Payloads above the
-// 65 KB single-packet cap are switched to KIND_REF transparently.
-// File / other payloads are accepted on the wire but ignored.
+// /api/v1/clipboard/blob endpoints) in both directions, and kind=4
+// (FILE_OFFER JSON) host-to-client file downloads. Payloads above the 65 KB
+// single-packet cap are switched to KIND_REF transparently. Unknown payloads
+// are accepted on the wire but ignored.
 //
 // Echo suppression: when we either write a payload to the local clipboard
 // (because the host pushed it) or send a payload to the host (because we
@@ -50,6 +52,7 @@ public:
         KIND_TEXT = 1,
         KIND_PNG  = 2,
         KIND_REF  = 3,
+        KIND_FILE_OFFER = 4,
     };
 
     static constexpr uint8_t WIRE_VERSION = 1;
@@ -60,6 +63,7 @@ public:
     // Mirrors the cross-client cap (64 MiB) shared with the Android and
     // HarmonyOS clients. The service-side blob store accepts up to this much.
     static constexpr qint64  MAX_BLOB_BYTES   = 64LL * 1024 * 1024;
+    static constexpr qint64  MAX_FILE_TRANSFER_BYTES = 4LL * 1024 * 1024 * 1024;
     static constexpr int     ECHO_TTL_MS  = 5000;
     static constexpr int     ECHO_MAX     = 16;
     // Mirror the Android client's cap (32 Mpx) so a stray full-screen capture
@@ -120,12 +124,21 @@ private:
 
     // Out-of-band blob helpers. Both run on the GUI thread; the
     // QNetworkAccessManager event-loop callbacks land back on the GUI thread.
+    bool buildApiUrl(const QString& path, QUrl& outUrl) const;
     bool buildBlobUrl(const QString& tail, QUrl& outUrl) const;
     QNetworkAccessManager* nam();
     void uploadAndSendRef(const QByteArray& payload, const QString& mime);
     void fetchRefAndApply(const QString& id, const QString& mime, qint64 advertisedSize);
+    void fetchFileOffer(const QByteArray& payload);
+    void downloadFileOffer(const QString& id,
+                           const QString& name,
+                           qint64 advertisedSize,
+                           const QString& downloadPath);
     void applyInboundText(const QByteArray& payload);
     void applyInboundPng(const QByteArray& payload);
+
+    static QString sanitizeFileName(const QString& name);
+    static QString uniqueDownloadPath(const QString& fileName);
 
     NvComputer* m_Computer = nullptr;
     QNetworkAccessManager* m_Nam = nullptr;


### PR DESCRIPTION
﻿**改了啥呀**
- `ClipboardSync` 新增 `kind=4` FILE_OFFER 处理。
- 解析 Sunshine 发来的 file offer JSON 后，通过当前配对主机的 HTTPS/mTLS nvhttp 连接下载文件。
- 文件保存到系统 Downloads 下的 `Sunshine Transfers` 目录，自动清理文件名、避让重名，并用 `.part` 临时文件避免失败残留成品。
- 下载过程中按 4 GiB 上限和 offer 声明大小校验，失败会删除临时文件。

**为啥要改**
- Sunshine 右键发送文件只会发一个小 offer，客户端必须真正拉取并保存文件，功能才闭环。这样剪贴板控制通道只管传令，文件字节自己走 HTTPS，杂鱼大文件别来挤控制包。

**验证**
- `cmd /c C:\Users\mohaha\source\repos\moonlight-qt\build\build_test.bat`
- `git diff --check`
