### PR TITLE
fix(streaming): isolate clipboard sync in helper process

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -211,7 +211,8 @@ SOURCES += \
     streaming/input/mouse.cpp \
     streaming/input/reltouch.cpp \
     streaming/session.cpp \
-    streaming/clipboardsync.cpp \
+    streaming/clipboardhelperclient.cpp \
+    streaming/clipboardipc.cpp \
     streaming/audio/audio.cpp \
     streaming/audio/renderers/sdlaud.cpp \
     streaming/network/bandwidth.cpp \
@@ -257,7 +258,8 @@ HEADERS += \
     settings/streamingpreferences.h \
     streaming/input/input.h \
     streaming/session.h \
-    streaming/clipboardsync.h \
+    streaming/clipboardhelperclient.h \
+    streaming/clipboardipc.h \
     streaming/audio/renderers/renderer.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \

--- a/app/streaming/clipboardhelperclient.cpp
+++ b/app/streaming/clipboardhelperclient.cpp
@@ -80,6 +80,7 @@ bool ClipboardHelperClient::startProcess()
     m_HelperReady = false;
     m_StdoutBuffer.clear();
     m_StderrBuffer.clear();
+    m_StdinBuffer.clear();
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Clipboard helper started: %s",
                 m_HelperPath.toUtf8().constData());
@@ -101,8 +102,11 @@ void ClipboardHelperClient::stop()
 
     if (m_Process->state() != QProcess::NotRunning) {
         writeLine(ClipboardIpc::encodeStop(nextSequence()));
-        m_Process->closeWriteChannel();
-        if (!m_Process->waitForFinished(1000)) {
+        flushProcessInput();
+        if (m_Process != nullptr) {
+            m_Process->closeWriteChannel();
+        }
+        if (m_Process != nullptr && !m_Process->waitForFinished(1000)) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "Clipboard helper did not exit cleanly; killing it");
             m_Process->kill();
@@ -110,8 +114,10 @@ void ClipboardHelperClient::stop()
         }
     }
 
-    delete m_Process;
-    m_Process = nullptr;
+    if (m_Process != nullptr) {
+        delete m_Process;
+        m_Process = nullptr;
+    }
 }
 
 void ClipboardHelperClient::updateHostContext()
@@ -155,9 +161,14 @@ void ClipboardHelperClient::processPendingMessages()
         delete m_Process;
         m_Process = nullptr;
         m_HelperReady = false;
+        m_StdinBuffer.clear();
         if (!m_StopRequested) {
             scheduleRestart("unexpected exit");
         }
+        return;
+    }
+
+    if (!flushProcessInput()) {
         return;
     }
 
@@ -272,8 +283,7 @@ bool ClipboardHelperClient::sendCurrentConfig()
 
     m_HelperReady = false;
     m_ConfigSequence = nextSequence();
-    writeLine(ClipboardIpc::encodeConfigure(m_ConfigSequence, config));
-    return true;
+    return writeLine(ClipboardIpc::encodeConfigure(m_ConfigSequence, config));
 }
 
 void ClipboardHelperClient::flushQueuedHostFrames()
@@ -294,7 +304,9 @@ void ClipboardHelperClient::flushQueuedHostFrames()
     }
 
     while (!frames.isEmpty()) {
-        writeLine(ClipboardIpc::encodeHostFrame(nextSequence(), frames.dequeue()));
+        if (!writeLine(ClipboardIpc::encodeHostFrame(nextSequence(), frames.dequeue()))) {
+            return;
+        }
     }
 }
 
@@ -344,11 +356,30 @@ void ClipboardHelperClient::readHelperErrors()
             line.chop(1);
         }
         if (!line.isEmpty()) {
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "Clipboard helper: %s",
-                         line.constData());
+            logHelperStderrLine(line);
         }
     }
+}
+
+void ClipboardHelperClient::logHelperStderrLine(const QByteArray& line)
+{
+    if (line.startsWith("ClipboardSync WARN:")) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper: %s",
+                    line.constData());
+        return;
+    }
+
+    if (line.startsWith("ClipboardSync INFO:")) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper: %s",
+                    line.constData());
+        return;
+    }
+
+    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                 "Clipboard helper: %s",
+                 line.constData());
 }
 
 void ClipboardHelperClient::processProtocolLine(const QByteArray& line)
@@ -400,24 +431,72 @@ void ClipboardHelperClient::handleProtocolError(const QString& error)
     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                 "Clipboard helper protocol error: %s",
                 error.toUtf8().constData());
+    restartHelper("protocol error");
 }
 
-void ClipboardHelperClient::writeLine(const QByteArray& line)
+void ClipboardHelperClient::restartHelper(const char* reason)
+{
+    m_HelperReady = false;
+    m_StdoutBuffer.clear();
+    m_StderrBuffer.clear();
+    m_StdinBuffer.clear();
+
+    if (m_Process != nullptr) {
+        if (m_Process->state() != QProcess::NotRunning) {
+            m_Process->kill();
+            m_Process->waitForFinished(1000);
+        }
+        delete m_Process;
+        m_Process = nullptr;
+    }
+
+    scheduleRestart(reason);
+}
+
+bool ClipboardHelperClient::flushProcessInput()
 {
     if (m_Process == nullptr || m_Process->state() == QProcess::NotRunning) {
-        return;
+        return false;
+    }
+
+    while (!m_StdinBuffer.isEmpty()) {
+        qint64 written = m_Process->write(m_StdinBuffer.constData(), m_StdinBuffer.size());
+        if (written < 0) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Clipboard helper pipe write failed: %s",
+                        m_Process->errorString().toUtf8().constData());
+            restartHelper("pipe write failed");
+            return false;
+        }
+
+        if (written == 0) {
+            break;
+        }
+
+        m_StdinBuffer.remove(0, static_cast<int>(written));
+    }
+
+    m_Process->waitForBytesWritten(0);
+    return true;
+}
+
+bool ClipboardHelperClient::writeLine(const QByteArray& line)
+{
+    if (m_Process == nullptr || m_Process->state() == QProcess::NotRunning) {
+        return false;
     }
 
     QByteArray out = line;
     out.append('\n');
-    qint64 written = m_Process->write(out);
-    if (written != out.size()) {
+    if (m_StdinBuffer.size() + out.size() > MAX_PENDING_STDIN_BYTES) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "Clipboard helper pipe write failed: wrote %lld of %d bytes",
-                    static_cast<long long>(written),
-                    out.size());
+                    "Clipboard helper stdin backlog exceeded protocol limit");
+        restartHelper("pipe backlog exceeded");
+        return false;
     }
-    m_Process->waitForBytesWritten(0);
+
+    m_StdinBuffer.append(out);
+    return flushProcessInput();
 }
 
 quint32 ClipboardHelperClient::nextSequence()

