### PR TITLE
fix: 修复 300ms 内离开浮动面板不会收回的 bug

### DIFF
--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -6,7 +6,6 @@
 #include <QPainterPath>
 #include <QCursor>
 #include <QFontDatabase>
-#include <QTimer>
 #include <memory>
 
 OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
@@ -106,6 +105,13 @@ OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
     connect(m_ContentSlideAnim, &QVariantAnimation::finished, this, [this]() {
         m_ContentOffset = 0;
         forceRepaint();
+    });
+
+    m_LeaveTimer.setSingleShot(true);
+    connect(&m_LeaveTimer, &QTimer::timeout, this, [this]() {
+        if (m_Visible && !geometry().contains(QCursor::pos())) {
+            closeMenu();
+        }
     });
 
     buildMenuLevels();
@@ -332,6 +338,7 @@ void OverlayMenuPanel::showAtCursor(int parentX, int parentY, int parentW, int p
 
 void OverlayMenuPanel::showInternal()
 {
+    m_LeaveTimer.stop();
     m_CurrentLevel = 0;
     m_HoveredIndex = -1;
     m_ContentOffset = 0;
@@ -448,6 +455,7 @@ void OverlayMenuPanel::navigateToLevel(int level)
 {
     if (level < 0 || level >= (int)m_MenuLevels.size()) return;
 
+    m_LeaveTimer.stop();
     bool goingForward = level > m_CurrentLevel;
     m_ContentSlideAnim->stop();
     m_ContentOffset = 0;
@@ -479,6 +487,7 @@ void OverlayMenuPanel::navigateToLevel(int level)
 
 void OverlayMenuPanel::closeMenu()
 {
+    m_LeaveTimer.stop();
     if (!m_Visible) return;
     if (m_Closing) return;  // already animating close
 
@@ -1003,14 +1012,7 @@ bool OverlayMenuPanel::event(QEvent* ev)
             constexpr qint64 LeaveGracePeriodMs = 300;
             const qint64 elapsed = m_ShowTimer.elapsed();
             if (elapsed < LeaveGracePeriodMs) {
-                QTimer::singleShot(static_cast<int>(LeaveGracePeriodMs - elapsed + 1),
-                                   this, [this]() {
-                    if (m_Visible &&
-                            m_ShowTimer.elapsed() >= LeaveGracePeriodMs &&
-                            !geometry().contains(QCursor::pos())) {
-                        closeMenu();
-                    }
-                });
+                m_LeaveTimer.start(static_cast<int>(LeaveGracePeriodMs - elapsed + 1));
                 return true;
             }
             // Verify cursor is actually outside (cursor warp may lag)

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -6,6 +6,7 @@
 #include <QPainterPath>
 #include <QCursor>
 #include <QFontDatabase>
+#include <QTimer>
 #include <memory>
 
 OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
@@ -995,8 +996,19 @@ bool OverlayMenuPanel::event(QEvent* ev)
 {
     if (ev->type() == QEvent::Leave) {
         if (m_Visible) {
-            // Grace period: ignore Leave within 300ms of showing
-            if (m_ShowTimer.elapsed() < 300) {
+            // During the grace period, defer the outside check instead of
+            // dropping the Leave event. Otherwise, leaving the panel quickly
+            // after it opens would keep it visible until the cursor entered
+            // and left the panel again.
+            constexpr qint64 LeaveGracePeriodMs = 300;
+            const qint64 elapsed = m_ShowTimer.elapsed();
+            if (elapsed < LeaveGracePeriodMs) {
+                QTimer::singleShot(static_cast<int>(LeaveGracePeriodMs - elapsed + 1),
+                                   this, [this]() {
+                    if (m_Visible && !geometry().contains(QCursor::pos())) {
+                        closeMenu();
+                    }
+                });
                 return true;
             }
             // Verify cursor is actually outside (cursor warp may lag)

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -1005,7 +1005,9 @@ bool OverlayMenuPanel::event(QEvent* ev)
             if (elapsed < LeaveGracePeriodMs) {
                 QTimer::singleShot(static_cast<int>(LeaveGracePeriodMs - elapsed + 1),
                                    this, [this]() {
-                    if (m_Visible && !geometry().contains(QCursor::pos())) {
+                    if (m_Visible &&
+                            m_ShowTimer.elapsed() >= LeaveGracePeriodMs &&
+                            !geometry().contains(QCursor::pos())) {
                         closeMenu();
                     }
                 });

--- a/app/streaming/video/overlaymenupanel.h
+++ b/app/streaming/video/overlaymenupanel.h
@@ -6,6 +6,7 @@
 #include <QFont>
 #include <QSurfaceFormat>
 #include <QElapsedTimer>
+#include <QTimer>
 #include <QPropertyAnimation>
 #include <QVariantAnimation>
 #include <functional>
@@ -179,6 +180,7 @@ private:
 
     // Anti-flicker: grace period after show
     QElapsedTimer m_ShowTimer;
+    QTimer m_LeaveTimer;
 
     // Animations
     QPropertyAnimation* m_OpacityAnim;


### PR DESCRIPTION
`leave()` 信号接收后会判断是否刚开启 300ms，此时如果鼠标指针已经离开且不回来的话，就会导致附加层面板不会收回。

这个修复是通过增加一个 one shot 的 timer 来在 300ms 结束时检测是否还在上面来手动关闭。