### PR TITLE
fix(clipboard): keep macOS helper in background

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -16,10 +16,15 @@
 #include <QRegularExpression>
 #include <QSslConfiguration>
 #include <QSslError>
+#include <QTimer>
 #include <QUrl>
 #include <QtEndian>
 
 #include <cstring>
+
+#ifdef Q_OS_MACOS
+extern "C" int ClipboardHelperPasteboardChangeCount();
+#endif
 
 namespace {
 bool isImageLikeMimeFormat(const QString& format)
@@ -104,6 +109,16 @@ void ClipboardSync::start()
             this, &ClipboardSync::onLocalClipboardChanged,
             Qt::UniqueConnection);
 
+#ifdef Q_OS_MACOS
+    m_LastPasteboardChangeCount = ClipboardHelperPasteboardChangeCount();
+    if (m_PasteboardPollTimer == nullptr) {
+        m_PasteboardPollTimer = new QTimer(this);
+        connect(m_PasteboardPollTimer, &QTimer::timeout,
+                this, &ClipboardSync::pollPasteboardChangeCount);
+    }
+    m_PasteboardPollTimer->start(500);
+#endif
+
     m_Active = true;
     ClipboardLog::info("ClipboardSync: started (text + PNG, bidirectional)");
 }
@@ -122,6 +137,12 @@ void ClipboardSync::stop()
 
     m_EchoCache.clear();
     m_PendingSelfWrites = 0;
+#ifdef Q_OS_MACOS
+    if (m_PasteboardPollTimer != nullptr) {
+        m_PasteboardPollTimer->stop();
+    }
+    m_LastPasteboardChangeCount = -1;
+#endif
     m_Active = false;
 
     ClipboardLog::info("ClipboardSync: stopped");
@@ -138,6 +159,32 @@ void ClipboardSync::handleIncomingFrame(const char* data, int length)
     QMetaObject::invokeMethod(this, "onIncomingFrame", Qt::QueuedConnection,
                               Q_ARG(QByteArray, frame));
 }
+
+#ifdef Q_OS_MACOS
+void ClipboardSync::pollPasteboardChangeCount()
+{
+    if (!m_Active) {
+        return;
+    }
+
+    int changeCount = ClipboardHelperPasteboardChangeCount();
+    if (changeCount < 0) {
+        return;
+    }
+
+    if (m_LastPasteboardChangeCount < 0) {
+        m_LastPasteboardChangeCount = changeCount;
+        return;
+    }
+
+    if (changeCount == m_LastPasteboardChangeCount) {
+        return;
+    }
+
+    m_LastPasteboardChangeCount = changeCount;
+    onLocalClipboardChanged();
+}
+#endif
 
 void ClipboardSync::onIncomingFrame(QByteArray frame)
 {

--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -105,18 +105,21 @@ void ClipboardSync::start()
         return;
     }
 
-    connect(cb, &QClipboard::dataChanged,
-            this, &ClipboardSync::onLocalClipboardChanged,
-            Qt::UniqueConnection);
-
 #ifdef Q_OS_MACOS
     m_LastPasteboardChangeCount = ClipboardHelperPasteboardChangeCount();
+    connect(cb, &QClipboard::dataChanged,
+            this, &ClipboardSync::onMacClipboardDataChanged,
+            Qt::UniqueConnection);
     if (m_PasteboardPollTimer == nullptr) {
         m_PasteboardPollTimer = new QTimer(this);
         connect(m_PasteboardPollTimer, &QTimer::timeout,
                 this, &ClipboardSync::pollPasteboardChangeCount);
     }
     m_PasteboardPollTimer->start(500);
+#else
+    connect(cb, &QClipboard::dataChanged,
+            this, &ClipboardSync::onLocalClipboardChanged,
+            Qt::UniqueConnection);
 #endif
 
     m_Active = true;
@@ -131,8 +134,13 @@ void ClipboardSync::stop()
 
     QClipboard* cb = QGuiApplication::clipboard();
     if (cb != nullptr) {
+#ifdef Q_OS_MACOS
+        disconnect(cb, &QClipboard::dataChanged,
+                   this, &ClipboardSync::onMacClipboardDataChanged);
+#else
         disconnect(cb, &QClipboard::dataChanged,
                    this, &ClipboardSync::onLocalClipboardChanged);
+#endif
     }
 
     m_EchoCache.clear();
@@ -161,6 +169,16 @@ void ClipboardSync::handleIncomingFrame(const char* data, int length)
 }
 
 #ifdef Q_OS_MACOS
