### PR TITLE
fix(input): prevent duplicate macOS trackpad clicks

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -178,6 +178,8 @@ win32:!winrt {
     CONFIG += discord-rpc
 }
 macx {
+    DEFINES += HAVE_MACOS_NATIVE_TOUCHPAD
+
     !disable-prebuilts {
         LIBS += -lssl.3 -lcrypto.3 -lavcodec.62 -lavutil.60 -lswscale.9 -lopus.0 -lSDL2 -lSDL2_ttf -lplacebo
         CONFIG += discord-rpc libplacebo

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -713,6 +713,14 @@ int main(int argc, char *argv[])
     // initializing the SDL video subsystem to have any effect.
     SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
 
+#ifdef Q_OS_DARWIN
+    // SDL reads this hint when the video subsystem is first initialized. Set
+    // the saved preference here so the hardware capability probe cannot lock
+    // in the default mouse-only behavior before a streaming session starts.
+    SDL_SetHint(SDL_HINT_TRACKPAD_IS_TOUCH_ONLY,
+                StreamingPreferences::get()->enableNativeTouchpad ? "1" : "0");
+#endif
+
     // We use MMAL to render on Raspberry Pi, so we do not require DRM master.
     SDL_SetHint(SDL_HINT_KMSDRM_REQUIRE_DRM_MASTER, "0");
 

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -163,7 +163,7 @@ void StreamingPreferences::reload()
     absoluteMouseMode = settings.value(SER_ABSMOUSEMODE, false).toBool();
     showLocalCursor = settings.value(SER_SHOWLOCALCURSOR, false).toBool();
     absoluteTouchMode = settings.value(SER_ABSTOUCHMODE, true).toBool();
-    enableNativeTouchpad = settings.value(SER_NATIVETOUCHPAD, true).toBool();
+    enableNativeTouchpad = settings.value(SER_NATIVETOUCHPAD, false).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     videoEnhancement = settings.value(SER_VIDEOENHANCEMENT, false).toBool();
     enableMicrophone = settings.value(SER_MICROPHONE, false).toBool();

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -52,6 +52,19 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_PendingTouchpadContactCount(0),
       m_ActiveTouchpadId(0),
       m_LastTouchpadScrollTimestamp(0),
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+      m_MacTouchpadSuppressedMouseButtons(0),
+      m_MacTouchpadPendingTapButtons(0),
+      m_MacTouchpadLastTapTimestamp(0),
+      m_MacTouchpadGestureStartTimestamp(0),
+      m_MacTouchpadGesturePrimaryFinger(0),
+      m_MacTouchpadGestureStartX(0),
+      m_MacTouchpadGestureStartY(0),
+      m_MacTouchpadGestureMaxContacts(0),
+      m_MacTouchpadGestureMoved(false),
+      m_MacTouchpadGestureHadPhysicalButton(false),
+      m_MacTouchpadButtonDown(false),
+#endif
 #ifdef HAVE_WINDOWS_RAW_TOUCHPAD
       m_ActiveWindowsTouchpadDevice(0),
       m_LastWindowsTouchpadFrameTicks(0),

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -87,6 +87,15 @@ struct DualSenseOutputReport{
 
 #define TOUCHPAD_SCROLL_SUPPRESSION_TIMEOUT_MS 500
 
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+// macOS reports trackpad contacts and promoted mouse clicks through separate
+// SDL event paths. Keep the click correlation window deliberately short to
+// avoid consuming an unrelated click from a physical mouse.
+#define MACOS_TOUCHPAD_TAP_MAX_DURATION_MS 500
+#define MACOS_TOUCHPAD_CLICK_CORRELATION_TIMEOUT_MS 250
+#define MACOS_TOUCHPAD_TAP_MAX_MOVEMENT 0.01f
+#endif
+
 #define GAMEPAD_HAPTIC_METHOD_NONE 0
 #define GAMEPAD_HAPTIC_METHOD_LEFTRIGHT 1
 #define GAMEPAD_HAPTIC_METHOD_SIMPLERUMBLE 2
@@ -244,6 +253,16 @@ private:
                                     uint16_t deviceWidthMm = 0,
                                     uint16_t deviceHeightMm = 0);
 
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    void updateMacTouchpadGesture(const SDL_TouchFingerEvent* event);
+
+    bool sendMacTouchpadButtonState(bool down);
+
+    bool shouldSuppressMacTouchpadMouseButtonEvent(const SDL_MouseButtonEvent* event);
+
+    void resetMacTouchpadState();
+#endif
+
 #ifdef HAVE_WINDOWS_RAW_TOUCHPAD
     void handleWindowsTouchpadFrame(uint64_t deviceId,
                                     const uint32_t* pointerIds,
@@ -338,6 +357,21 @@ private:
     QHash<SDL_FingerID, NativeTouchpadContact> m_ActiveTouchpadContacts;
     QSet<SDL_FingerID> m_IgnoredTouchpadContacts;
     Uint32 m_LastTouchpadScrollTimestamp;
+
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    Uint32 m_MacTouchpadSuppressedMouseButtons;
+    Uint32 m_MacTouchpadPendingTapButtons;
+    Uint32 m_MacTouchpadLastTapTimestamp;
+    Uint32 m_MacTouchpadGestureStartTimestamp;
+    SDL_FingerID m_MacTouchpadGesturePrimaryFinger;
+    QSet<SDL_FingerID> m_MacTouchpadGestureContacts;
+    float m_MacTouchpadGestureStartX;
+    float m_MacTouchpadGestureStartY;
+    int m_MacTouchpadGestureMaxContacts;
+    bool m_MacTouchpadGestureMoved;
+    bool m_MacTouchpadGestureHadPhysicalButton;
+    bool m_MacTouchpadButtonDown;
+#endif
 
 #ifdef HAVE_WINDOWS_RAW_TOUCHPAD
     QHash<uint32_t, NativeTouchpadContact> m_ActiveWindowsTouchpadContacts;

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -12,6 +12,13 @@ void SdlInputHandler::handleMouseButtonEvent(SDL_MouseButtonEvent* event)
         // Ignore synthetic mouse events
         return;
     }
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    else if (shouldSuppressMacTouchpadMouseButtonEvent(event)) {
+        // macOS reports a trackpad click as a regular mouse button event even
+        // when the same gesture is already being sent as native contacts.
+        return;
+    }
+#endif
 #ifdef HAVE_WINDOWS_RAW_TOUCHPAD
     else if (shouldSuppressWindowsTouchpadMouseButtonEvent(event)) {
         // The click state is carried by the native touchpad frame.

--- a/app/streaming/input/touchpad.cpp
+++ b/app/streaming/input/touchpad.cpp
@@ -39,17 +39,20 @@ void SdlInputHandler::handleNativeTouchpadEvent(SDL_TouchFingerEvent* event)
 
     selectNativeTouchpadTransport();
 
-    if (m_NativeTouchpadTransport == NTT_SOFTWARE_POINTER) {
-        handleRelativeFingerEvent(event);
-        return;
-    }
-
     uint8_t eventType;
     switch (event->type) {
     case SDL_FINGERDOWN: eventType = LI_TOUCH_EVENT_DOWN; break;
     case SDL_FINGERMOTION: eventType = LI_TOUCH_EVENT_MOVE; break;
     case SDL_FINGERUP: eventType = LI_TOUCH_EVENT_UP; break;
     default: return;
+    }
+
+    if (m_NativeTouchpadTransport == NTT_SOFTWARE_POINTER) {
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+        updateMacTouchpadGesture(event);
+#endif
+        handleRelativeFingerEvent(event);
+        return;
     }
 
     if ((!m_ActiveTouchpadContacts.isEmpty() || !m_IgnoredTouchpadContacts.isEmpty()) &&
@@ -64,6 +67,10 @@ void SdlInputHandler::handleNativeTouchpadEvent(SDL_TouchFingerEvent* event)
         // previous device before switching to another touch surface.
         cancelSdlTouchpadContacts();
     }
+
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    updateMacTouchpadGesture(event);
+#endif
 
     if (m_IgnoredTouchpadContacts.contains(event->fingerId)) {
         if (eventType == LI_TOUCH_EVENT_UP || eventType == LI_TOUCH_EVENT_CANCEL) {
@@ -158,6 +165,232 @@ void SdlInputHandler::handleNativeTouchpadEvent(SDL_TouchFingerEvent* event)
         }
     }
 }
+
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+void SdlInputHandler::updateMacTouchpadGesture(const SDL_TouchFingerEvent* event)
+{
+    if (event->type == SDL_FINGERDOWN &&
+            m_MacTouchpadGestureContacts.isEmpty()) {
+        m_MacTouchpadGestureStartTimestamp = event->timestamp;
+        m_MacTouchpadGesturePrimaryFinger = event->fingerId;
+        m_MacTouchpadGestureStartX = event->x;
+        m_MacTouchpadGestureStartY = event->y;
+        m_MacTouchpadGestureMaxContacts = 1;
+        m_MacTouchpadGestureMoved = false;
+        m_MacTouchpadGestureHadPhysicalButton = false;
+        m_MacTouchpadPendingTapButtons = 0;
+    }
+
+    if (event->type == SDL_FINGERDOWN) {
+        m_MacTouchpadGestureContacts.insert(event->fingerId);
+    }
+    else if (event->type == SDL_FINGERUP) {
+        m_MacTouchpadGestureContacts.remove(event->fingerId);
+    }
+
+    m_MacTouchpadGestureMaxContacts =
+            qMax(m_MacTouchpadGestureMaxContacts,
+                 static_cast<int>(m_MacTouchpadGestureContacts.size()));
+
+    if (event->fingerId == m_MacTouchpadGesturePrimaryFinger) {
+        const float deltaX = event->x - m_MacTouchpadGestureStartX;
+        const float deltaY = event->y - m_MacTouchpadGestureStartY;
+        const float maxMovement = MACOS_TOUCHPAD_TAP_MAX_MOVEMENT;
+        if (deltaX * deltaX + deltaY * deltaY > maxMovement * maxMovement) {
+            m_MacTouchpadGestureMoved = true;
+        }
+    }
+
+    if (!m_MacTouchpadGestureContacts.isEmpty()) {
+        return;
+    }
+
+    const Uint32 gestureDuration =
+            event->timestamp - m_MacTouchpadGestureStartTimestamp;
+    if (!m_MacTouchpadGestureHadPhysicalButton &&
+            !m_MacTouchpadGestureMoved &&
+            m_MacTouchpadGestureMaxContacts > 0 &&
+            m_MacTouchpadGestureMaxContacts <= 2 &&
+            gestureDuration <= MACOS_TOUCHPAD_TAP_MAX_DURATION_MS) {
+        m_MacTouchpadPendingTapButtons =
+                m_MacTouchpadGestureMaxContacts == 1 ?
+                    SDL_BUTTON(SDL_BUTTON_LEFT) :
+                    SDL_BUTTON(SDL_BUTTON_RIGHT);
+        m_MacTouchpadLastTapTimestamp = event->timestamp;
+        SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                     "macOS trackpad tap candidate armed: fingers=%d timestamp=%u",
+                     m_MacTouchpadGestureMaxContacts, event->timestamp);
+    }
+    else {
+        m_MacTouchpadPendingTapButtons = 0;
+        m_MacTouchpadLastTapTimestamp = 0;
+    }
+
+    m_MacTouchpadGestureStartTimestamp = 0;
+    m_MacTouchpadGesturePrimaryFinger = 0;
+    m_MacTouchpadGestureMaxContacts = 0;
+    m_MacTouchpadGestureMoved = false;
+    m_MacTouchpadGestureHadPhysicalButton = false;
+}
+
+bool SdlInputHandler::sendMacTouchpadButtonState(bool down)
+{
+    const uint8_t buttonState = down ? LI_TOUCHPAD_BUTTON_PRIMARY : 0;
+
+    if (m_NativeTouchpadTransport == NTT_FRAME) {
+        int rc = LiSendTouchpadFrameEvent(0, nullptr, nullptr, nullptr, nullptr,
+                                          nullptr, LI_ROT_UNKNOWN, 0, 0,
+                                          buttonState);
+        if (rc == 0) {
+            return true;
+        }
+        if (rc != LI_ERR_UNSUPPORTED) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "LiSendTouchpadFrameEvent for macOS button failed: %d", rc);
+            return false;
+        }
+
+        if (LiGetHostFeatureFlags() & LI_FF_TOUCHPAD_EVENTS) {
+            m_NativeTouchpadTransport = NTT_INDIVIDUAL;
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Native touchpad transport downgraded: frame -> individual");
+        }
+        else {
+            m_NativeTouchpadTransport = NTT_SOFTWARE_POINTER;
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Native touchpad transport downgraded: frame -> software-pointer");
+            transitionNativeTouchpadToSoftwarePointer();
+            return false;
+        }
+    }
+
+    if (m_NativeTouchpadTransport == NTT_INDIVIDUAL) {
+        int rc = LiSendTouchpadEvent(LI_TOUCH_EVENT_BUTTON_ONLY, 0,
+                                     0.0f, 0.0f, 0.0f,
+                                     0.0f, 0.0f, LI_ROT_UNKNOWN,
+                                     0, 0, buttonState);
+        if (rc == 0) {
+            return true;
+        }
+        if (rc == LI_ERR_UNSUPPORTED) {
+            m_NativeTouchpadTransport = NTT_SOFTWARE_POINTER;
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Native touchpad transport downgraded: individual -> software-pointer");
+            transitionNativeTouchpadToSoftwarePointer();
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "LiSendTouchpadEvent for macOS button failed: %d", rc);
+        }
+    }
+
+    return false;
+}
+
+bool SdlInputHandler::shouldSuppressMacTouchpadMouseButtonEvent(
+        const SDL_MouseButtonEvent* event)
+{
+    if (!m_NativeTouchpadEnabled ||
+            m_NativeTouchpadTransport == NTT_UNKNOWN ||
+            event->button < SDL_BUTTON_LEFT ||
+            event->button > SDL_BUTTON_X2) {
+        return false;
+    }
+
+    const Uint32 buttonMask = SDL_BUTTON(event->button);
+    if (event->state == SDL_RELEASED) {
+        if (!(m_MacTouchpadSuppressedMouseButtons & buttonMask)) {
+            return false;
+        }
+
+        m_MacTouchpadSuppressedMouseButtons &= ~buttonMask;
+        if (m_MacTouchpadButtonDown &&
+                m_MacTouchpadSuppressedMouseButtons == 0) {
+            sendMacTouchpadButtonState(false);
+            m_MacTouchpadButtonDown = false;
+        }
+        SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                     "Suppressed macOS trackpad mouse button release: button=%d",
+                     static_cast<int>(event->button));
+        return true;
+    }
+
+    if (event->state != SDL_PRESSED || !isCaptureActive()) {
+        return false;
+    }
+
+    const bool hasActiveContacts = !m_MacTouchpadGestureContacts.isEmpty();
+    const bool hasCorrelatedTap =
+            (m_MacTouchpadPendingTapButtons & buttonMask) &&
+            event->timestamp - m_MacTouchpadLastTapTimestamp <=
+                MACOS_TOUCHPAD_CLICK_CORRELATION_TIMEOUT_MS;
+    if (!hasActiveContacts && !hasCorrelatedTap) {
+        if (m_MacTouchpadPendingTapButtons != 0 &&
+                event->timestamp - m_MacTouchpadLastTapTimestamp >
+                    MACOS_TOUCHPAD_CLICK_CORRELATION_TIMEOUT_MS) {
+            m_MacTouchpadPendingTapButtons = 0;
+            m_MacTouchpadLastTapTimestamp = 0;
+        }
+        return false;
+    }
+
+    if (hasActiveContacts &&
+            m_NativeTouchpadTransport == NTT_SOFTWARE_POINTER) {
+        // The legacy relative-touch path will otherwise synthesize another
+        // tap after this real click. Let the real mouse event through, but
+        // invalidate tap and long-press emulation for the current gesture.
+        m_MacTouchpadGestureHadPhysicalButton = true;
+        SDL_RemoveTimer(m_DragTimer);
+        m_DragTimer = 0;
+        for (int i = 0; i < MAX_FINGERS; i++) {
+            m_TouchDownEvent[i].timestamp = 0;
+        }
+        SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                     "Using legacy macOS trackpad mouse button: button=%d",
+                     static_cast<int>(event->button));
+        return false;
+    }
+
+    if (hasActiveContacts) {
+        m_MacTouchpadGestureHadPhysicalButton = true;
+        if (!m_MacTouchpadButtonDown) {
+            if (!sendMacTouchpadButtonState(true)) {
+                return false;
+            }
+            m_MacTouchpadButtonDown = true;
+        }
+    }
+
+    m_MacTouchpadPendingTapButtons = 0;
+    m_MacTouchpadLastTapTimestamp = 0;
+    m_MacTouchpadSuppressedMouseButtons |= buttonMask;
+    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                 "Suppressed promoted macOS trackpad mouse button press: button=%d source=%s",
+                 static_cast<int>(event->button),
+                 hasActiveContacts ? "active-contact" : "tap");
+    return true;
+}
+
+void SdlInputHandler::resetMacTouchpadState()
+{
+    if (m_MacTouchpadButtonDown) {
+        sendMacTouchpadButtonState(false);
+    }
+
+    m_MacTouchpadSuppressedMouseButtons = 0;
+    m_MacTouchpadPendingTapButtons = 0;
+    m_MacTouchpadLastTapTimestamp = 0;
+    m_MacTouchpadGestureStartTimestamp = 0;
+    m_MacTouchpadGesturePrimaryFinger = 0;
+    m_MacTouchpadGestureContacts.clear();
+    m_MacTouchpadGestureStartX = 0;
+    m_MacTouchpadGestureStartY = 0;
+    m_MacTouchpadGestureMaxContacts = 0;
+    m_MacTouchpadGestureMoved = false;
+    m_MacTouchpadGestureHadPhysicalButton = false;
+    m_MacTouchpadButtonDown = false;
+}
+#endif
 
 void SdlInputHandler::sendNativeTouchpadContacts(const NativeTouchpadContact* contacts,
                                                  int contactCount,
@@ -538,7 +771,13 @@ void SdlInputHandler::sendPendingTouchpadFrame()
     if (m_PendingTouchpadContactCount == 0) {
         return;
     }
-    sendNativeTouchpadContacts(m_PendingTouchpadContacts, m_PendingTouchpadContactCount);
+    uint8_t buttonState = 0;
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    buttonState = m_MacTouchpadButtonDown ? LI_TOUCHPAD_BUTTON_PRIMARY : 0;
+#endif
+    sendNativeTouchpadContacts(m_PendingTouchpadContacts,
+                               m_PendingTouchpadContactCount,
+                               true, buttonState);
     m_PendingTouchpadContactCount = 0;
     m_PendingTouchpadId = 0;
     m_PendingTouchpadTimestamp = 0;
@@ -553,6 +792,10 @@ void SdlInputHandler::flushPendingTouchpadFrameEvent()
 void SdlInputHandler::cancelSdlTouchpadContacts()
 {
     sendPendingTouchpadFrame();
+
+#ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    resetMacTouchpadState();
+#endif
 
     if (!m_ActiveTouchpadContacts.isEmpty()) {
         const NativeTouchpadContact cancelAll = {

--- a/app/streaming/input/touchpad.cpp
+++ b/app/streaming/input/touchpad.cpp
@@ -377,7 +377,7 @@ void SdlInputHandler::resetMacTouchpadState()
         sendMacTouchpadButtonState(false);
     }
 
-    m_MacTouchpadSuppressedMouseButtons = 0;
+    // Preserve suppressed buttons until SDL delivers their matching releases.
     m_MacTouchpadPendingTapButtons = 0;
     m_MacTouchpadLastTapTimestamp = 0;
     m_MacTouchpadGestureStartTimestamp = 0;


### PR DESCRIPTION
## 改了啥呀

- 在 SDL 视频子系统初始化前，根据已保存的“原生触摸板”设置配置 `SDL_HINT_TRACKPAD_IS_TOUCH_ONLY`，避免硬件探测提前锁定错误的 macOS 触摸板行为。
- 为 macOS 秒控板手势增加短时点击关联：同一次手势产生的触摸事件与系统提升的鼠标事件只向主机发送一次，杂鱼重复点击别想偷偷混进去啦。
- 物理按压在原生触摸板通道中携带按钮状态；软件指针回退路径则保留传统鼠标事件，同时停用同一手势的二次点击模拟。
- 在取消输入或切换状态时完整释放按钮并清理关联状态，避免残留按下状态。
- 将未显式配置时的原生触摸板默认值改为关闭；已经保存过的用户选择保持不变。

## 为啥要改

v6.2.99 启用原生精确式触摸板后，macOS 会为同一个秒控板点击同时产生触摸接触事件和提升后的鼠标按钮事件。客户端把两条路径都转发给主机，于是一次点击容易被识别成双击。

这次修复只在短时间窗口内抑制能与秒控板手势明确关联的鼠标事件，正常外接鼠标点击以及真正的连续双击仍会照常发送。

## 用户影响

- macOS 客户端使用秒控板串流时，轻触、物理按压和拖动不再因为双路径转发而重复点击。
- 单指左键与双指右键仍保留原生触摸板语义。
- 新安装或没有保存过该设置的用户默认使用更稳妥的关闭状态，可按需重新开启。

## 验证

- `git diff --check`
- Windows x64 Release：使用 Qt 6.9.2 qmake 重新生成 Makefile，并通过 MSVC `nmake /NOLOGO` 完成编译和链接。
- 使用 MSVC 为 `input.cpp`、`mouse.cpp`、`touchpad.cpp` 强制定义 `HAVE_MACOS_NATIVE_TOUCHPAD`，确认 macOS 条件编译路径可通过语法编译。

> 还需要在真实 macOS + Magic Trackpad 环境补充手工验证：轻触、物理按压、真正双击、拖动、双指右键和外接鼠标。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved native macOS touchpad handling for gestures, taps, clicks, and button state reporting.
  * Added an option to enable/disable native touchpad behavior on macOS.

* **Bug Fixes**
  * Prevented duplicate mouse click events by suppressing overlapping mouse-button input when native touchpad contacts are active.
  * Reset macOS touchpad gesture/button state correctly when touch contacts are canceled or switched.
  * Changed the default native touchpad setting to disabled when the preference is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->