### PR TITLE
fix(macos): deploy Qt into the clipboard helper

### DIFF
--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -99,7 +99,13 @@ if [ ! -f "$HELPER_BINARY" ]; then
 fi
 cp "$HELPER_BINARY" $BUILD_FOLDER/app/Moonlight.app/Contents/MacOS/ || fail "Clipboard helper copy failed!"
 
-macdeployqt $BUILD_FOLDER/app/Moonlight.app $EXTRA_ARGS -qmldir=$SOURCE_ROOT/app/gui -appstore-compliant || fail "macdeployqt failed!"
+# macdeployqt only rewrites Qt references in the main executable and the
+# plugins it deploys, so the clipboard helper has to be named explicitly with
+# -executable. Otherwise it keeps the build machine's absolute Qt paths, which
+# either don't exist on the user's machine or pull a second copy of Qt into the
+# process alongside the bundled one. Either way the helper aborts at startup
+# and clipboard sync silently disables itself.
+macdeployqt $BUILD_FOLDER/app/Moonlight.app $EXTRA_ARGS -executable=$BUILD_FOLDER/app/Moonlight.app/Contents/MacOS/moonlight-clipboard-helper -qmldir=$SOURCE_ROOT/app/gui -appstore-compliant || fail "macdeployqt failed!"
 
 echo Building File Provider extension into app bundle
 bash "$SOURCE_ROOT/scripts/build-macos-fileprovider-extension.sh" "$SOURCE_ROOT" "$BUILD_FOLDER" "$BUILD_FOLDER/app/Moonlight.app" "$MOONLIGHT_ARCH" || fail "File Provider extension build failed"


### PR DESCRIPTION
## 问题

在用 Homebrew Qt 构建的本地包里，剪贴板同步完全不工作。

剪贴板同步靠独立子进程 `moonlight-clipboard-helper` 实现（`ClipboardHelperClient` 用 `QProcess` 启动它）。`scripts/generate-dmg.sh` 先把 helper 拷进 `Contents/MacOS/`，再调用 `macdeployqt` —— 但 macdeployqt 只改写主可执行文件和它自己部署的插件，`Contents/MacOS/` 下额外的可执行文件必须用 `-executable=` 显式指定。

官方 Qt（CI 用 aqtinstall 装的那份）的 framework install name 是 `@rpath/QtCore.framework/...`，而 qmake 会把 `@executable_path/../Frameworks` 作为第一条 rpath 写进去，所以即使 macdeployqt 没处理 helper，它也能正确解析到 bundle 内的 Qt —— **发布版的 DMG 不受此问题影响**。

但 Homebrew 的 qtbase 不是 relocatable 的，install name 是绝对路径：

```
/opt/homebrew/opt/qtbase/lib/QtCore.framework/Versions/A/QtCore
/opt/homebrew/opt/qtbase/lib/QtGui.framework/Versions/A/QtGui
/opt/homebrew/opt/qtbase/lib/QtNetwork.framework/Versions/A/QtNetwork
```

rpath 在这里帮不上忙。于是 helper 加载 Homebrew 那份 Qt，而 bundle 内的 cocoa 插件加载 `Contents/Frameworks` 里的 Qt，一个进程里出现两套 Qt：

```
objc[88036]: Class QT_ROOT_LEVEL_POOL__... is implemented in both
  /opt/homebrew/Cellar/qtbase/6.11.1/lib/QtCore.framework/... and
  /Applications/Moonlight.app/Contents/Frameworks/QtCore.framework/...
QObject::moveToThread: Current thread is not the object's thread
qt.qpa.plugin: Could not load the Qt platform plugin "cocoa" in "" even though it was found.
```

helper abort（exit 134）。`ClipboardHelperClient` 重试几次后就静默禁用剪贴板同步，用户侧没有任何可见错误。如果构建机的 Qt 路径在目标机器上根本不存在，helper 同样起不来。

## 改动

给 `macdeployqt` 加上 `-executable=<bundle>/Contents/MacOS/moonlight-clipboard-helper`，让 helper 的 Qt 引用也被改写进 bundle，不再依赖 Qt 是否 relocatable、也不再依赖 rpath 的搜索顺序。

对 CI 构建是无副作用的加固：那边本来就能正常工作，改动后引用从 `@rpath/...` 变成 `@loader_path/../Frameworks/...`，结果一致。

## 验证

**发布版对照**（v6.2.99 的 DMG，确认不受影响）：

```
@rpath/QtCore.framework/Versions/A/QtCore
LC_RPATH: @executable_path/../Frameworks
LC_RPATH: /Users/runner/work/moonlight-qt/Qt/6.11.1/macos/lib
```

**Homebrew Qt 6.11.1 本地 Release 构建**：改动前 helper 有 3 处 `/opt/homebrew` 绝对引用，直接运行立即 abort 并打印上面的重复 Qt 警告。改动后：

```
$ otool -L Moonlight.app/Contents/MacOS/moonlight-clipboard-helper | grep Qt
	@loader_path/../Frameworks/QtGui.framework/Versions/A/QtGui
	@loader_path/../Frameworks/QtNetwork.framework/Versions/A/QtNetwork
	@loader_path/../Frameworks/QtCore.framework/Versions/A/QtCore
```

`/opt/homebrew` 引用数量 3 → 0，helper 能正常常驻运行，无重复 Qt 警告，剪贴板同步恢复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)