--- a/app/streaming/clipboardhelperclient.cpp
+++ b/app/streaming/clipboardhelperclient.cpp
@@ -1,0 +1,429 @@
+#include "clipboardhelperclient.h"
+
+#include "backend/identitymanager.h"
+#include "backend/nvcomputer.h"
+#include "clipboardipc.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QMutexLocker>
+#include <QProcess>
+
+#include <SDL.h>
+
+#include <Limelight.h>
+
+ClipboardHelperClient::ClipboardHelperClient(NvComputer* computer, QObject* parent)
+    : QObject(parent),
+      m_Computer(computer),
+      m_Process(nullptr),
+      m_Enabled(false),
+      m_Disabled(false),
+      m_StopRequested(false),
+      m_HelperReady(false),
+      m_ConfigSequence(0),
+      m_NextSequence(1),
+      m_NextRestartTicks(0),
+      m_RestartAttempts(0),
+      m_DroppedInboundFrames(0)
+{
+}
+
+ClipboardHelperClient::~ClipboardHelperClient()
+{
+    stop();
+}
+
+void ClipboardHelperClient::start()
+{
+    if (m_Enabled) {
+        return;
+    }
+
+    m_Enabled = true;
+    m_Disabled = false;
+    m_StopRequested = false;
+    m_RestartAttempts = 0;
+    m_NextRestartTicks = 0;
+    m_HelperPath = findHelperExecutable();
+    if (m_HelperPath.isEmpty()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper executable not found; clipboard sync disabled");
+        m_Disabled = true;
+        return;
+    }
+
+    startProcess();
+}
+
+bool ClipboardHelperClient::startProcess()
+{
+    if (!m_Enabled || m_Disabled || m_Process != nullptr) {
+        return false;
+    }
+
+    m_Process = new QProcess(this);
+    m_Process->setProgram(m_HelperPath);
+    m_Process->setProcessChannelMode(QProcess::SeparateChannels);
+    m_Process->start();
+    if (!m_Process->waitForStarted(2000)) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper failed to start: %s",
+                    m_Process->errorString().toUtf8().constData());
+        delete m_Process;
+        m_Process = nullptr;
+        scheduleRestart("start failed");
+        return false;
+    }
+
+    m_HelperReady = false;
+    m_StdoutBuffer.clear();
+    m_StderrBuffer.clear();
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Clipboard helper started: %s",
+                m_HelperPath.toUtf8().constData());
+
+    sendCurrentConfig();
+    return true;
+}
+
+void ClipboardHelperClient::stop()
+{
+    m_Enabled = false;
+    m_StopRequested = true;
+    m_HelperReady = false;
+    m_NextRestartTicks = 0;
+
+    if (m_Process == nullptr) {
+        return;
+    }
+
+    if (m_Process->state() != QProcess::NotRunning) {
+        writeLine(ClipboardIpc::encodeStop(nextSequence()));
+        m_Process->closeWriteChannel();
+        if (!m_Process->waitForFinished(1000)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Clipboard helper did not exit cleanly; killing it");
+            m_Process->kill();
+            m_Process->waitForFinished(1000);
+        }
+    }
+
+    delete m_Process;
+    m_Process = nullptr;
+}
+
+void ClipboardHelperClient::updateHostContext()
+{
+    if (!m_Enabled || m_Disabled || m_Process == nullptr ||
+            m_Process->state() == QProcess::NotRunning) {
+        return;
+    }
+
+    sendCurrentConfig();
+}
+
+void ClipboardHelperClient::handleIncomingFrame(const char* data, int length)
+{
+    if (data == nullptr || length <= 0) {
+        return;
+    }
+
+    QMutexLocker locker(&m_InboundMutex);
+    if (m_InboundFrames.size() >= MAX_QUEUED_HOST_FRAMES) {
+        m_InboundFrames.dequeue();
+        m_DroppedInboundFrames++;
+    }
+    m_InboundFrames.enqueue(QByteArray(data, length));
+}
+
+void ClipboardHelperClient::processPendingMessages()
+{
+    if (m_Process == nullptr) {
+        maybeRestart();
+        return;
+    }
+
+    if (m_Process->state() == QProcess::NotRunning) {
+        readHelperOutput();
+        readHelperErrors();
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper exited: exitCode=%d error=%s",
+                    m_Process->exitCode(),
+                    m_Process->errorString().toUtf8().constData());
+        delete m_Process;
+        m_Process = nullptr;
+        m_HelperReady = false;
+        if (!m_StopRequested) {
+            scheduleRestart("unexpected exit");
+        }
+        return;
+    }
+
+    m_Process->waitForReadyRead(0);
+    readHelperOutput();
+    readHelperErrors();
+    if (m_HelperReady) {
+        flushQueuedHostFrames();
+    }
+}
+
+bool ClipboardHelperClient::isRunning() const
+{
+    return m_Process != nullptr && m_Process->state() != QProcess::NotRunning;
+}
+
+void ClipboardHelperClient::scheduleRestart(const char* reason)
+{
+    m_HelperReady = false;
+    if (!m_Enabled || m_Disabled || m_StopRequested) {
+        return;
+    }
+
+    if (m_RestartAttempts >= MAX_RESTART_ATTEMPTS) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper disabled after %d restart attempts (%s)",
+                    m_RestartAttempts,
+                    reason);
+        m_Disabled = true;
+        return;
+    }
+
+    m_RestartAttempts++;
+    m_NextRestartTicks = SDL_GetTicks() + RESTART_DELAY_MS;
+    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                "Clipboard helper will restart after %s (attempt %d/%d)",
+                reason,
+                m_RestartAttempts,
+                MAX_RESTART_ATTEMPTS);
+}
+
+void ClipboardHelperClient::maybeRestart()
+{
+    if (!m_Enabled || m_Disabled || m_StopRequested || m_HelperPath.isEmpty()) {
+        return;
+    }
+
+    if (m_NextRestartTicks == 0 || SDL_TICKS_PASSED(SDL_GetTicks(), m_NextRestartTicks)) {
+        m_NextRestartTicks = 0;
+        startProcess();
+    }
+}
+
+QString ClipboardHelperClient::findHelperExecutable() const
+{
+#ifdef Q_OS_WIN
+    const QString helperName = QStringLiteral("moonlight-clipboard-helper.exe");
+#else
+    const QString helperName = QStringLiteral("moonlight-clipboard-helper");
+#endif
+
+    QString envPath = QString::fromLocal8Bit(qgetenv("MOONLIGHT_CLIPBOARD_HELPER"));
+    if (!envPath.isEmpty() && QFileInfo::exists(envPath)) {
+        return envPath;
+    }
+
+    const QString appDir = QCoreApplication::applicationDirPath();
+    const QStringList candidates = {
+        QDir(appDir).filePath(helperName),
+        QDir(appDir).filePath(QStringLiteral("../clipboard-helper/release/") + helperName),
+        QDir(appDir).filePath(QStringLiteral("../clipboard-helper/debug/") + helperName),
+        QDir(appDir).filePath(QStringLiteral("../clipboard-helper/") + helperName),
+        QDir(appDir).filePath(QStringLiteral("../../clipboard-helper/release/") + helperName),
+        QDir(appDir).filePath(QStringLiteral("../../clipboard-helper/debug/") + helperName),
+        QDir(appDir).filePath(QStringLiteral("../../clipboard-helper/") + helperName),
+        QDir(QDir::currentPath()).filePath(helperName)
+    };
+
+    for (const QString& candidate : candidates) {
+        const QString cleanPath = QDir::cleanPath(candidate);
+        if (QFileInfo::exists(cleanPath)) {
+            return cleanPath;
+        }
+    }
+
+    return QString();
+}
+
+bool ClipboardHelperClient::sendCurrentConfig()
+{
+    ClipboardIpc::HostConfig config;
+    if (m_Computer != nullptr) {
+        config.address = m_Computer->activeAddress.address();
+        config.httpsPort = m_Computer->activeHttpsPort;
+        config.serverCertPem = m_Computer->serverCert.toPem();
+    }
+
+    IdentityManager* identity = IdentityManager::get();
+    if (identity != nullptr) {
+        config.clientCertPem = identity->getCertificate();
+        config.clientKeyPem = identity->getPrivateKey();
+    }
+
+    if (config.address.isEmpty() || config.httpsPort == 0 ||
+            config.serverCertPem.isEmpty() ||
+            config.clientCertPem.isEmpty() ||
+            config.clientKeyPem.isEmpty()) {
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "Clipboard helper config is not available yet");
+        return false;
+    }
+
+    m_HelperReady = false;
+    m_ConfigSequence = nextSequence();
+    writeLine(ClipboardIpc::encodeConfigure(m_ConfigSequence, config));
+    return true;
+}
+
+void ClipboardHelperClient::flushQueuedHostFrames()
+{
+    QQueue<QByteArray> frames;
+    int droppedFrames = 0;
+    {
+        QMutexLocker locker(&m_InboundMutex);
+        qSwap(frames, m_InboundFrames);
+        droppedFrames = m_DroppedInboundFrames;
+        m_DroppedInboundFrames = 0;
+    }
+
+    if (droppedFrames != 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Dropped %d queued clipboard frames while helper was busy",
+                    droppedFrames);
+    }
+
+    while (!frames.isEmpty()) {
+        writeLine(ClipboardIpc::encodeHostFrame(nextSequence(), frames.dequeue()));
+    }
+}
+
+void ClipboardHelperClient::readHelperOutput()
+{
+    if (m_Process == nullptr) {
+        return;
+    }
+
+    m_StdoutBuffer += m_Process->readAllStandardOutput();
+    if (m_StdoutBuffer.size() > ClipboardIpc::MAX_LINE_BYTES) {
+        handleProtocolError(QStringLiteral("helper stdout line exceeded protocol limit"));
+        m_StdoutBuffer.clear();
+        return;
+    }
+
+    int newlineIndex = -1;
+    while ((newlineIndex = m_StdoutBuffer.indexOf('\n')) >= 0) {
+        QByteArray line = m_StdoutBuffer.left(newlineIndex);
+        m_StdoutBuffer.remove(0, newlineIndex + 1);
+        while (line.endsWith('\r')) {
+            line.chop(1);
+        }
+        processProtocolLine(line);
+    }
+}
+
+void ClipboardHelperClient::readHelperErrors()
+{
+    if (m_Process == nullptr) {
+        return;
+    }
+
+    m_StderrBuffer += m_Process->readAllStandardError();
+    if (m_StderrBuffer.size() > ClipboardIpc::MAX_LINE_BYTES) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper stderr line exceeded protocol limit; discarding buffered stderr");
+        m_StderrBuffer.clear();
+        return;
+    }
+
+    int newlineIndex = -1;
+    while ((newlineIndex = m_StderrBuffer.indexOf('\n')) >= 0) {
+        QByteArray line = m_StderrBuffer.left(newlineIndex);
+        m_StderrBuffer.remove(0, newlineIndex + 1);
+        while (line.endsWith('\r')) {
+            line.chop(1);
+        }
+        if (!line.isEmpty()) {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "Clipboard helper: %s",
+                         line.constData());
+        }
+    }
+}
+
+void ClipboardHelperClient::processProtocolLine(const QByteArray& line)
+{
+    ClipboardIpc::Message message;
+    QString error;
+    if (!ClipboardIpc::decodeLine(line, message, error)) {
+        handleProtocolError(error);
+        return;
+    }
+
+    if (message.type == ClipboardIpc::MessageType::Ready) {
+        if (message.sequence != m_ConfigSequence) {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "Clipboard helper READY for stale config sequence %u",
+                         message.sequence);
+            return;
+        }
+        m_HelperReady = true;
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Clipboard helper is ready");
+        return;
+    }
+
+    if (message.type == ClipboardIpc::MessageType::LocalFrame) {
+        int rc = LiSendClipboardData(message.frame.constData(), message.frame.size());
+        if (rc != 0) {
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                         "LiSendClipboardData(helper, %d bytes) -> %d",
+                         static_cast<int>(message.frame.size()),
+                         rc);
+        }
+        return;
+    }
+
+    if (message.type == ClipboardIpc::MessageType::Error) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper error [%s]: %s",
+                    message.code.toUtf8().constData(),
+                    message.text.toUtf8().constData());
+        return;
+    }
+
+    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                 "Clipboard helper sent unexpected message type");
+}
+
+void ClipboardHelperClient::handleProtocolError(const QString& error)
+{
+    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                "Clipboard helper protocol error: %s",
+                error.toUtf8().constData());
+}
+
+void ClipboardHelperClient::writeLine(const QByteArray& line)
+{
+    if (m_Process == nullptr || m_Process->state() == QProcess::NotRunning) {
+        return;
+    }
+
+    QByteArray out = line;
+    out.append('\n');
+    qint64 written = m_Process->write(out);
+    if (written != out.size()) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Clipboard helper pipe write failed: wrote %lld of %d bytes",
+                    static_cast<long long>(written),
+                    out.size());
+    }
+    m_Process->waitForBytesWritten(0);
+}
+
+quint32 ClipboardHelperClient::nextSequence()
+{
+    if (m_NextSequence == 0) {
+        m_NextSequence = 1;
+    }
+    return m_NextSequence++;
+}

