### PR TITLE
fix(vt): 统一 AVSampleBufferDisplayLayer 渲染器的性能覆盖层样式

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm
@@ -15,6 +15,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <dispatch/dispatch.h>
 #import <Metal/Metal.h>
+#import <QuartzCore/QuartzCore.h>
 
 @interface VTView : NSView
 - (NSView *)hitTest:(NSPoint)point;
@@ -43,9 +44,12 @@ public:
           m_LastColorTrc(-1),
           m_ColorSpace(nullptr),
           m_VsyncMutex(nullptr),
-          m_VsyncPassed(nullptr)
+          m_VsyncPassed(nullptr),
+          m_OverlayLock(0)
     {
-        SDL_zero(m_OverlayTextFields);
+        SDL_zero(m_OverlayLayers);
+        SDL_zero(m_OverlayImages);
+        SDL_zero(m_OverlayEnabled);
         for (int i = 0; i < Overlay::OverlayMax; i++) {
             m_OverlayUpdateBlocks[i] = dispatch_block_create(DISPATCH_BLOCK_DETACHED, ^{
                 updateOverlayOnMainThread((Overlay::OverlayType)i);
@@ -88,9 +92,12 @@ public:
         }
 
         for (int i = 0; i < Overlay::OverlayMax; i++) {
-            if (m_OverlayTextFields[i] != nullptr) {
-                [m_OverlayTextFields[i] removeFromSuperview];
-                [m_OverlayTextFields[i] release];
+            if (m_OverlayLayers[i] != nullptr) {
+                [m_OverlayLayers[i] removeFromSuperlayer];
+                [m_OverlayLayers[i] release];
+            }
+            if (m_OverlayImages[i] != nullptr) {
+                CGImageRelease(m_OverlayImages[i]);
             }
         }
 
@@ -406,43 +413,135 @@ public:
         return true;
     }}
 
+    // Converts an OverlayManager surface (always ARGB8888) into a CGImage.
+    // The surface data is copied, so the caller may free it after we return.
+    static CGImageRef createImageFromSurface(SDL_Surface* surface)
+    {
+        SDL_assert(surface->format->format == SDL_PIXELFORMAT_ARGB8888);
+
+        CFDataRef data = CFDataCreate(kCFAllocatorDefault,
+                                      (const UInt8*)surface->pixels,
+                                      surface->h * surface->pitch);
+        if (data == nullptr) {
+            return nullptr;
+        }
+
+        CGDataProviderRef provider = CGDataProviderCreateWithCFData(data);
+        CFRelease(data);
+        if (provider == nullptr) {
+            return nullptr;
+        }
+
+        CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+
+        // SDL_PIXELFORMAT_ARGB8888 is a native-endian 32-bit word with
+        // non-premultiplied alpha in the high byte.
+        CGImageRef image = CGImageCreate(surface->w, surface->h, 8, 32, surface->pitch,
+                                         colorSpace,
+                                         kCGBitmapByteOrder32Host | kCGImageAlphaFirst,
+                                         provider, nullptr, false,
+                                         kCGRenderingIntentDefault);
+
+        CGColorSpaceRelease(colorSpace);
+        CGDataProviderRelease(provider);
+
+        return image;
+    }
+
     void updateOverlayOnMainThread(Overlay::OverlayType type)
     { @autoreleasepool {
         // Lazy initialization for the overlay
-        if (m_OverlayTextFields[type] == nullptr) {
-            m_OverlayTextFields[type] = [[NSTextField alloc] initWithFrame:m_StreamView.bounds];
-            [m_OverlayTextFields[type] setBezeled:NO];
-            [m_OverlayTextFields[type] setDrawsBackground:NO];
-            [m_OverlayTextFields[type] setEditable:NO];
-            [m_OverlayTextFields[type] setSelectable:NO];
+        if (m_OverlayLayers[type] == nullptr) {
+            m_OverlayLayers[type] = [[CALayer alloc] init];
+            m_OverlayLayers[type].anchorPoint = CGPointMake(0, 0);
 
+            // Overlays are always drawn at exact size, like our other renderers
+            m_OverlayLayers[type].magnificationFilter = kCAFilterNearest;
+            m_OverlayLayers[type].minificationFilter = kCAFilterNearest;
+
+            [m_DisplayLayer addSublayer: m_OverlayLayers[type]];
+        }
+
+        // Grab the latest image produced by notifyOverlayUpdated()
+        SDL_AtomicLock(&m_OverlayLock);
+        CGImageRef image = CGImageRetain(m_OverlayImages[type]);
+        bool enabled = m_OverlayEnabled[type];
+        SDL_AtomicUnlock(&m_OverlayLock);
+
+        // Don't animate contents/geometry changes
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+
+        if (image != nullptr) {
+            CGFloat scale = m_StreamView.window.screen.backingScaleFactor;
+            if (scale <= 0) {
+                scale = 1;
+            }
+
+            // The overlay surface is sized in pixels, so scale the layer to
+            // render it 1:1 with the display's pixel grid.
+            m_OverlayLayers[type].contentsScale = scale;
+
+            CGRect bounds = m_StreamView.bounds;
+            CGSize size = CGSizeMake(CGImageGetWidth(image) / scale,
+                                     CGImageGetHeight(image) / scale);
+
+            CGPoint position;
             switch (type) {
             case Overlay::OverlayDebug:
-                [m_OverlayTextFields[type] setAlignment:NSTextAlignmentLeft];
+                // Top center
+                position = CGPointMake(CGRectGetMidX(bounds) - (size.width / 2),
+                                       CGRectGetMaxY(bounds) - size.height);
                 break;
             case Overlay::OverlayStatusUpdate:
-                [m_OverlayTextFields[type] setAlignment:NSTextAlignmentRight];
-                break;
             default:
+                // Bottom left
+                position = CGPointMake(0, 0);
                 break;
             }
 
-            SDL_Color color = Session::get()->getOverlayManager().getOverlayColor(type);
-            [m_OverlayTextFields[type] setTextColor:[NSColor colorWithSRGBRed:color.r / 255.0 green:color.g / 255.0 blue:color.b / 255.0 alpha:color.a / 255.0]];
-            [m_OverlayTextFields[type] setFont:[NSFont messageFontOfSize:Session::get()->getOverlayManager().getOverlayFontSize(type)]];
+            m_OverlayLayers[type].bounds = CGRectMake(0, 0, size.width, size.height);
+            m_OverlayLayers[type].position = position;
+            m_OverlayLayers[type].contents = (id)image;
 
-            [m_StreamView addSubview: m_OverlayTextFields[type]];
+            CGImageRelease(image);
+        }
+        else {
+            m_OverlayLayers[type].contents = nil;
         }
 
-        // Update text contents
-        [m_OverlayTextFields[type] setStringValue: [NSString stringWithUTF8String:Session::get()->getOverlayManager().getOverlayText(type)]];
+        [m_OverlayLayers[type] setHidden: !enabled];
 
-        // Unhide if it's enabled
-        [m_OverlayTextFields[type] setHidden: !Session::get()->getOverlayManager().isOverlayEnabled(type)];
+        [CATransaction commit];
     }}
 
     virtual void notifyOverlayUpdated(Overlay::OverlayType type) override
     {
+        SDL_Surface* newSurface = Session::get()->getOverlayManager().getUpdatedOverlaySurface(type);
+        bool overlayEnabled = Session::get()->getOverlayManager().isOverlayEnabled(type);
+        if (newSurface == nullptr && overlayEnabled) {
+            // The overlay is enabled and there is no new surface. Leave the old image alone.
+            return;
+        }
+
+        CGImageRef newImage = nullptr;
+        if (newSurface != nullptr) {
+            if (overlayEnabled) {
+                newImage = createImageFromSurface(newSurface);
+            }
+            SDL_FreeSurface(newSurface);
+        }
+
+        SDL_AtomicLock(&m_OverlayLock);
+        CGImageRef oldImage = m_OverlayImages[type];
+        m_OverlayImages[type] = newImage;
+        m_OverlayEnabled[type] = overlayEnabled;
+        SDL_AtomicUnlock(&m_OverlayLock);
+
+        if (oldImage != nullptr) {
+            CGImageRelease(oldImage);
+        }
+
         // We must do the actual UI updates on the main thread, so queue an
         // async callback on the main thread via GCD to do the UI update.
         dispatch_async(dispatch_get_main_queue(), m_OverlayUpdateBlocks[type]);
@@ -487,13 +586,16 @@ private:
     CMVideoFormatDescriptionRef m_FormatDesc;
     NSView* m_StreamView;
     dispatch_block_t m_OverlayUpdateBlocks[Overlay::OverlayMax];
-    NSTextField* m_OverlayTextFields[Overlay::OverlayMax];
+    CALayer* m_OverlayLayers[Overlay::OverlayMax];
+    CGImageRef m_OverlayImages[Overlay::OverlayMax];
+    bool m_OverlayEnabled[Overlay::OverlayMax];
     CVDisplayLinkRef m_DisplayLink;
     int m_LastColorSpace;
     int m_LastColorTrc;
     CGColorSpaceRef m_ColorSpace;
     SDL_mutex* m_VsyncMutex;
     SDL_cond* m_VsyncPassed;
+    SDL_SpinLock m_OverlayLock;
     bool m_DirectRendering;
 };
 

--- a/app/streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm
@@ -10,6 +10,7 @@
 #include <streaming/session.h>
 
 #include <mach/mach_time.h>
+#include <cmath>
 #import <Cocoa/Cocoa.h>
 #import <VideoToolbox/VideoToolbox.h>
 #import <AVFoundation/AVFoundation.h>
@@ -473,7 +474,14 @@ public:
         [CATransaction setDisableActions:YES];
 
         if (image != nullptr) {
-            CGFloat scale = m_StreamView.window.screen.backingScaleFactor;
+            // NSWindow.backingScaleFactor stays valid even when the window is
+            // not currently on a screen, unlike NSWindow.screen which can be nil
+            // while moving between displays or entering full-screen. Getting this
+            // wrong stretches the overlay and makes it look blurry.
+            CGFloat scale = m_StreamView.window.backingScaleFactor;
+            if (scale <= 0) {
+                scale = [NSScreen mainScreen].backingScaleFactor;
+            }
             if (scale <= 0) {
                 scale = 1;
             }
@@ -499,6 +507,13 @@ public:
                 position = CGPointMake(0, 0);
                 break;
             }
+
+            // Snap the origin to the pixel grid. Centering an overlay with an odd
+            // pixel width lands it on a half pixel, which resamples the bitmap font
+            // and makes the text look smeared. The overlay text changes size as it
+            // updates, so without this the overlay alternates between crisp and blurry.
+            position.x = std::round(position.x * scale) / scale;
+            position.y = std::round(position.y * scale) / scale;
 
             m_OverlayLayers[type].bounds = CGRectMake(0, 0, size.width, size.height);
             m_OverlayLayers[type].position = position;


### PR DESCRIPTION
## 问题

`AVSampleBufferDisplayLayer` 渲染器是唯一不消费 `OverlayManager` 渲染结果的渲染器。它自己创建了一个 `NSTextField`，直接把 `getOverlayText()` 的原始字符串塞进去，导致性能覆盖层：

- 使用系统 `messageFont`，而非统一的 `ModeSeven.ttf` 点阵字体
- 丢失半透明黑色背景（`bgcolor` 只在 surface 合成路径里生效）
- 把 `**粗体**` / `{18}` 这类格式标记原样显示出来
- 文本框铺满整个 view，靠 `NSTextAlignment` 定位，与其他渲染器的位置不一致

## 改动

改为和 `vt_metal` 一样消费 `getUpdatedOverlaySurface()`，用 `CALayer` 呈现：

- 在非主线程把 ARGB8888 surface 转成 `CGImageRef`，再交给主线程赋给图层 contents。沿用 Metal 渲染器的语义：overlay 启用但没有新 surface 时保留旧图像。
- `contentsScale` 设为屏幕 backing scale factor，图层尺寸按点换算，使覆盖层 1:1 落在物理像素网格上，与 Metal 的逐像素贴图一致。
- Debug 覆盖层顶部居中、状态覆盖层左下角，与 `vt_metal` 对齐。
- `kCAFilterNearest` 对应其他渲染器"按精确尺寸绘制"的行为；关闭隐式动画，避免约 1 Hz 的内容更新出现交叉淡入淡出。

## 验证

- **完整构建通过**：Qt 6.11.1 + 预构建依赖，`make release` 成功，该文件在 `-Wall -Wextra` 下零告警。
- **像素级验证**：独立测试原样抽出 `createImageFromSurface()`，喂入按 `OverlayManager` 方式构造的 surface 后合成到白底读回像素 —— 不透明文字像素 189,249,231 原色保留（通道顺序正确）；0x66 alpha 黑底压白后得 153,153,153，即 40% 黑，确认 CG 按非预乘 alpha 解释，与 TTF Blended 输出一致。图层几何：2x 屏上 400×60 px → 200×30 pt，frame 顶部居中 / 左下角符合预期。
- 已在本机安装构建产物。**实机串流观感尚未确认** —— 需要真实串流会话才能让覆盖层显示出来。

## Reviewer 注意

- 只影响 macOS 上显式选择 `AVSampleBufferDisplayLayer` 渲染器的路径（设置里手动选择；Automatic 会走 Vulkan/libplacebo 或 Metal）。
- Debug 覆盖层位置跟随的是 `vt_metal` 的**顶部居中**；`sdlvid` 是**左上角** —— 上游本来就不一致，此处选择了 macOS 上的主渲染器行为。
- 窗口尺寸变化后的重新定位依赖下一次覆盖层更新（Debug 覆盖层每秒刷新，会自行纠正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video overlay rendering for smoother, more reliable display.
  * Updated overlay positioning and scaling to better match the current display, reducing half‑pixel/blur artifacts.
  * Refined overlay enable/disable behavior so overlays consistently show and hide as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->