+void ClipboardSync::onMacClipboardDataChanged()
+{
+    int changeCount = ClipboardHelperPasteboardChangeCount();
+    if (changeCount >= 0) {
+        m_LastPasteboardChangeCount = changeCount;
+    }
+
+    onLocalClipboardChanged();
+}
+
 void ClipboardSync::pollPasteboardChangeCount()
 {
     if (!m_Active) {

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -101,6 +101,12 @@ signals:
     void outboundFrame(QByteArray frame);
 
 private slots:
+#ifdef Q_OS_MACOS
+    // QClipboard::dataChanged wrapper that keeps the native pasteboard
+    // changeCount baseline in sync before processing the clipboard.
+    void onMacClipboardDataChanged();
+#endif
+
     // QClipboard::dataChanged -> emitted on GUI thread.
     void onLocalClipboardChanged();
 

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -16,6 +16,7 @@ class QMimeData;
 class QNetworkAccessManager;
 class QNetworkReply;
 class QSslError;
+class QTimer;
 
 struct ClipboardSyncHostContext
 {
@@ -103,6 +104,12 @@ private slots:
     // QClipboard::dataChanged -> emitted on GUI thread.
     void onLocalClipboardChanged();
 
+#ifdef Q_OS_MACOS
+    // macOS does not reliably emit QClipboard::dataChanged for external
+    // pasteboard changes while the helper is a background accessory process.
+    void pollPasteboardChangeCount();
+#endif
+
     // Queued slot used by handleIncomingFrame() to deliver to GUI thread.
     void onIncomingFrame(QByteArray frame);
 
@@ -151,6 +158,11 @@ private:
 
     bool m_Active = false;
     QQueue<QPair<uint64_t, qint64>> m_EchoCache; // (hash, timestamp_ms)
+
+#ifdef Q_OS_MACOS
+    QTimer* m_PasteboardPollTimer = nullptr;
+    int m_LastPasteboardChangeCount = -1;
+#endif
 
     // Counter for self-writes pending QClipboard::dataChanged callbacks.
     // Some Windows clipboard hooks (e.g. IME composition managers) cause a

--- a/clipboard-helper/clipboard-helper.pro
+++ b/clipboard-helper/clipboard-helper.pro
@@ -14,6 +14,8 @@ SOURCES += \
     ../app/streaming/clipboardipc.cpp \
     ../app/streaming/clipboardsync.cpp
 
+macx:SOURCES += macos.mm
+
 HEADERS += \
     ../app/streaming/clipboardipc.h \
     ../app/streaming/clipboardlogging.h \

--- a/clipboard-helper/macos.mm
+++ b/clipboard-helper/macos.mm
@@ -1,0 +1,11 @@
+#import <AppKit/AppKit.h>
+
+extern "C" void ClipboardHelperSetBackgroundActivationPolicy()
+{
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+}
+
+extern "C" int ClipboardHelperPasteboardChangeCount()
+{
+    return static_cast<int>([[NSPasteboard generalPasteboard] changeCount]);
+}

--- a/clipboard-helper/main.cpp
+++ b/clipboard-helper/main.cpp
@@ -13,6 +13,10 @@
 #include <iostream>
 #include <string>
 
+#ifdef Q_OS_MACOS
+extern "C" void ClipboardHelperSetBackgroundActivationPolicy();
+#endif
+
 class StdinReaderThread : public QThread
 {
     Q_OBJECT
@@ -144,6 +148,9 @@ private:
 int main(int argc, char* argv[])
 {
     QGuiApplication app(argc, argv);
+#ifdef Q_OS_MACOS
+    ClipboardHelperSetBackgroundActivationPolicy();
+#endif
     QCoreApplication::setApplicationName(QStringLiteral("Moonlight Clipboard Helper"));
     QCoreApplication::setOrganizationName(QStringLiteral("Moonlight Game Streaming Project"));
 


### PR DESCRIPTION
## 改了啥呀

- macOS 下把 `moonlight-clipboard-helper` 设置为 accessory activation policy，避免 helper 作为第二个 Dock 图标出现。
- macOS helper 增加 `NSPasteboard.changeCount` 轮询；当 Qt 的 `QClipboard::dataChanged` 没有可靠收到外部剪贴板变化时，也能检测客户端本地复制并发出 `localFrame`。
- 轮询只在 changeCount 变化时触发，不会对同一份剪贴板内容定时重复发送，杂鱼重复同步退退退。

## 为啥要改

#107 把剪贴板同步放进独立 helper 后，macOS 会把这个 `QGuiApplication` helper 当成普通前台 app，于是 Dock 上出现两个图标。同时，后台 helper 不能完全依赖 Qt 的剪贴板变化信号，导致主机到客户端可用，但客户端到主机可能不触发发送。

这个补丁把 helper 后台化，并用 macOS 原生 pasteboard change count 补上本地变化检测。

## 验证

- `git diff --check origin/master..HEAD`
- Windows 本地构建 `moonlight-clipboard-helper.exe`
- helper IPC 冒烟：发送 CONFIG，收到 READY，sequence `4294967295` 正确回显
- helper outbound 冒烟：临时设置客户端剪贴板文本，收到 `localFrame`，payload 匹配，STOP 后 exit code 0

备注：macOS 的 AppKit `.mm` 编译和实际 Dock 行为需要 GitHub macOS CI / 真实 macOS 客户端再确认。