--- a/app/streaming/clipboardhelperclient.h
+++ b/app/streaming/clipboardhelperclient.h
@@ -31,6 +31,7 @@ public:
 
 private:
     static constexpr int MAX_QUEUED_HOST_FRAMES = 32;
+    static constexpr int MAX_PENDING_STDIN_BYTES = 4 * 1024 * 1024;
     static constexpr int MAX_RESTART_ATTEMPTS = 3;
     static constexpr quint32 RESTART_DELAY_MS = 1000;
 
@@ -42,9 +43,12 @@ private:
     void flushQueuedHostFrames();
     void readHelperOutput();
     void readHelperErrors();
+    void logHelperStderrLine(const QByteArray& line);
     void processProtocolLine(const QByteArray& line);
     void handleProtocolError(const QString& error);
-    void writeLine(const QByteArray& line);
+    void restartHelper(const char* reason);
+    bool flushProcessInput();
+    bool writeLine(const QByteArray& line);
     quint32 nextSequence();
 
     NvComputer* m_Computer;
@@ -54,6 +58,7 @@ private:
     QQueue<QByteArray> m_InboundFrames;
     QByteArray m_StdoutBuffer;
     QByteArray m_StderrBuffer;
+    QByteArray m_StdinBuffer;
     bool m_Enabled;
     bool m_Disabled;
     bool m_StopRequested;

--- a/app/streaming/clipboardhelperclient.h
+++ b/app/streaming/clipboardhelperclient.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <QByteArray>
+#include <QMutex>
+#include <QObject>
+#include <QQueue>
+#include <QString>
+
+class NvComputer;
+class QProcess;
+
+class ClipboardHelperClient : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ClipboardHelperClient(NvComputer* computer, QObject* parent = nullptr);
+    ~ClipboardHelperClient() override;
+
+    void start();
+    void stop();
+    void updateHostContext();
+
+    // Thread-safe. Called from the Limelight control receive thread.
+    void handleIncomingFrame(const char* data, int length);
+
+    // Called from the SDL streaming loop on the session/main thread.
+    void processPendingMessages();
+
+    bool isRunning() const;
+
+private:
+    static constexpr int MAX_QUEUED_HOST_FRAMES = 32;
+    static constexpr int MAX_RESTART_ATTEMPTS = 3;
+    static constexpr quint32 RESTART_DELAY_MS = 1000;
+
+    QString findHelperExecutable() const;
+    bool sendCurrentConfig();
+    bool startProcess();
+    void scheduleRestart(const char* reason);
+    void maybeRestart();
+    void flushQueuedHostFrames();
+    void readHelperOutput();
+    void readHelperErrors();
+    void processProtocolLine(const QByteArray& line);
+    void handleProtocolError(const QString& error);
+    void writeLine(const QByteArray& line);
+    quint32 nextSequence();
+
+    NvComputer* m_Computer;
+    QProcess* m_Process;
+    QString m_HelperPath;
+    QMutex m_InboundMutex;
+    QQueue<QByteArray> m_InboundFrames;
+    QByteArray m_StdoutBuffer;
+    QByteArray m_StderrBuffer;
+    bool m_Enabled;
+    bool m_Disabled;
+    bool m_StopRequested;
+    bool m_HelperReady;
+    quint32 m_ConfigSequence;
+    quint32 m_NextSequence;
+    quint32 m_NextRestartTicks;
+    int m_RestartAttempts;
+    int m_DroppedInboundFrames;
+};

--- a/app/streaming/clipboardipc.cpp
+++ b/app/streaming/clipboardipc.cpp
@@ -2,6 +2,7 @@
 
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonValue>
 
 namespace ClipboardIpc {
 namespace {
@@ -151,7 +152,16 @@ bool decodeLine(const QByteArray& line, Message& outMessage, QString& outError)
     }
 
     outMessage.type = stringToType(obj.value(QStringLiteral("type")).toString());
-    outMessage.sequence = static_cast<quint32>(obj.value(QStringLiteral("sequence")).toInt());
+    QJsonValue sequenceValue = obj.value(QStringLiteral("sequence"));
+    double sequence = sequenceValue.toDouble(-1);
+    if (!sequenceValue.isDouble() ||
+            sequence < 0 ||
+            sequence > 4294967295.0 ||
+            static_cast<double>(static_cast<quint32>(sequence)) != sequence) {
+        outError = QStringLiteral("invalid sequence number");
+        return false;
+    }
+    outMessage.sequence = static_cast<quint32>(sequence);
     if (outMessage.type == MessageType::Unknown) {
         outError = QStringLiteral("unknown message type");
         return false;

--- a/app/streaming/clipboardipc.cpp
+++ b/app/streaming/clipboardipc.cpp
@@ -1,0 +1,193 @@
+#include "clipboardipc.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace ClipboardIpc {
+namespace {
+
+QString typeToString(MessageType type)
+{
+    switch (type) {
+    case MessageType::Configure:
+        return QStringLiteral("configure");
+    case MessageType::HostFrame:
+        return QStringLiteral("hostFrame");
+    case MessageType::LocalFrame:
+        return QStringLiteral("localFrame");
+    case MessageType::Ready:
+        return QStringLiteral("ready");
+    case MessageType::Error:
+        return QStringLiteral("error");
+    case MessageType::Stop:
+        return QStringLiteral("stop");
+    case MessageType::Unknown:
+        break;
+    }
+    return QStringLiteral("unknown");
+}
+
+MessageType stringToType(const QString& type)
+{
+    if (type == QStringLiteral("configure")) {
+        return MessageType::Configure;
+    }
+    if (type == QStringLiteral("hostFrame")) {
+        return MessageType::HostFrame;
+    }
+    if (type == QStringLiteral("localFrame")) {
+        return MessageType::LocalFrame;
+    }
+    if (type == QStringLiteral("ready")) {
+        return MessageType::Ready;
+    }
+    if (type == QStringLiteral("error")) {
+        return MessageType::Error;
+    }
+    if (type == QStringLiteral("stop")) {
+        return MessageType::Stop;
+    }
+    return MessageType::Unknown;
+}
+
+QByteArray encodeObject(QJsonObject obj)
+{
+    obj.insert(QStringLiteral("version"), PROTOCOL_VERSION);
+    return QJsonDocument(obj).toJson(QJsonDocument::Compact);
+}
+
+QJsonObject baseMessage(MessageType type, quint32 sequence)
+{
+    QJsonObject obj;
+    obj.insert(QStringLiteral("type"), typeToString(type));
+    obj.insert(QStringLiteral("sequence"), static_cast<double>(sequence));
+    return obj;
+}
+
+bool readBase64Payload(const QJsonObject& obj, const QString& key, QByteArray& out)
+{
+    QString encoded = obj.value(key).toString();
+    if (encoded.isEmpty()) {
+        out.clear();
+        return false;
+    }
+
+    out = QByteArray::fromBase64(encoded.toLatin1());
+    return !out.isEmpty();
+}
+
+}
+
+QByteArray encodeConfigure(quint32 sequence, const HostConfig& config)
+{
+    QJsonObject host;
+    host.insert(QStringLiteral("address"), config.address);
+    host.insert(QStringLiteral("httpsPort"), static_cast<int>(config.httpsPort));
+    host.insert(QStringLiteral("serverCertPem"),
+                QString::fromLatin1(config.serverCertPem.toBase64()));
+    host.insert(QStringLiteral("clientCertPem"),
+                QString::fromLatin1(config.clientCertPem.toBase64()));
+    host.insert(QStringLiteral("clientKeyPem"),
+                QString::fromLatin1(config.clientKeyPem.toBase64()));
+
+    QJsonObject obj = baseMessage(MessageType::Configure, sequence);
+    obj.insert(QStringLiteral("host"), host);
+    return encodeObject(obj);
+}
+
+QByteArray encodeHostFrame(quint32 sequence, const QByteArray& frame)
+{
+    QJsonObject obj = baseMessage(MessageType::HostFrame, sequence);
+    obj.insert(QStringLiteral("payload"), QString::fromLatin1(frame.toBase64()));
+    return encodeObject(obj);
+}
+
+QByteArray encodeLocalFrame(quint32 sequence, const QByteArray& frame)
+{
+    QJsonObject obj = baseMessage(MessageType::LocalFrame, sequence);
+    obj.insert(QStringLiteral("payload"), QString::fromLatin1(frame.toBase64()));
+    return encodeObject(obj);
+}
+
+QByteArray encodeReady(quint32 sequence)
+{
+    return encodeObject(baseMessage(MessageType::Ready, sequence));
+}
+
+QByteArray encodeError(quint32 sequence, const QString& code, const QString& text)
+{
+    QJsonObject obj = baseMessage(MessageType::Error, sequence);
+    obj.insert(QStringLiteral("code"), code);
+    obj.insert(QStringLiteral("text"), text);
+    return encodeObject(obj);
+}
+
+QByteArray encodeStop(quint32 sequence)
+{
+    return encodeObject(baseMessage(MessageType::Stop, sequence));
+}
+
+bool decodeLine(const QByteArray& line, Message& outMessage, QString& outError)
+{
+    outMessage = Message();
+    outError.clear();
+
+    if (line.size() > MAX_LINE_BYTES) {
+        outError = QStringLiteral("message line too large");
+        return false;
+    }
+
+    QJsonParseError parseError{};
+    QJsonDocument doc = QJsonDocument::fromJson(line, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        outError = QStringLiteral("invalid JSON message: %1").arg(parseError.errorString());
+        return false;
+    }
+
+    QJsonObject obj = doc.object();
+    if (obj.value(QStringLiteral("version")).toInt() != PROTOCOL_VERSION) {
+        outError = QStringLiteral("unsupported protocol version");
+        return false;
+    }
+
+    outMessage.type = stringToType(obj.value(QStringLiteral("type")).toString());
+    outMessage.sequence = static_cast<quint32>(obj.value(QStringLiteral("sequence")).toInt());
+    if (outMessage.type == MessageType::Unknown) {
+        outError = QStringLiteral("unknown message type");
+        return false;
+    }
+
+    switch (outMessage.type) {
+    case MessageType::Configure:
+        {
+            QJsonObject host = obj.value(QStringLiteral("host")).toObject();
+            outMessage.config.address = host.value(QStringLiteral("address")).toString();
+            outMessage.config.httpsPort = static_cast<quint16>(host.value(QStringLiteral("httpsPort")).toInt());
+            readBase64Payload(host, QStringLiteral("serverCertPem"), outMessage.config.serverCertPem);
+            readBase64Payload(host, QStringLiteral("clientCertPem"), outMessage.config.clientCertPem);
+            readBase64Payload(host, QStringLiteral("clientKeyPem"), outMessage.config.clientKeyPem);
+            return true;
+        }
+    case MessageType::HostFrame:
+    case MessageType::LocalFrame:
+        if (!readBase64Payload(obj, QStringLiteral("payload"), outMessage.frame)) {
+            outError = QStringLiteral("missing or invalid frame payload");
+            return false;
+        }
+        return true;
+    case MessageType::Error:
+        outMessage.code = obj.value(QStringLiteral("code")).toString();
+        outMessage.text = obj.value(QStringLiteral("text")).toString();
+        return true;
+    case MessageType::Ready:
+    case MessageType::Stop:
+        return true;
+    case MessageType::Unknown:
+        break;
+    }
+
+    outError = QStringLiteral("unhandled message type");
+    return false;
+}
+
+}

--- a/app/streaming/clipboardipc.h
+++ b/app/streaming/clipboardipc.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+namespace ClipboardIpc {
+
+static constexpr int PROTOCOL_VERSION = 1;
+static constexpr int MAX_LINE_BYTES = 1024 * 1024;
+
+enum class MessageType {
+    Unknown,
+    Configure,
+    HostFrame,
+    LocalFrame,
+    Ready,
+    Error,
+    Stop,
+};
+
+struct HostConfig {
+    QString address;
+    quint16 httpsPort = 0;
+    QByteArray serverCertPem;
+    QByteArray clientCertPem;
+    QByteArray clientKeyPem;
+};
+
+struct Message {
+    MessageType type = MessageType::Unknown;
+    quint32 sequence = 0;
+    HostConfig config;
+    QByteArray frame;
+    QString code;
+    QString text;
+};
+
+QByteArray encodeConfigure(quint32 sequence, const HostConfig& config);
+QByteArray encodeHostFrame(quint32 sequence, const QByteArray& frame);
+QByteArray encodeLocalFrame(quint32 sequence, const QByteArray& frame);
+QByteArray encodeReady(quint32 sequence);
+QByteArray encodeError(quint32 sequence, const QString& code, const QString& text);
+QByteArray encodeStop(quint32 sequence);
+
+bool decodeLine(const QByteArray& line, Message& outMessage, QString& outError);
+
+}

--- a/app/streaming/clipboardlogging.h
+++ b/app/streaming/clipboardlogging.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QtGlobal>
+
+#include <cstdarg>
+#include <cstdio>
+
+namespace ClipboardLog {
+
+inline bool debugEnabled()
+{
+    return qEnvironmentVariableIntValue("MOONLIGHT_CLIPBOARD_HELPER_DEBUG") != 0;
+}
+
+inline void write(const char* level, const char* format, va_list args)
+{
+    if (level[0] == 'D' && !debugEnabled()) {
+        return;
+    }
+
+    fprintf(stderr, "ClipboardSync %s: ", level);
+    vfprintf(stderr, format, args);
+    fputc('\n', stderr);
+    fflush(stderr);
+}
+
+inline void debug(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    write("DEBUG", format, args);
+    va_end(args);
+}
+
+inline void info(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    write("INFO", format, args);
+    va_end(args);
+}
+
+inline void warn(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    write("WARN", format, args);
+    va_end(args);
+}
+
+}

--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -1,6 +1,5 @@
 #include "clipboardsync.h"
-#include "backend/nvcomputer.h"
-#include "backend/identitymanager.h"
+#include "clipboardlogging.h"
 
 #include <QBuffer>
 #include <QClipboard>
@@ -21,10 +20,6 @@
 #include <QtEndian>
 
 #include <cstring>
-
-#include <SDL.h>
-
-#include <Limelight.h>
 
 namespace {
 bool isImageLikeMimeFormat(const QString& format)
@@ -76,9 +71,9 @@ bool looksLikePngBytes(const QByteArray& bytes)
 }
 }
 
