### PR TITLE
ci(qt): upgrade desktop builds to Qt 6.11.1

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@
 **支持平台：**
 - Windows (x64/ARM64) - 使用 Qt 6.11.1
 - macOS - 使用 Qt 6.11.1
-- Linux (x86_64) - 固定使用 Qt 6.8.3
+- Linux (x86_64) - 使用 Qt 6.11.1
 - SteamLink - 交叉编译
 
 **构建产物：**
@@ -73,7 +73,7 @@
 
 3. **Qt 版本问题**：
    - Windows/macOS 使用 Qt 6.x
-   - Linux 固定使用 Qt 6.8.3
+   - Linux 使用 CI 安装的 Qt 6.x
 
 4. **依赖库构建失败**：
    - 检查网络连接（需要下载源码）
@@ -83,7 +83,7 @@
 
 - **Windows**: Visual Studio 2022, Qt 6.11.1
 - **macOS**: Xcode, Qt 6.11.1, Node.js
-- **Linux**: 完整的开发环境，Qt 6.8.3
+- **Linux**: 完整的开发环境，Qt 6.11.1
 - **所有平台**: Git, 网络访问
 
 ### 密钥配置

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,9 +12,9 @@
 - 发布 Release
 
 **支持平台：**
-- Windows (x64/ARM64) - 使用 Qt 6.8.0
-- macOS - 使用 Qt 6.6.0
-- Linux (x86_64) - 使用系统 Qt 5.15
+- Windows (x64/ARM64) - 使用 Qt 6.11.1
+- macOS - 使用 Qt 6.11.1
+- Linux (x86_64) - 固定使用 Qt 6.8.3
 - SteamLink - 交叉编译
 
 **构建产物：**
@@ -73,7 +73,7 @@
 
 3. **Qt 版本问题**：
    - Windows/macOS 使用 Qt 6.x
-   - Linux 使用系统 Qt 5.15
+   - Linux 固定使用 Qt 6.8.3
 
 4. **依赖库构建失败**：
    - 检查网络连接（需要下载源码）
@@ -81,9 +81,9 @@
 
 ### 环境要求
 
-- **Windows**: Visual Studio 2022, Qt 6.8.0
-- **macOS**: Xcode, Qt 6.6.0, Node.js
-- **Linux**: 完整的开发环境，系统 Qt 5.15
+- **Windows**: Visual Studio 2022, Qt 6.11.1
+- **macOS**: Xcode, Qt 6.11.1, Node.js
+- **Linux**: 完整的开发环境，Qt 6.8.3
 - **所有平台**: Git, 网络访问
 
 ### 密钥配置
@@ -118,4 +118,4 @@
 - 详细的错误日志
 - 优雅的失败处理
 
-这个工作流设计为开箱即用，无需额外配置即可在 GitHub Actions 中运行。 
+这个工作流设计为开箱即用，无需额外配置即可在 GitHub Actions 中运行。

--- a/.github/workflows/build-translate.yml
+++ b/.github/workflows/build-translate.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
-        version: '6.8.3'
+        version: '6.11.1'
         arch: 'win64_msvc2022_64'
         modules: 'qtmultimedia'
         cache: true

--- a/.github/workflows/build-win-mac.yml
+++ b/.github/workflows/build-win-mac.yml
@@ -51,7 +51,7 @@ jobs:
           set-env: ${{ runner.os != 'Windows' }}
           add-tools-to-path: ${{ runner.os != 'Windows' }}
           version: ${{ matrix.qt_version }}
-          modules: 'qtimageformats'
+          modules: 'qtmultimedia qtimageformats'
           aqtsource: 'git+https://github.com/miurahr/aqtinstall.git@073e34d7c2ab4ae6961ed7cca690b3abd5ba5a7e'
 
       - name: Install Qt ARM64 (Windows)
@@ -63,7 +63,7 @@ jobs:
           add-tools-to-path: false
           arch: win64_msvc2022_arm64_cross_compiled
           version: ${{ matrix.qt_version }}
-          modules: 'qtimageformats'
+          modules: 'qtmultimedia qtimageformats'
 
       - name: Build x64 binaries (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         arch: win64_msvc2022_64
         host: windows
         target: desktop
-        version: '6.8.3'
+        version: '6.11.1'
         modules: 'qtmultimedia qtimageformats'
         use-naqt: true
 
@@ -115,7 +115,7 @@ jobs:
         dir: ${{ github.workspace }}\arm64\
         host: windows
         target: desktop
-        version: '6.8.3'
+        version: '6.11.1'
         modules: 'qtmultimedia qtimageformats'
         use-naqt: true
 
@@ -181,7 +181,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.11.0'
+        version: '6.11.1'
         modules: 'qtmultimedia qtimageformats'
         cache: true
         aqtsource: 'git+https://github.com/miurahr/aqtinstall.git@073e34d7c2ab4ae6961ed7cca690b3abd5ba5a7e'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,10 +212,10 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "CI_VERSION=$VERSION" >> $GITHUB_ENV
 
-    - name: Install Qt 6.8.3
+    - name: Install Qt 6.11.1
       uses: jurplel/install-qt-action@v3
       with:
-        version: '6.8.3'
+        version: '6.11.1'
         modules: 'qtmultimedia qtimageformats'
         cache: true
 

--- a/scripts/update_translate.sh
+++ b/scripts/update_translate.sh
@@ -3,7 +3,7 @@
 # 编译所有翻译文件
 for f in app/languages/*.ts; do
     echo "Processing $f..."
-    /c/Qt/6.8.3/msvc2022_64/bin/lrelease "$f"
+    /c/Qt/6.11.1/msvc2022_64/bin/lrelease "$f"
 done
 
 echo "Translation compilation completed!"


### PR DESCRIPTION
## 改了啥呀

- 将 Windows x64/ARM64、macOS、Linux 和翻译资源 CI 统一升级到 Qt 6.11.1
- 为可复用的 Windows/macOS 工作流补齐 `qtmultimedia`，与项目实际链接模块保持一致
- 更新翻译脚本中的 `lrelease` 路径
- 同步更新 GitHub Actions 说明文档

## 为啥要改

桌面 CI 里的 Qt 版本之前各走各的，杂鱼版本漂移很容易让本机能构建、CI 却突然闹脾气。现在所有桌面构建和翻译任务统一使用当前稳定版 Qt 6.11.1，与本地开发环境保持一致。

## 验证

- `git diff --check`
- 使用 PyYAML 成功解析 5 个工作流 YAML 文件
- `bash -lc 'git show :scripts/update_translate.sh | bash -n'`
- 检查所有桌面 CI Qt 安装引用，均为 6.11.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to reflect Qt 6.11.1 support across Windows, macOS, and Linux.

* **Build & Translation Updates**
  * Standardized automated builds and translation compilation on Qt 6.11.1.
  * Added multimedia support to Windows build environments, improving compatibility with related application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->