### PR TITLE
fix(streaming): isolate microphone processing

### DIFF
--- a/app/streaming/micstream.cpp
+++ b/app/streaming/micstream.cpp
@@ -80,22 +80,14 @@ public:
         }
 
         if (!device.isFormatSupported(fmt)) {
-            qWarning() << "[MicStream] Requested audio format not supported by default device, attempting fallbacks";
-            QAudioFormat fmt2 = fmt;
-            fmt2.setSampleRate(44100);
-            if (device.isFormatSupported(fmt2)) {
-                fmt = fmt2;
-                qInfo() << "[MicStream] Falling back to 44100 Hz";
-            } else {
-                QAudioFormat fmt3 = fmt;
-                fmt3.setChannelCount(2);
-                if (device.isFormatSupported(fmt3)) {
-                    fmt = fmt3;
-                    qInfo() << "[MicStream] Falling back to stereo 48000";
-                } else {
-                    qWarning() << "[MicStream] No compatible fallback format found; will still attempt start and log errors";
-                }
-            }
+            const QAudioFormat preferredFormat = device.preferredFormat();
+            qWarning() << "[MicStream] Default audio input does not support required format: 48000 Hz mono Int16"
+                       << "device=" << device.description()
+                       << "preferred=" << preferredFormat.sampleRate() << "Hz"
+                       << preferredFormat.channelCount() << "channels"
+                       << "sampleFormat=" << preferredFormat.sampleFormat();
+            cleanupAudioResources();
+            return false;
         }
 
         qInfo() << "[MicStream] Using audio input device:" << device.description()

--- a/app/streaming/micstream.cpp
+++ b/app/streaming/micstream.cpp
@@ -2,14 +2,17 @@
 #include "macpermissions.h"
 
 #include <opus.h>
-#include <QtEndian>
-#include <QRandomGenerator>
-#include <QAudioFormat>
-#include <QAudioDevice>
-#include <QMediaDevices>
 #include <QAudio>
-#include <QList>
+#include <QAudioDevice>
+#include <QAudioFormat>
+#include <QAudioSource>
 #include <QDebug>