-ClipboardSync::ClipboardSync(NvComputer* computer, QObject* parent)
+ClipboardSync::ClipboardSync(const ClipboardSyncHostContext& hostContext, QObject* parent)
     : QObject(parent),
-      m_Computer(computer)
+      m_HostContext(hostContext)
 {
     qRegisterMetaType<QByteArray>("QByteArray");
 }
@@ -86,6 +81,11 @@ ClipboardSync::ClipboardSync(NvComputer* computer, QObject* parent)
 ClipboardSync::~ClipboardSync()
 {
     stop();
+}
+
+void ClipboardSync::setHostContext(const ClipboardSyncHostContext& hostContext)
+{
+    m_HostContext = hostContext;
 }
 
 void ClipboardSync::start()
@@ -96,8 +96,7 @@ void ClipboardSync::start()
 
     QClipboard* cb = QGuiApplication::clipboard();
     if (cb == nullptr) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: no QClipboard available; sync disabled");
+        ClipboardLog::warn("ClipboardSync: no QClipboard available; sync disabled");
         return;
     }
 
@@ -106,8 +105,7 @@ void ClipboardSync::start()
             Qt::UniqueConnection);
 
     m_Active = true;
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "ClipboardSync: started (text + PNG, bidirectional)");
+    ClipboardLog::info("ClipboardSync: started (text + PNG, bidirectional)");
 }
 
 void ClipboardSync::stop()
@@ -126,7 +124,7 @@ void ClipboardSync::stop()
     m_PendingSelfWrites = 0;
     m_Active = false;
 
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "ClipboardSync: stopped");
+    ClipboardLog::info("ClipboardSync: stopped");
 }
 
 void ClipboardSync::handleIncomingFrame(const char* data, int length)
@@ -150,8 +148,7 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
     uint8_t kind = 0;
     QByteArray payload;
     if (!decodeFrame(frame, kind, payload)) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: discarding malformed inbound frame (%d bytes)",
+        ClipboardLog::warn("ClipboardSync: discarding malformed inbound frame (%d bytes)",
                     static_cast<int>(frame.size()));
         return;
     }
@@ -171,8 +168,7 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
         QJsonParseError jerr{};
         QJsonDocument doc = QJsonDocument::fromJson(payload, &jerr);
         if (jerr.error != QJsonParseError::NoError || !doc.isObject()) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping inbound REF with bad JSON (%s)",
+            ClipboardLog::warn("ClipboardSync: dropping inbound REF with bad JSON (%s)",
                         jerr.errorString().toUtf8().constData());
             return;
         }
@@ -181,13 +177,11 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
         QString mime = obj.value(QStringLiteral("mime")).toString();
         qint64 size = static_cast<qint64>(obj.value(QStringLiteral("size")).toDouble(0));
         if (id.isEmpty() || id.size() > 128) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping inbound REF with bad id length");
+            ClipboardLog::warn("ClipboardSync: dropping inbound REF with bad id length");
             return;
         }
         if (size > MAX_BLOB_BYTES) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping inbound REF, declared size %lld exceeds %lld cap",
+            ClipboardLog::warn("ClipboardSync: dropping inbound REF, declared size %lld exceeds %lld cap",
                         static_cast<long long>(size), static_cast<long long>(MAX_BLOB_BYTES));
             return;
         }
@@ -201,8 +195,7 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
 void ClipboardSync::applyInboundText(const QByteArray& payload)
 {
     if (payload.contains('\0')) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: dropping inbound text payload with embedded NUL");
+        ClipboardLog::warn("ClipboardSync: dropping inbound text payload with embedded NUL");
         return;
     }
 
@@ -223,8 +216,7 @@ void ClipboardSync::applyInboundPng(const QByteArray& payload)
 {
     QImage image;
     if (!image.loadFromData(payload, "PNG") || image.isNull()) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: dropping inbound PNG payload (decode failed, %d bytes)",
+        ClipboardLog::warn("ClipboardSync: dropping inbound PNG payload (decode failed, %d bytes)",
                     static_cast<int>(payload.size()));
         return;
     }
@@ -258,8 +250,7 @@ bool ClipboardSync::encodeImageAsPng(const QImage& image,
 {
     const qint64 pixels = static_cast<qint64>(image.width()) * image.height();
     if (pixels <= 0 || pixels > MAX_IMAGE_PIXELS) {
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: image too large from %s (%dx%d), dropping",
+        ClipboardLog::info("ClipboardSync: image too large from %s (%dx%d), dropping",
                     sourceDescription,
                     image.width(),
                     image.height());
@@ -271,8 +262,7 @@ bool ClipboardSync::encodeImageAsPng(const QImage& image,
     QBuffer buf(&outPng);
     buf.open(QIODevice::WriteOnly);
     if (!image.save(&buf, "PNG") || outPng.isEmpty()) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: PNG encode failed for %s (%dx%d)",
+        ClipboardLog::warn("ClipboardSync: PNG encode failed for %s (%dx%d)",
                     sourceDescription,
                     image.width(),
                     image.height());
@@ -295,8 +285,7 @@ void ClipboardSync::sendClipboardPng(const QByteArray& png,
         // upload so the echo we'll see when the host loops the REF
         // back (and we fetch the same bytes) is suppressed.
         if (png.size() > MAX_BLOB_BYTES) {
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: PNG payload %lld B from %s exceeds %lld B blob cap, dropping",
+            ClipboardLog::info("ClipboardSync: PNG payload %lld B from %s exceeds %lld B blob cap, dropping",
                         static_cast<long long>(png.size()),
                         sourceUtf8.constData(),
                         static_cast<long long>(MAX_BLOB_BYTES));
@@ -319,14 +308,10 @@ void ClipboardSync::sendClipboardPng(const QByteArray& png,
 
     QByteArray frame;
     if (encodeFrame(KIND_PNG, png, frame)) {
-        int rc = LiSendClipboardData(frame.constData(), frame.size());
-        if (rc != 0) {
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "ClipboardSync: LiSendClipboardData(PNG, %d bytes from %s) -> %d",
-                         static_cast<int>(frame.size()),
-                         sourceUtf8.constData(),
-                         rc);
-        }
+        ClipboardLog::debug("ClipboardSync: outbound PNG frame queued (%d bytes from %s)",
+                     static_cast<int>(frame.size()),
+                     sourceUtf8.constData());
+        emit outboundFrame(frame);
     }
 }
 
@@ -364,8 +349,7 @@ bool ClipboardSync::tryExtractImageBytes(const QMimeData* mime,
                 && looksLikePngBytes(bytes)) {
             const qint64 pixels = static_cast<qint64>(image.width()) * image.height();
             if (pixels <= 0 || pixels > MAX_IMAGE_PIXELS) {
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "ClipboardSync: image too large from mime %s (%dx%d), dropping",
+                ClipboardLog::info("ClipboardSync: image too large from mime %s (%dx%d), dropping",
                             format.toUtf8().constData(),
                             image.width(),
                             image.height());
@@ -461,8 +445,7 @@ bool ClipboardSync::tryExtractImageFromHtml(const QMimeData* mime,
             if (dataUrlMatch.captured(1).compare(QStringLiteral("image/png"), Qt::CaseInsensitive) == 0) {
                 const qint64 pixels = static_cast<qint64>(image.width()) * image.height();
                 if (pixels <= 0 || pixels > MAX_IMAGE_PIXELS) {
-                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                                "ClipboardSync: image too large from html data URL (%dx%d), dropping",
+                    ClipboardLog::info("ClipboardSync: image too large from html data URL (%dx%d), dropping",
                                 image.width(),
                                 image.height());
                     return false;
@@ -599,8 +582,7 @@ void ClipboardSync::onLocalClipboardChanged()
 
         if (hasImageLikeHints) {
             const QString formatsSummary = mime->formats().join(QStringLiteral(", "));
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "ClipboardSync: no transferable image found in clipboard formats [%s]",
+            ClipboardLog::debug("ClipboardSync: no transferable image found in clipboard formats [%s]",
                          formatsSummary.toUtf8().constData());
         }
     }
@@ -627,14 +609,9 @@ void ClipboardSync::onLocalClipboardChanged()
         return;
     }
 
-    int rc = LiSendClipboardData(frame.constData(), frame.size());
-    if (rc != 0) {
-        // Negative return = no active session, host doesn't support clipboard,
-        // or send failed; log once at debug level to avoid spam.
-        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                     "ClipboardSync: LiSendClipboardData(text, %d bytes) -> %d",
-                     static_cast<int>(frame.size()), rc);
-    }
+    ClipboardLog::debug("ClipboardSync: outbound text frame queued (%d bytes)",
+                 static_cast<int>(frame.size()));
+    emit outboundFrame(frame);
 }
 
 bool ClipboardSync::encodeFrame(uint8_t kind, const QByteArray& payload, QByteArray& outFrame) const
@@ -736,11 +713,11 @@ QNetworkAccessManager* ClipboardSync::nam()
         // SSL errors only when the offending cert matches the pinned one.
         connect(m_Nam, &QNetworkAccessManager::sslErrors, this,
                 [this](QNetworkReply* reply, const QList<QSslError>& errors) {
-                    if (m_Computer == nullptr || m_Computer->serverCert.isNull()) {
+                    if (m_HostContext.serverCertificate.isNull()) {
                         return;
                     }
                     for (const QSslError& e : errors) {
-                        if (m_Computer->serverCert != e.certificate()) {
+                        if (m_HostContext.serverCertificate != e.certificate()) {
                             return;
                         }
                     }
@@ -752,19 +729,16 @@ QNetworkAccessManager* ClipboardSync::nam()
 
 bool ClipboardSync::buildBlobUrl(const QString& tail, QUrl& outUrl) const
 {
-    if (m_Computer == nullptr || m_Computer->serverCert.isNull()) {
+    if (m_HostContext.address.isEmpty() ||
+            m_HostContext.httpsPort == 0 ||
+            m_HostContext.serverCertificate.isNull()) {
         return false;
     }
-    NvAddress addr = m_Computer->activeAddress;
-    uint16_t port = m_Computer->activeHttpsPort;
-    if (addr.isNull() || port == 0) {
-        return false;
-    }
-    QString host = addr.address();
+    QString host = m_HostContext.address;
     if (host.contains(':')) {
         host = QString("[%1]").arg(host); // bracketed IPv6
     }
-    outUrl = QUrl(QString("https://%1:%2/api/v1/clipboard%3").arg(host).arg(port).arg(tail));
+    outUrl = QUrl(QString("https://%1:%2/api/v1/clipboard%3").arg(host).arg(m_HostContext.httpsPort).arg(tail));
     return outUrl.isValid();
 }
 
@@ -772,8 +746,7 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
 {
     QUrl url;
     if (!buildBlobUrl(QStringLiteral("/blob"), url)) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: cannot upload blob (no host context)");
+        ClipboardLog::warn("ClipboardSync: cannot upload blob (no host context)");
         return;
     }
 
@@ -784,29 +757,29 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
     // Sunshine pins clipboard blob endpoint to its mTLS server (cert
     // required); reuse the same paired client identity nvhttp does, or
     // every fetch/upload fails with a TLS 'certificate required' alert.
-    req.setSslConfiguration(IdentityManager::get()->getSslConfig());
+    QSslConfiguration sslConfig(QSslConfiguration::defaultConfiguration());
+    sslConfig.setLocalCertificate(m_HostContext.clientCertificate);
+    sslConfig.setPrivateKey(m_HostContext.clientPrivateKey);
+    req.setSslConfiguration(sslConfig);
 
     QNetworkReply* reply = nam()->post(req, payload);
     connect(reply, &QNetworkReply::finished, this, [this, reply, mime, payloadSize = payload.size()]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: blob upload failed: %s",
+            ClipboardLog::warn("ClipboardSync: blob upload failed: %s",
                         reply->errorString().toUtf8().constData());
             return;
         }
         QJsonParseError jerr{};
         QJsonDocument doc = QJsonDocument::fromJson(reply->readAll(), &jerr);
         if (jerr.error != QJsonParseError::NoError || !doc.isObject()) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: blob upload response not JSON: %s",
+            ClipboardLog::warn("ClipboardSync: blob upload response not JSON: %s",
                         jerr.errorString().toUtf8().constData());
             return;
         }
         QString id = doc.object().value(QStringLiteral("id")).toString();
         if (id.isEmpty()) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: blob upload response missing id");
+            ClipboardLog::warn("ClipboardSync: blob upload response missing id");
             return;
         }
 
@@ -820,12 +793,9 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
         if (!encodeFrame(KIND_REF, json, frame)) {
             return;
         }
-        int rc = LiSendClipboardData(frame.constData(), frame.size());
-        if (rc != 0) {
-            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                         "ClipboardSync: LiSendClipboardData(REF, %d bytes) -> %d",
-                         static_cast<int>(frame.size()), rc);
-        }
+        ClipboardLog::debug("ClipboardSync: outbound REF frame queued (%d bytes)",
+                     static_cast<int>(frame.size()));
+        emit outboundFrame(frame);
     });
 }
 
@@ -833,20 +803,21 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qin
 {
     QUrl url;
     if (!buildBlobUrl(QStringLiteral("/blob/") + id, url)) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                    "ClipboardSync: cannot fetch blob (no host context)");
+        ClipboardLog::warn("ClipboardSync: cannot fetch blob (no host context)");
         return;
     }
 
     QNetworkRequest req(url);
-    req.setSslConfiguration(IdentityManager::get()->getSslConfig());
+    QSslConfiguration sslConfig(QSslConfiguration::defaultConfiguration());
+    sslConfig.setLocalCertificate(m_HostContext.clientCertificate);
+    sslConfig.setPrivateKey(m_HostContext.clientPrivateKey);
+    req.setSslConfiguration(sslConfig);
 
     QNetworkReply* reply = nam()->get(req);
     connect(reply, &QNetworkReply::finished, this, [this, reply, mime, advertisedSize]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: blob fetch failed: %s",
+            ClipboardLog::warn("ClipboardSync: blob fetch failed: %s",
                         reply->errorString().toUtf8().constData());
             return;
         }
@@ -857,16 +828,14 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qin
         // Defense: cap actual download size in case the server lied about
         // advertised size or QNAM streamed past the declared length.
         if (bytes.size() > MAX_BLOB_BYTES) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping fetched blob, actual size %lld exceeds %lld cap",
+            ClipboardLog::warn("ClipboardSync: dropping fetched blob, actual size %lld exceeds %lld cap",
                         static_cast<long long>(bytes.size()),
                         static_cast<long long>(MAX_BLOB_BYTES));
             return;
         }
         // Hard-fail on advertised/actual mismatch when REF declared a size.
         if (advertisedSize > 0 && bytes.size() != advertisedSize) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping fetched blob, size mismatch (got %lld, advertised %lld)",
+            ClipboardLog::warn("ClipboardSync: dropping fetched blob, size mismatch (got %lld, advertised %lld)",
                         static_cast<long long>(bytes.size()),
                         static_cast<long long>(advertisedSize));
             return;
@@ -877,8 +846,7 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qin
         } else if (mime.startsWith(QStringLiteral("text/"))) {
             applyInboundText(bytes);
         } else {
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                        "ClipboardSync: dropping fetched blob with unsupported mime '%s'",
+            ClipboardLog::info("ClipboardSync: dropping fetched blob with unsupported mime '%s'",
                         mime.toUtf8().constData());
         }
     });

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -5,22 +5,33 @@
 #include <QMutex>
 #include <QPair>
 #include <QQueue>