+#include <QElapsedTimer>
+#include <QIODevice>
+#include <QMediaDevices>
+#include <QQueue>
+#include <QThread>
+#include <QTimer>
 
 extern "C" {
 #include <Input.h>
@@ -23,24 +26,312 @@ int sendMicrophoneOpusData(const unsigned char* opusData, int opusLength);
 static const int PCM_FRAME_SAMPLES = 960; // 20 ms at 48 kHz
 static const int PCM_FRAME_SIZE = PCM_FRAME_SAMPLES * 2; // mono 16-bit
 static const int MAX_OPUS_SIZE = 4000;
+static const int MAX_PENDING_PCM_FRAMES = 10;
+static const int MAX_PENDING_OPUS_FRAMES = 10;
+static const int MAX_ENCODE_FRAMES_PER_PASS = 4;
+static const int MAX_SEND_FRAMES_PER_PASS = 4;
+
+class MicStreamWorker : public QObject
+{
+public:
+    MicStreamWorker()
+        : m_audioInput(nullptr),
+          m_audioDevice(nullptr),
+          m_encoder(nullptr),
+          m_sendTimer(nullptr),
+          m_logTimer(nullptr),
+          m_streamInitialized(false),
+          m_audioContinuationPending(false),
+          m_pcmBytes(0),
+          m_opusBytes(0),
+          m_sentBytes(0),
+          m_sentPackets(0),
+          m_idleLoops(0),
+          m_droppedPcmFrames(0),
+          m_droppedOpusFrames(0),
+          m_maxAudioCallbackMs(0)
+    {
+    }
+
+    bool start()
+    {
+        Q_ASSERT(QThread::currentThread() == thread());
+        if (m_audioInput)
+            return false;
+
+        int err;
+        m_encoder = opus_encoder_create(48000, 1, OPUS_APPLICATION_VOIP, &err);
+        if (err != OPUS_OK) {
+            m_encoder = nullptr;
+            return false;
+        }
+        opus_encoder_ctl(m_encoder, OPUS_SET_BITRATE(64000));
+
+        QAudioFormat fmt;
+        fmt.setSampleRate(48000);
+        fmt.setChannelCount(1);
+        fmt.setSampleFormat(QAudioFormat::Int16);
+
+        QAudioDevice device = QMediaDevices::defaultAudioInput();
+        if (device.isNull()) {
+            qWarning() << "[MicStream] No default audio input device available";
+            cleanupAudioResources();
+            return false;
+        }
+
+        if (!device.isFormatSupported(fmt)) {
+            qWarning() << "[MicStream] Requested audio format not supported by default device, attempting fallbacks";
+            QAudioFormat fmt2 = fmt;
+            fmt2.setSampleRate(44100);
+            if (device.isFormatSupported(fmt2)) {
+                fmt = fmt2;
+                qInfo() << "[MicStream] Falling back to 44100 Hz";
+            } else {
+                QAudioFormat fmt3 = fmt;
+                fmt3.setChannelCount(2);
+                if (device.isFormatSupported(fmt3)) {
+                    fmt = fmt3;
+                    qInfo() << "[MicStream] Falling back to stereo 48000";
+                } else {
+                    qWarning() << "[MicStream] No compatible fallback format found; will still attempt start and log errors";
+                }
+            }
+        }
+
+        qInfo() << "[MicStream] Using audio input device:" << device.description()
+                << "format=" << fmt.sampleRate() << "Hz" << fmt.channelCount() << "channels";
+
+        m_audioInput = new QAudioSource(device, fmt, this);
+        m_audioInput->setBufferSize(PCM_FRAME_SIZE * 4);
+        connect(m_audioInput, &QAudioSource::stateChanged, this, [this](QAudio::State state) {
+            qInfo() << "[MicStream] Audio state changed state=" << state
+                    << "error=" << m_audioInput->error();
+        });
+
+        m_audioDevice = m_audioInput->start();
+        if (!m_audioDevice || m_audioInput->error() != QAudio::NoError) {
+            qWarning() << "[MicStream] Failed to start audio device error=" << m_audioInput->error();
+            cleanupAudioResources();
+            return false;
+        }
+
+        qInfo() << "[MicStream] Audio device initialized successfully";
+        connect(m_audioDevice, &QIODevice::readyRead, this, &MicStreamWorker::onAudio);
+
+        if (initializeMicrophoneStream() != 0) {
+            qWarning() << "[MicStream] initializeMicrophoneStream failed";
+            cleanupAudioResources();
+            return false;
+        }
+        m_streamInitialized = true;
+
+        resetStatistics();
+        m_partialBuffer.clear();
+        m_queue.clear();
+        m_audioContinuationPending = false;
+
+        m_sendTimer = new QTimer(this);
+        m_sendTimer->setInterval(20);
+        connect(m_sendTimer, &QTimer::timeout, this, &MicStreamWorker::sendLoop);
+        m_sendTimer->start();
+
+        m_logTimer = new QTimer(this);
+        m_logTimer->setInterval(5000);
+        connect(m_logTimer, &QTimer::timeout, this, &MicStreamWorker::logSummary);
+        m_logTimer->start();
+
+        qInfo() << "[MicStream] start thread=" << QThread::currentThread()->objectName();
+        return true;
+    }
+
+    void stop()
+    {
+        Q_ASSERT(QThread::currentThread() == thread());
+        if (!m_audioInput && !m_encoder && !m_streamInitialized)
+            return;
+
+        if (m_sendTimer)
+            m_sendTimer->stop();
+        if (m_logTimer)
+            m_logTimer->stop();
+        logSummary();
+        cleanupAudioResources();
+
+        if (m_streamInitialized) {
+            destroyMicrophoneStream();
+            m_streamInitialized = false;
+        }
+
+        m_partialBuffer.clear();
+        m_queue.clear();
+        m_audioContinuationPending = false;
+        qInfo() << "[MicStream] stop";
+    }
+
+private:
+    void cleanupAudioResources()
+    {
+        if (m_audioInput) {
+            m_audioInput->stop();
+            delete m_audioInput;
+            m_audioInput = nullptr;
+            m_audioDevice = nullptr;
+        }
+        if (m_encoder) {
+            opus_encoder_destroy(m_encoder);
+            m_encoder = nullptr;
+        }
+    }
+
+    void onAudio()
+    {
+        if (!m_audioDevice || !m_encoder)
+            return;
+
+        QElapsedTimer callbackTimer;
+        callbackTimer.start();
+
+        QByteArray chunk = m_audioDevice->readAll();
+        if (!chunk.isEmpty()) {
+            m_partialBuffer.append(chunk);
+            trimPcmBacklog();
+            processPendingAudio();
+        }
+
+        m_maxAudioCallbackMs = qMax(m_maxAudioCallbackMs, callbackTimer.elapsed());
+    }
+
+    void trimPcmBacklog()
+    {
+        const int maxBytes = MAX_PENDING_PCM_FRAMES * PCM_FRAME_SIZE;
+        if (m_partialBuffer.size() <= maxBytes)
+            return;
+
+        const int excessBytes = m_partialBuffer.size() - maxBytes;
+        const int framesToDrop = (excessBytes + PCM_FRAME_SIZE - 1) / PCM_FRAME_SIZE;
+        const int completeBytes = m_partialBuffer.size() - (m_partialBuffer.size() % PCM_FRAME_SIZE);
+        const int bytesToDrop = qMin(framesToDrop * PCM_FRAME_SIZE, completeBytes);
+        m_partialBuffer.remove(0, bytesToDrop);
+        m_droppedPcmFrames += bytesToDrop / PCM_FRAME_SIZE;
+    }
+
+    void processPendingAudio()
+    {
+        if (!m_encoder)
+            return;
+
+        int processedFrames = 0;
+        while (m_partialBuffer.size() >= PCM_FRAME_SIZE &&
+               processedFrames < MAX_ENCODE_FRAMES_PER_PASS) {
+            QByteArray pcm = m_partialBuffer.left(PCM_FRAME_SIZE);
+            m_partialBuffer.remove(0, PCM_FRAME_SIZE);
+            m_pcmBytes += pcm.size();
+
+            unsigned char encoded[MAX_OPUS_SIZE];
+            int len = opus_encode(m_encoder,
+                                  reinterpret_cast<const opus_int16*>(pcm.constData()),
+                                  PCM_FRAME_SAMPLES,
+                                  encoded,
+                                  MAX_OPUS_SIZE);
+            if (len > 0) {
+                while (m_queue.size() >= MAX_PENDING_OPUS_FRAMES) {
+                    m_queue.dequeue();
+                    m_droppedOpusFrames++;
+                }
+                m_queue.enqueue(QByteArray(reinterpret_cast<char*>(encoded), len));
+                m_opusBytes += len;
+            } else {
+                qWarning() << "[MicStream] opus_encode failed len=" << len;
+            }
+            processedFrames++;
+        }
+
+        if (m_partialBuffer.size() >= PCM_FRAME_SIZE && !m_audioContinuationPending) {
+            m_audioContinuationPending = true;
+            QTimer::singleShot(0, this, [this]() {
+                m_audioContinuationPending = false;
+                processPendingAudio();
+            });
+        }
+    }
+
+    void sendLoop()
+    {
+        if (m_queue.isEmpty()) {
+            m_idleLoops++;
+            return;
+        }
+
+        int processedFrames = 0;
+        while (!m_queue.isEmpty() && processedFrames < MAX_SEND_FRAMES_PER_PASS) {
+            QByteArray opus = m_queue.dequeue();
+            int opusLen = opus.size();
+
+            opus.resize(((opusLen + 15) / 16) * 16);
+            int rc = sendMicrophoneOpusData(reinterpret_cast<const unsigned char*>(opus.data()), opusLen);
+            if (rc < 0) {
+                qWarning() << "[MicStream] sendMicrophoneOpusData failed rc=" << rc;
+            } else {
+                m_sentPackets++;
+                m_sentBytes += opusLen;
+            }
+            processedFrames++;
+        }
+    }
+
+    void logSummary()
+    {
+        const int state = m_audioInput ? static_cast<int>(m_audioInput->state()) : -1;
+        const int error = m_audioInput ? static_cast<int>(m_audioInput->error()) : -1;
+        qInfo() << "[MicStream] 5s summary pcm=" << m_pcmBytes
+                << "B opus=" << m_opusBytes
+                << "B sent=" << m_sentPackets << "/" << m_sentBytes
+                << "B idle=" << m_idleLoops
+                << "queue=" << m_queue.size()
+                << "pcmDrop=" << m_droppedPcmFrames
+                << "opusDrop=" << m_droppedOpusFrames
+                << "maxAudioMs=" << m_maxAudioCallbackMs
+                << "state=" << state
+                << "error=" << error;
+        resetStatistics();
+    }
+
+    void resetStatistics()
+    {
+        m_pcmBytes = 0;
+        m_opusBytes = 0;
+        m_sentBytes = 0;
+        m_sentPackets = 0;
+        m_idleLoops = 0;
+        m_droppedPcmFrames = 0;
+        m_droppedOpusFrames = 0;
+        m_maxAudioCallbackMs = 0;
+    }
+
+    QAudioSource *m_audioInput;
+    QIODevice *m_audioDevice;
+    OpusEncoder *m_encoder;
+    QTimer *m_sendTimer;
+    QTimer *m_logTimer;
+    QQueue<QByteArray> m_queue;
+    bool m_streamInitialized;
+    bool m_audioContinuationPending;
+    quint64 m_pcmBytes;
+    quint64 m_opusBytes;
+    quint64 m_sentBytes;
+    int m_sentPackets;
+    int m_idleLoops;
+    int m_droppedPcmFrames;
+    int m_droppedOpusFrames;
+    qint64 m_maxAudioCallbackMs;
+    QByteArray m_partialBuffer;
+};
 
 MicStream::MicStream(QObject *parent)
     : QObject(parent),
-    m_audioInput(nullptr),
-    m_audioDevice(nullptr),
-    m_encoder(nullptr),
-    m_seq(0),
-    m_timestamp(0),
-    m_ssrc(0),
-    m_pcmBytes(0),
-    m_opusBytes(0),
-    m_sentBytes(0),
-    m_sentPackets(0),
-    m_idleLoops(0)
+      m_thread(nullptr),
+      m_worker(nullptr)
 {
-    connect(&m_sendTimer, &QTimer::timeout, this, &MicStream::sendLoop);
-    m_logTimer.setInterval(5000);
-    connect(&m_logTimer, &QTimer::timeout, this, &MicStream::logSummary);
 }
 
 MicStream::~MicStream()
@@ -50,200 +341,56 @@ MicStream::~MicStream()
 
 bool MicStream::start()
 {
-    if (m_audioInput)
+    if (m_thread)
         return false;
 
-    // On macOS, request microphone permission once via AVCaptureDevice
-    // *before* touching QMediaDevices / CoreAudio to avoid multiple
-    // TCC dialogs (especially with universal binaries).
+    // Keep the macOS permission request on the application thread. Touching
+    // QMediaDevices and creating QAudioSource happens in the worker thread.
     if (!checkAndRequestMicrophonePermission()) {
         qWarning() << "[MicStream] Microphone permission denied";
         return false;
     }
 
-    int err;
-    m_encoder = opus_encoder_create(48000, 1, OPUS_APPLICATION_VOIP, &err);
-    if (err != OPUS_OK)
-        return false;
-    opus_encoder_ctl(m_encoder, OPUS_SET_BITRATE(64000));
+    QThread *thread = new QThread(this);
+    thread->setObjectName("Microphone Streaming Thread");
+    MicStreamWorker *worker = new MicStreamWorker();
+    worker->moveToThread(thread);
+    connect(thread, &QThread::finished, worker, &QObject::deleteLater);
+    thread->start();
 
-    QAudioFormat fmt;
-    fmt.setSampleRate(48000);
-    fmt.setChannelCount(1);
-    fmt.setSampleFormat(QAudioFormat::Int16);
+    bool started = false;
+    const bool invoked = QMetaObject::invokeMethod(worker, [worker, &started]() {
+        started = worker->start();
+    }, Qt::BlockingQueuedConnection);
 
-    // Obtain the default input device once and reuse it for format
-    // checks, logging, and the actual QAudioSource to avoid redundant
-    // QMediaDevices calls that can each trigger a macOS TCC prompt.
-    QAudioDevice device = QMediaDevices::defaultAudioInput();
-    if (device.isNull()) {
-        qWarning() << "[MicStream] No default audio input device available";
-        opus_encoder_destroy(m_encoder);
-        m_encoder = nullptr;
+    if (!invoked || !started) {
+        qWarning() << "[MicStream] Failed to start microphone worker";
+        thread->quit();
+        thread->wait();
+        delete thread;
         return false;
     }
 
-    if (!device.isFormatSupported(fmt)) {
-        qWarning() << "[MicStream] Requested audio format not supported by default device, attempting fallbacks";
-        // try common fallbacks
-        QAudioFormat fmt2 = fmt;
-        fmt2.setSampleRate(44100);
-        if (device.isFormatSupported(fmt2)) {
-            fmt = fmt2;
-            qInfo() << "[MicStream] Falling back to 44100 Hz";
-        } else {
-            // try stereo 48000 then
-            QAudioFormat fmt3 = fmt;
-            fmt3.setChannelCount(2);
-            if (device.isFormatSupported(fmt3)) {
-                fmt = fmt3;
-                qInfo() << "[MicStream] Falling back to stereo 48000";
-            } else {
-                qWarning() << "[MicStream] No compatible fallback format found; will still attempt start and log errors";
-            }
-        }
-    }
-
-    qInfo() << "[MicStream] Using audio input device:" << device.description();
-
-    m_audioInput = new QAudioSource(device, fmt, this);
-    // make buffer at least one PCM frame or a few frames to smooth reads
-    m_audioInput->setBufferSize(PCM_FRAME_SIZE * 4);
-    m_audioDevice = m_audioInput->start();
-    if (!m_audioDevice || m_audioInput->error() != QAudio::NoError) {
-        qWarning() << "[MicStream] Failed to start audio device error=" << m_audioInput->error();
-        delete m_audioInput;
-        m_audioInput = nullptr;
-        return false;
-    }
-
-    qInfo() << "[MicStream] Audio device initialized successfully";
-
-    connect(m_audioDevice, &QIODevice::readyRead, this, &MicStream::onAudio);
-
-    if (initializeMicrophoneStream() != 0) {
-        qWarning() << "[MicStream] initializeMicrophoneStream failed";
-        m_audioInput->stop();
-        delete m_audioInput;
-        m_audioInput = nullptr;
-        opus_encoder_destroy(m_encoder);
-        m_encoder = nullptr;
-        return false;
-    }
-
-    m_seq = 0;
-    m_timestamp = 0;
-    m_ssrc = QRandomGenerator::global()->generate();
-
-    qInfo() << "[MicStream] start";
-
-    m_sendTimer.start(20);
-    m_logTimer.start();
-    m_pcmBytes = 0;
-    m_opusBytes = 0;
-    m_sentBytes = 0;
-    m_sentPackets = 0;
-    m_idleLoops = 0;
+    m_thread = thread;
+    m_worker = worker;
     return true;
 }
 
 void MicStream::stop()
 {
-    m_sendTimer.stop();
-    m_logTimer.stop();
-    logSummary();
-    if (m_audioInput) {
-        m_audioInput->stop();
-        delete m_audioInput;
-        m_audioInput = nullptr;
-        m_audioDevice = nullptr;
-    }
-    if (m_encoder) {
-        opus_encoder_destroy(m_encoder);
-        m_encoder = nullptr;
-    }
-
-    destroyMicrophoneStream();
-    m_queue.clear();
-
-    qInfo() << "[MicStream] stop";
-}
-
-void MicStream::onAudio()
-{
-    // accumulate partial reads to form complete PCM frames
-    if (!m_audioDevice)
+    if (!m_thread)
         return;
 
-    QByteArray chunk = m_audioDevice->readAll();
-    if (chunk.isEmpty()) {
-        return;
-    }
-    // append to partial buffer
-    m_partialBuffer.append(chunk);
-    while (m_partialBuffer.size() >= PCM_FRAME_SIZE) {
-        QByteArray pcm = m_partialBuffer.left(PCM_FRAME_SIZE);
-        m_partialBuffer.remove(0, PCM_FRAME_SIZE);
-        if (pcm.size() < PCM_FRAME_SIZE) {
-            qWarning() << "[MicStream] PCM underrun after assembly read=" << pcm.size() << " expected=" << PCM_FRAME_SIZE;
-            break;
-        }
-        m_pcmBytes += pcm.size();
-
-        unsigned char encoded[MAX_OPUS_SIZE];
-        int len = opus_encode(m_encoder,
-                              reinterpret_cast<const opus_int16*>(pcm.constData()),
-                              PCM_FRAME_SAMPLES,
-                              encoded,
-                              MAX_OPUS_SIZE);
-        if (len > 0) {
-            m_queue.enqueue(QByteArray(reinterpret_cast<char*>(encoded), len));
-            m_opusBytes += len;
-        } else {
-            qWarning() << "[MicStream] opus_encode failed len=" << len;
-        }
-    }
-}
-
-void MicStream::sendLoop()
-{
-    if (m_queue.isEmpty()) {
-        m_idleLoops++;
-        return;
+    Q_ASSERT(QThread::currentThread() != m_thread);
+    if (m_worker && m_thread->isRunning()) {
+        QMetaObject::invokeMethod(m_worker, [worker = m_worker]() {
+            worker->stop();
+        }, Qt::BlockingQueuedConnection);
     }
 
-    while (!m_queue.isEmpty()) {
-        QByteArray opus = m_queue.dequeue();
-        int opusLen = opus.size();
-
-        // PltEncryptMessage with CIPHER_FLAG_PAD_TO_BLOCK_SIZE writes PKCS7
-        // padding in-place past the input buffer. Reserve extra space so the
-        // underlying buffer can absorb up to 15 bytes of padding without
-        // overwriting adjacent heap memory.
-        opus.resize(((opusLen + 15) / 16) * 16);
-
-        // sendMicrophoneOpusData handles RTP header and encryption internally
-        int rc = sendMicrophoneOpusData(reinterpret_cast<const unsigned char*>(opus.data()), opusLen);
-        if (rc < 0) {
-            qWarning() << "[MicStream] sendMicrophoneOpusData failed rc=" << rc;
-            continue;
-        }
-        m_sentPackets++;
-        m_sentBytes += opusLen;
-        m_timestamp += PCM_FRAME_SAMPLES;
-    }
-}
-
-void MicStream::logSummary()
-{
-    qInfo() << "[MicStream] 5s summary pcm=" << m_pcmBytes
-            << "B opus=" << m_opusBytes
-            << "B sent=" << m_sentPackets << "/" << m_sentBytes
-            << "B idle=" << m_idleLoops
-            << "queue=" << m_queue.size();
-    m_pcmBytes = 0;
-    m_opusBytes = 0;
-    m_sentBytes = 0;
-    m_sentPackets = 0;
-    m_idleLoops = 0;
+    m_thread->quit();
+    m_thread->wait();
+    delete m_thread;
+    m_thread = nullptr;
+    m_worker = nullptr;
 }

--- a/app/streaming/micstream.h
+++ b/app/streaming/micstream.h
@@ -1,11 +1,8 @@
 #pragma once
 
 #include <QObject>
-#include <QAudioSource>
-#include <QTimer>
-#include <QQueue>
-
-struct OpusEncoder;
+class QThread;
+class MicStreamWorker;
 
 class MicStream : public QObject
 {
@@ -18,26 +15,7 @@ public:
     bool start();
     void stop();
 
-private slots:
-    void onAudio();
-    void sendLoop();
-    void logSummary();
-
 private:
-    QAudioSource *m_audioInput;
-    QIODevice *m_audioDevice;
-    OpusEncoder *m_encoder;
-    QTimer m_sendTimer;
-    QTimer m_logTimer;
-    QQueue<QByteArray> m_queue;
-    quint16 m_seq;
-    quint32 m_timestamp;
-    quint32 m_ssrc;
-
-    quint64 m_pcmBytes;
-    quint64 m_opusBytes;
-    quint64 m_sentBytes;
-    int m_sentPackets;
-    int m_idleLoops;
-    QByteArray m_partialBuffer;
+    QThread *m_thread;
+    MicStreamWorker *m_worker;
 };


### PR DESCRIPTION
## 改了啥呢

- 把 `QAudioSource`、Opus 编码和麦克风数据发送挪到独立工作线程
- 为 PCM 和 Opus 队列加上约 200 ms 的积压上限，过载时丢弃旧帧
- 限制单次编码和发送的处理量，避免麦克风任务长期占住事件循环
- 增加音频状态、错误、丢帧数和最大回调耗时日志
- 补上音频设备启动失败时遗漏的 Opus encoder 释放

## 为啥要改

Issue #113 中有用户在启用麦克风约 1.5 小时后遇到“画面正常但界面无法交互”。视频线程仍然工作，更像是麦克风采集、编码或发送拖住了 UI/SDL 主线程。

现在这些实时任务都有自己的事件循环。就算音频后端偶尔卡顿，UI 也不用陪它一起罚站啦，杂鱼阻塞退散。

## 验证

- `git diff --cached --check`
- Qt 6.9.2 + MSVC 2022：应用编译并链接成功
- GitHub Actions：Windows、macOS、Linux、Steam Link 全部通过
- 分支已更新到同步后的最新 `master`

Related to #113