+#include <QSslCertificate>
+#include <QSslKey>
 #include <QString>
 #include <QStringList>
 #include <cstdint>
 
-class NvComputer;
 class QImage;
 class QMimeData;
 class QNetworkAccessManager;
 class QNetworkReply;
 class QSslError;
 
-// ClipboardSync owns the bidirectional clipboard sync state for an active
-// streaming session against an AlkaidLab Sunshine fork host. It implements
-// the v1 wire format (u8 version=1, u8 kind, u32 token, u32 length, bytes
-// payload, little-endian) over Limelight control packet 0x5508
-// (LiSendClipboardData / ConnListenerClipboardData).
+struct ClipboardSyncHostContext
+{
+    QString address;
+    quint16 httpsPort = 0;
+    QSslCertificate serverCertificate;
+    QSslCertificate clientCertificate;
+    QSslKey clientPrivateKey;
+};
+
+// ClipboardSync owns the local clipboard state inside the clipboard helper
+// process. It implements the v1 wire format (u8 version=1, u8 kind, u32
+// token, u32 length, bytes payload, little-endian) used by the Limelight
+// control packet 0x5508, but it does not talk to Limelight directly. The
+// helper process reports outbound frames to the main process via IPC, and the
+// main process forwards them through LiSendClipboardData().
 //
 // Supports kind=1 (UTF-8 text), kind=2 (PNG image), and kind=3 (REF JSON
 // pointing to an out-of-band blob transferred over HTTPS via the Sunshine
@@ -38,9 +49,8 @@ class QSslError;
 // Threading:
 //   * Construct on the GUI thread.
 //   * start() / stop() must run on the GUI thread.
-//   * handleIncomingFrame() may be called from any thread (specifically the
-//     moonlight-common-c control receive thread). It marshals the payload
-//     onto the GUI thread via a queued metacall.
+//   * handleIncomingFrame() may be called from any thread. It marshals the
+//     payload onto the helper GUI thread via a queued metacall.
 class ClipboardSync : public QObject
 {
     Q_OBJECT
@@ -66,8 +76,11 @@ public:
     // doesn't try to PNG-encode a 100 MB bitmap and stall the GUI thread.
     static constexpr qint64  MAX_IMAGE_PIXELS = 32LL * 1024 * 1024;
 
-    explicit ClipboardSync(NvComputer* computer = nullptr, QObject* parent = nullptr);
+    explicit ClipboardSync(const ClipboardSyncHostContext& hostContext = ClipboardSyncHostContext(),
+                           QObject* parent = nullptr);
     ~ClipboardSync() override;
+
+    void setHostContext(const ClipboardSyncHostContext& hostContext);
 
     // Start watching the local clipboard and accepting inbound payloads.
     // Must be called on the GUI thread.
@@ -79,6 +92,12 @@ public:
     // Called from the control receive thread when the host pushes a 0x5508
     // payload. Buffer is only valid for the duration of the call; we copy.
     void handleIncomingFrame(const char* data, int length);
+
+signals:
+    // Emitted when local clipboard changes need to be sent to the host. The
+    // owner decides how to deliver the frame, which lets the clipboard engine
+    // run in a helper process without direct access to the Limelight session.
+    void outboundFrame(QByteArray frame);
 
 private slots:
     // QClipboard::dataChanged -> emitted on GUI thread.
@@ -127,7 +146,7 @@ private:
     void applyInboundText(const QByteArray& payload);
     void applyInboundPng(const QByteArray& payload);
 
-    NvComputer* m_Computer = nullptr;
+    ClipboardSyncHostContext m_HostContext;
     QNetworkAccessManager* m_Nam = nullptr;
 
     bool m_Active = false;

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -276,21 +276,45 @@ void SdlInputHandler::setWindow(SDL_Window *window)
 #endif
 }
 
-void SdlInputHandler::raiseAllKeys()
+void SdlInputHandler::raiseAllKeys(bool clearKeys)
 {
     if (m_KeysDown.isEmpty()) {
         return;
     }
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                "Raising %d keys",
-                (int)m_KeysDown.count());
+                "Raising %d keys%s",
+                (int)m_KeysDown.count(),
+                clearKeys ? "" : " (keeping local state for retry)");
 
-    for (auto keyDown : std::as_const(m_KeysDown)) {
-        LiSendKeyboardEvent(keyDown, KEY_ACTION_UP, 0);
+    int failedCount = 0;
+    auto keysDown = m_KeysDown;
+
+    for (auto keyDown : std::as_const(keysDown)) {
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                     "Raising key: vk=0x%04x",
+                     (int)keyDown);
+
+        int rc = LiSendKeyboardEvent(keyDown, KEY_ACTION_UP, 0);
+        if (rc == 0) {
+            if (clearKeys) {
+                m_KeysDown.remove(keyDown);
+            }
+        }
+        else {
+            failedCount++;
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "LiSendKeyboardEvent failed while raising key: rc=%d vk=0x%04x",
+                        rc,
+                        (int)keyDown);
+        }
     }
 
-    m_KeysDown.clear();
+    if (clearKeys && failedCount != 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Keeping %d keys marked down for a later retry",
+                    failedCount);
+    }
 }
 
 void SdlInputHandler::notifyMouseLeave()
@@ -315,11 +339,19 @@ void SdlInputHandler::notifyMouseLeave()
 
 void SdlInputHandler::notifyFocusLost()
 {
+    Uint32 windowFlags = SDL_GetWindowFlags(m_Window);
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Input focus lost: windowFlags=0x%08x keysDown=%d capture=%d",
+                (unsigned int)windowFlags,
+                (int)m_KeysDown.count(),
+                isCaptureActive() ? 1 : 0);
+
     // Release mouse cursor when another window is activated (e.g. by using ALT+TAB).
     // This lets user to interact with our window's title bar and with the buttons in it.
     // Doing this while the window is full-screen breaks the transition out of FS
     // (desktop and exclusive), so we must check for that before releasing mouse capture.
-    if (!(SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN) && !m_AbsoluteMouseMode) {
+    if (!(windowFlags & SDL_WINDOW_FULLSCREEN) && !m_AbsoluteMouseMode) {
         setCaptureActive(false);
     }
 

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -132,7 +132,8 @@ public:
 
     int getAttachedGamepadMask();
 
-    void raiseAllKeys();
+    void raiseAllKeys(bool clearKeys = true);
+    bool hasKeysDown() const { return !m_KeysDown.isEmpty(); }
 
     void notifyMouseLeave();
 

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -473,9 +473,30 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
         m_KeysDown.remove(keyCode);
     }
 
-    LiSendKeyboardEvent2(0x8000 | keyCode,
-                        event->state == SDL_PRESSED ?
-                            KEY_ACTION_DOWN : KEY_ACTION_UP,
-                        modifiers,
-                        shouldNotConvertToScanCodeOnServer ? SS_KBE_FLAG_NON_NORMALIZED : 0);
+    const char keyAction = event->state == SDL_PRESSED ? KEY_ACTION_DOWN : KEY_ACTION_UP;
+    const char flags = shouldNotConvertToScanCodeOnServer ? SS_KBE_FLAG_NON_NORMALIZED : 0;
+
+    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                 "Keyboard %s: scancode=%d sym=%d vk=0x%04x modifiers=0x%02x flags=0x%02x keysDown=%d",
+                 event->state == SDL_PRESSED ? "down" : "up",
+                 (int)event->keysym.scancode,
+                 (int)event->keysym.sym,
+                 (int)(0x8000 | keyCode),
+                 (int)(unsigned char)modifiers,
+                 (int)(unsigned char)flags,
+                 (int)m_KeysDown.count());
+
+    int rc = LiSendKeyboardEvent2(0x8000 | keyCode,
+                                  keyAction,
+                                  modifiers,
+                                  flags);
+    if (rc != 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "LiSendKeyboardEvent2 failed: rc=%d action=%s scancode=%d vk=0x%04x keysDown=%d",
+                    rc,
+                    keyAction == KEY_ACTION_DOWN ? "down" : "up",
+                    (int)event->keysym.scancode,
+                    (int)(0x8000 | keyCode),
+                    (int)m_KeysDown.count());
+    }
 }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1,5 +1,5 @@
 #include "session.h"
-#include "clipboardsync.h"
+#include "clipboardhelperclient.h"
 #include "settings/streamingpreferences.h"
 #include "streaming/streamutils.h"
 #include "backend/richpresencemanager.h"
@@ -347,12 +347,12 @@ void Session::clSetHdrMode(bool enabled)
 void Session::clClipboardData(const char* data, int length)
 {
     Session* session = s_ActiveSession;
-    if (session == nullptr || session->m_ClipboardSync == nullptr) {
+    if (session == nullptr || session->m_ClipboardHelper == nullptr) {
         return;
     }
 
-    // Marshals to GUI thread internally; safe to call from the recv thread.
-    session->m_ClipboardSync->handleIncomingFrame(data, length);
+    // Queues internally; safe to call from the recv thread.
+    session->m_ClipboardHelper->handleIncomingFrame(data, length);
 }
 
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
@@ -731,7 +731,7 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_MicStream(nullptr)
 {
     memset(&m_LastAbrVideoStats, 0, sizeof(m_LastAbrVideoStats));
-    m_ClipboardSync = nullptr;
+    m_ClipboardHelper = nullptr;
 }
 
 Session::~Session()
@@ -739,10 +739,10 @@ Session::~Session()
     // NB: This may not get destroyed for a long time! Don't put any non-trivial cleanup here.
     // Use Session::exec() or DeferredSessionCleanupTask instead.
 
-    if (m_ClipboardSync != nullptr) {
-        m_ClipboardSync->stop();
-        delete m_ClipboardSync;
-        m_ClipboardSync = nullptr;
+    if (m_ClipboardHelper != nullptr) {
+        m_ClipboardHelper->stop();
+        delete m_ClipboardHelper;
+        m_ClipboardHelper = nullptr;
     }
 
     SDL_DestroyMutex(m_DecoderLock);
@@ -2181,6 +2181,13 @@ public:
 
 bool Session::tryReconnect()
 {
+    // Release any locally tracked pressed keys before tearing down the dead connection.
+    // If the old control stream is still partly alive, this gives the host one last
+    // chance to clear stuck key state before reconnecting.
+    if (m_InputHandler != nullptr) {
+        m_InputHandler->raiseAllKeys(false);
+    }
+
     // The decoder can only be used between LiStartConnection() and
     // LiStopConnection(), so tear it down before stopping the dead connection.
     SDL_LockMutex(m_DecoderLock);
@@ -2252,6 +2259,12 @@ bool Session::tryReconnect()
 
         if (m_AsyncConnectionSuccess) {
             reconnected = true;
+            if (m_ClipboardHelper != nullptr) {
+                m_ClipboardHelper->updateHostContext();
+            }
+            if (m_InputHandler != nullptr) {
+                m_InputHandler->raiseAllKeys();
+            }
             break;
         }
 
@@ -2623,13 +2636,15 @@ void Session::start()
     // We're now active
     s_ActiveSession = this;
 
-    // Construct the clipboard sync helper on the GUI thread before the
-    // control receive thread can possibly invoke clClipboardData(). It is
-    // started after a successful connection in clConnectionStatusUpdate.
-    if (m_ClipboardSync == nullptr) {
-        m_ClipboardSync = new ClipboardSync(m_Computer, this);
-        m_ClipboardSync->start();
+#ifndef STEAM_LINK
+    // Construct the clipboard sync helper process before the control receive
+    // thread can possibly invoke clClipboardData(). Host frames are queued by
+    // ClipboardHelperClient and flushed from the SDL loop.
+    if (m_ClipboardHelper == nullptr) {
+        m_ClipboardHelper = new ClipboardHelperClient(m_Computer, this);
+        m_ClipboardHelper->start();
     }
+#endif
 
     // Initialize the gamepad code with our preferences
     // NB: m_InputHandler must be initialize before starting the connection.
@@ -2713,11 +2728,20 @@ void Session::exec()
 {
     // If the connection failed, clean up and abort the connection.
     if (!m_AsyncConnectionSuccess) {
+        if (m_ClipboardHelper != nullptr) {
+            m_ClipboardHelper->stop();
+            delete m_ClipboardHelper;
+            m_ClipboardHelper = nullptr;
+        }
         delete m_InputHandler;
         m_InputHandler = nullptr;
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
         QThreadPool::globalInstance()->start(new DeferredSessionCleanupTask(this));
         return;
+    }
+
+    if (m_ClipboardHelper != nullptr) {
+        m_ClipboardHelper->updateHostContext();
     }
 
     // Pump the Qt event loop one last time before we create our SDL window
@@ -2800,6 +2824,11 @@ void Session::exec()
                          "SDL_CreateWindow() failed: %s",
                          SDL_GetError());
 
+            if (m_ClipboardHelper != nullptr) {
+                m_ClipboardHelper->stop();
+                delete m_ClipboardHelper;
+                m_ClipboardHelper = nullptr;
+            }
             delete m_InputHandler;
             m_InputHandler = nullptr;
             SDL_QuitSubSystem(SDL_INIT_VIDEO);
@@ -2937,23 +2966,30 @@ void Session::exec()
     // Switch to async logging mode when we enter the SDL loop
     StreamUtils::enterAsyncLoggingMode();
 
-    // Hijack this thread to be the SDL main thread. We still need to pump Qt
-    // periodically while streaming because ClipboardSync relies on Qt's event
-    // loop for QClipboard notifications, queued inbound frames, and QNAM blob
-    // callbacks. Without this, PNG clipboard sync can stall on every platform.
-    constexpr Uint32 QT_EVENT_PUMP_INTERVAL_MS = 10;
+    // Hijack this thread to be the SDL main thread. Pump Qt only for visible
+    // streaming UI; clipboard sync runs in a helper process with its own Qt
+    // event loop and is serviced via pipe polling below.
+    constexpr Uint32 QT_UI_EVENT_PUMP_INTERVAL_MS = 10;
     Uint32 lastQtEventPumpTicks = 0;
     auto processQtEventsDuringStream = [this, &lastQtEventPumpTicks](bool force = false) {
         const bool qtUiVisible = (m_MenuPanel && m_MenuPanel->needsEventProcessing()) ||
                                  (m_Toast && m_Toast->isVisible());
+        if (!qtUiVisible) {
+            return;
+        }
+
         const Uint32 now = SDL_GetTicks();
-        if (!force && !qtUiVisible && now - lastQtEventPumpTicks < QT_EVENT_PUMP_INTERVAL_MS) {
+        if (!force && now - lastQtEventPumpTicks < QT_UI_EVENT_PUMP_INTERVAL_MS) {
             return;
         }
         lastQtEventPumpTicks = now;
-        QCoreApplication::processEvents(qtUiVisible
-                                        ? QEventLoop::AllEvents
-                                        : QEventLoop::ExcludeUserInputEvents);
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+    };
+
+    auto processClipboardHelperMessages = [this]() {
+        if (m_ClipboardHelper != nullptr) {
+            m_ClipboardHelper->processPendingMessages();
+        }
     };
 
     constexpr Uint32 ABR_FEEDBACK_INTERVAL_MS = 3000;
@@ -2972,6 +3008,7 @@ void Session::exec()
     SDL_Event event;
     for (;;) {
         processSunshineAbrFeedback();
+        processClipboardHelperMessages();
 
 #if SDL_VERSION_ATLEAST(2, 0, 18) && !defined(STEAM_LINK)
         // SDL 2.0.18 has a proper wait event implementation that uses platform
@@ -2983,8 +3020,10 @@ void Session::exec()
         // NB: This behavior was introduced in SDL 2.0.16, but had a few critical
         // issues that could cause indefinite timeouts, delayed joystick detection,
         // and other problems.
-        if (!SDL_WaitEventTimeout(&event, 1000)) {
+        int waitTimeoutMs = (m_ClipboardHelper != nullptr && m_ClipboardHelper->isRunning()) ? 100 : 1000;
+        if (!SDL_WaitEventTimeout(&event, waitTimeoutMs)) {
             presence.runCallbacks();
+            processClipboardHelperMessages();
             processQtEventsDuringStream(true);
             processSunshineAbrFeedback();
             continue;
@@ -3003,6 +3042,7 @@ void Session::exec()
             SDL_Delay(10);
 #endif
             presence.runCallbacks();
+            processClipboardHelperMessages();
             processQtEventsDuringStream();
             processSunshineAbrFeedback();
             continue;
@@ -3424,6 +3464,7 @@ void Session::exec()
             break;
         }
 
+        processClipboardHelperMessages();
         processQtEventsDuringStream();
 
         // Deferred microphone toggle — runs outside processEvents() to avoid
@@ -3449,6 +3490,13 @@ void Session::exec()
 DispatchDeferredCleanup:
     // Switch back to synchronous logging mode
     StreamUtils::exitAsyncLoggingMode();
+
+    if (m_ClipboardHelper != nullptr) {
+        m_ClipboardHelper->processPendingMessages();
+        m_ClipboardHelper->stop();
+        delete m_ClipboardHelper;
+        m_ClipboardHelper = nullptr;
+    }
 
     // Destroy the Qt overlay menu panel
     if (m_MenuPanel) {

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -337,7 +337,7 @@ private:
     OverlayMenuButton* m_MenuButton; // Qt-based floating menu button
     OverlayToast* m_Toast;           // Qt-based toast notification
     Uint32 m_MenuCloseTicks;       // 菜单关闭时间戳（防抖）
-    class ClipboardSync* m_ClipboardSync; // Bidirectional clipboard sync (Sunshine 0x5508); nullptr when stream not active
+    class ClipboardHelperClient* m_ClipboardHelper; // Bidirectional clipboard sync helper process; nullptr when stream not active
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;

--- a/clipboard-helper/clipboard-helper.pro
+++ b/clipboard-helper/clipboard-helper.pro
@@ -1,0 +1,32 @@
+QT += core gui network
+CONFIG += c++17
+CONFIG -= app_bundle
+
+TARGET = moonlight-clipboard-helper
+TEMPLATE = app
+
+include(../globaldefs.pri)
+
+INCLUDEPATH += $$PWD/../app
+
+SOURCES += \
+    main.cpp \
+    ../app/streaming/clipboardipc.cpp \
+    ../app/streaming/clipboardsync.cpp
+
+HEADERS += \
+    ../app/streaming/clipboardipc.h \
+    ../app/streaming/clipboardlogging.h \
+    ../app/streaming/clipboardsync.h
+
+unix:!macx {
+    isEmpty(PREFIX) {
+        PREFIX = /usr/local
+    }
+    isEmpty(BINDIR) {
+        BINDIR = bin
+    }
+
+    target.path = $$PREFIX/$$BINDIR/
+    INSTALLS += target
+}

--- a/clipboard-helper/main.cpp
+++ b/clipboard-helper/main.cpp
@@ -1,0 +1,167 @@
+#include "streaming/clipboardsync.h"
+#include "streaming/clipboardipc.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QObject>
+#include <QSslCertificate>
+#include <QSslKey>
+#include <QThread>
+
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+class StdinReaderThread : public QThread
+{
+    Q_OBJECT
+
+signals:
+    void lineReceived(QByteArray line);
+
+protected:
+    void run() override
+    {
+        std::string line;
+        while (std::getline(std::cin, line)) {
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            emit lineReceived(QByteArray(line.data(), static_cast<int>(line.size())));
+        }
+        emit lineReceived(ClipboardIpc::encodeStop(0));
+    }
+};
+
+class ClipboardHelperController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ClipboardHelperController(QObject* parent = nullptr)
+        : QObject(parent)
+    {
+    }
+
+public slots:
+    void handleLine(const QByteArray& line)
+    {
+        ClipboardIpc::Message message;
+        QString error;
+        if (!ClipboardIpc::decodeLine(line, message, error)) {
+            writeProtocolLine(ClipboardIpc::encodeError(0, QStringLiteral("bad-message"), error));
+            return;
+        }
+
+        if (message.type == ClipboardIpc::MessageType::Stop) {
+            QCoreApplication::quit();
+            return;
+        }
+
+        if (message.type == ClipboardIpc::MessageType::Configure) {
+            handleConfig(message.sequence, message.config);
+            return;
+        }
+
+        if (message.type == ClipboardIpc::MessageType::HostFrame) {
+            if (m_ClipboardEngine == nullptr) {
+                writeProtocolLine(ClipboardIpc::encodeError(message.sequence,
+                                                            QStringLiteral("not-ready"),
+                                                            QStringLiteral("clipboard sync is not configured")));
+                return;
+            }
+            m_ClipboardEngine->handleIncomingFrame(message.frame.constData(), message.frame.size());
+            return;
+        }
+
+        writeProtocolLine(ClipboardIpc::encodeError(message.sequence,
+                                                    QStringLiteral("unexpected-message"),
+                                                    QStringLiteral("message type is not valid for helper input")));
+    }
+
+private:
+    void handleConfig(quint32 sequence, const ClipboardIpc::HostConfig& config)
+    {
+        if (config.address.isEmpty() || config.httpsPort == 0 ||
+                config.serverCertPem.isEmpty() ||
+                config.clientCertPem.isEmpty() ||
+                config.clientKeyPem.isEmpty()) {
+            writeProtocolLine(ClipboardIpc::encodeError(sequence,
+                                                        QStringLiteral("bad-config"),
+                                                        QStringLiteral("missing host address, port, or certificate data")));
+            return;
+        }
+
+        ClipboardSyncHostContext context;
+        context.address = config.address;
+        context.httpsPort = config.httpsPort;
+        context.serverCertificate = QSslCertificate(config.serverCertPem);
+        context.clientCertificate = QSslCertificate(config.clientCertPem);
+        context.clientPrivateKey = QSslKey(config.clientKeyPem, QSsl::Rsa);
+        if (context.serverCertificate.isNull() ||
+                context.clientCertificate.isNull() ||
+                context.clientPrivateKey.isNull()) {
+            writeProtocolLine(ClipboardIpc::encodeError(sequence,
+                                                        QStringLiteral("bad-config"),
+                                                        QStringLiteral("certificate or private key data is unreadable")));
+            return;
+        }
+
+        if (m_ClipboardEngine == nullptr) {
+            m_ClipboardEngine = new ClipboardSync(context, this);
+            connect(m_ClipboardEngine, &ClipboardSync::outboundFrame,
+                    this, &ClipboardHelperController::sendLocalFrame);
+            m_ClipboardEngine->start();
+        }
+        else {
+            m_ClipboardEngine->setHostContext(context);
+        }
+
+        writeProtocolLine(ClipboardIpc::encodeReady(sequence));
+    }
+
+    void sendLocalFrame(const QByteArray& frame)
+    {
+        writeProtocolLine(ClipboardIpc::encodeLocalFrame(m_NextSequence++, frame));
+    }
+
+    void writeProtocolLine(const QByteArray& line)
+    {
+        QByteArray out = line;
+        out.append('\n');
+        size_t written = fwrite(out.constData(), 1, static_cast<size_t>(out.size()), stdout);
+        fflush(stdout);
+        if (written != static_cast<size_t>(out.size())) {
+            QCoreApplication::quit();
+        }
+    }
+
+    ClipboardSync* m_ClipboardEngine = nullptr;
+    quint32 m_NextSequence = 1;
+};
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("Moonlight Clipboard Helper"));
+    QCoreApplication::setOrganizationName(QStringLiteral("Moonlight Game Streaming Project"));
+
+    ClipboardHelperController controller;
+    StdinReaderThread stdinThread;
+    QObject::connect(&stdinThread, &StdinReaderThread::lineReceived,
+                     &controller, &ClipboardHelperController::handleLine,
+                     Qt::QueuedConnection);
+    QObject::connect(&app, &QCoreApplication::aboutToQuit,
+                     &stdinThread, &QThread::requestInterruption);
+
+    stdinThread.start();
+    int rc = app.exec();
+    if (!stdinThread.wait(1000)) {
+        stdinThread.terminate();
+        stdinThread.wait();
+    }
+    return rc;
+}
+
+#include "main.moc"

--- a/clipboard-helper/main.cpp
+++ b/clipboard-helper/main.cpp
@@ -152,8 +152,6 @@ int main(int argc, char* argv[])
     QObject::connect(&stdinThread, &StdinReaderThread::lineReceived,
                      &controller, &ClipboardHelperController::handleLine,
                      Qt::QueuedConnection);
-    QObject::connect(&app, &QCoreApplication::aboutToQuit,
-                     &stdinThread, &QThread::requestInterruption);
 
     stdinThread.start();
     int rc = app.exec();

--- a/moonlight-qt.pro
+++ b/moonlight-qt.pro
@@ -7,6 +7,10 @@ SUBDIRS = \
 
 # Build the dependencies in parallel before the final app
 app.depends = qmdnsengine moonlight-common-c h264bitstream
+!config_SL {
+    SUBDIRS += clipboard-helper
+    app.depends += clipboard-helper
+}
 win32:!winrt {
     SUBDIRS += AntiHooking
     app.depends += AntiHooking

--- a/scripts/build-arch.bat
+++ b/scripts/build-arch.bat
@@ -198,6 +198,10 @@ echo Copying AntiHooking.dll
 copy %BUILD_FOLDER%\AntiHooking\%BUILD_CONFIG%\AntiHooking.dll %DEPLOY_FOLDER%
 if !ERRORLEVEL! NEQ 0 goto Error
 
+echo Copying clipboard helper
+copy %BUILD_FOLDER%\clipboard-helper\%BUILD_CONFIG%\moonlight-clipboard-helper.exe %DEPLOY_FOLDER%
+if !ERRORLEVEL! NEQ 0 goto Error
+
 echo Copying GC mapping list
 copy %SOURCE_ROOT%\app\SDL_GameControllerDB\gamecontrollerdb.txt %DEPLOY_FOLDER%
 if !ERRORLEVEL! NEQ 0 goto Error

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -89,6 +89,16 @@ if [ "$GITHUB_ACTIONS" == "true" ]; then
   fi
 fi
 
+echo Copying clipboard helper into app bundle
+HELPER_BINARY=$BUILD_FOLDER/clipboard-helper/moonlight-clipboard-helper
+if [ ! -f "$HELPER_BINARY" ]; then
+  HELPER_BINARY=$BUILD_FOLDER/clipboard-helper/$BUILD_CONFIG/moonlight-clipboard-helper
+fi
+if [ ! -f "$HELPER_BINARY" ]; then
+  HELPER_BINARY=$BUILD_FOLDER/clipboard-helper/$(echo "$BUILD_CONFIG" | tr '[:upper:]' '[:lower:]')/moonlight-clipboard-helper
+fi
+cp "$HELPER_BINARY" $BUILD_FOLDER/app/Moonlight.app/Contents/MacOS/ || fail "Clipboard helper copy failed!"
+
 macdeployqt $BUILD_FOLDER/app/Moonlight.app $EXTRA_ARGS -qmldir=$SOURCE_ROOT/app/gui -appstore-compliant || fail "macdeployqt failed!"
 
 echo Removing dSYM files from app bundle


### PR DESCRIPTION
## 改了啥呀

- 把剪贴板同步从主进程 SDL 串流循环里拆到 `moonlight-clipboard-helper` 子进程，helper 自己跑 `QGuiApplication` 事件循环。
- 主进程新增 `ClipboardHelperClient`，通过 JSON line IPC 转发 host/local clipboard frame，并处理 READY 握手、队列上限、协议错误日志和有限重启。
- `ClipboardSync` 降成纯剪贴板引擎，不再直接依赖 Limelight、SDL、NvComputer 或 IdentityManager。
- 串流循环不再为了剪贴板长期 pump Qt events，只保留 overlay/toast 可见时的 UI 事件处理。
- 补强卡键恢复路径：发送 key-up 失败时保留待释放按键，重连前后都尝试释放。
- 把 helper 接进 qmake、Windows deploy 脚本和 macOS dmg 打包流程。

## 为啥要改

之前为了让剪贴板同步在 streaming 期间工作，主串流循环会持续 `QCoreApplication::processEvents()`。这个状态很容易跟 SDL/input/control thread 混在一起，杂鱼事件循环一搅和，就可能让卡键问题变得更难复现也更难兜底。

现在剪贴板 GUI 事件循环被关进 helper 子进程，主串流线程只轮询 pipe 和转发 Limelight clipboard frame。剪贴板崩了也不会把串流主循环一起拖下水，边界清楚很多。

## 验证

- `git diff --check`
- `nmake /f Makefile sub-app-release`，在 VS 2022 amd64 环境下通过

备注：构建时仍有 Qt 自带 `Qt6EntryPoint.lib` 的 `/guard:ehcont` 链接警告，和本次代码无关。