### PR TITLE
feat(cursor): synchronize host cursor shapes locally

### DIFF
--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -348,6 +348,15 @@ int SdlInputHandler::getCapturedCursorVisibilityState() const
     return SDL_ENABLE;
 }
 
+void SdlInputHandler::applyCapturedCursorState()
+{
+    if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL &&
+        m_RemoteCursor != nullptr) {
+        SDL_SetCursor(m_RemoteCursor);
+    }
+    SDL_ShowCursor(getCapturedCursorVisibilityState());
+}
+
 void SdlInputHandler::resetRemoteCursor()
 {
     if (m_RemoteCursor == nullptr) {
@@ -431,11 +440,8 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
         }
     }
 
-    if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL && isCaptureActive()) {
-        if (m_RemoteCursor != nullptr) {
-            SDL_SetCursor(m_RemoteCursor);
-        }
-        SDL_ShowCursor(getCapturedCursorVisibilityState());
+    if (isCaptureActive()) {
+        applyCapturedCursorState();
     }
 }
 
@@ -602,16 +608,12 @@ bool SdlInputHandler::isSystemKeyCaptureActive()
 void SdlInputHandler::setCaptureActive(bool active)
 {
     if (active) {
-        if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL &&
-            m_RemoteCursor != nullptr) {
-            SDL_SetCursor(m_RemoteCursor);
-        }
-
         // If we're in relative mode, try to activate SDL's relative mouse mode
         if (m_AbsoluteMouseMode || SDL_SetRelativeMouseMode(SDL_TRUE) < 0) {
-            // Relative mouse mode didn't work or was disabled, so we'll just hide the cursor
-            SDL_ShowCursor(getCapturedCursorVisibilityState());
             m_FakeMouseCaptureActive = true;
+            // Relative mouse mode didn't work or was disabled, so apply the
+            // cursor shape and visibility directly.
+            applyCapturedCursorState();
         }
 
         // Synchronize the client and host cursor when activating absolute capture

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -368,7 +368,9 @@ void SdlInputHandler::synchronizeLocalCursorMode()
                                LI_CURSOR_MODE_LOCAL : LI_CURSOR_MODE_VIDEO;
     m_LocalCursorMode.store(cursorMode, std::memory_order_relaxed);
     const int result = LiSetCursorMode(cursorMode);
-    if (result != 0 && result != -2 && result != -3) {
+    if (result != LI_CURSOR_MODE_OK &&
+        result != LI_CURSOR_MODE_ERR_UNSUPPORTED &&
+        result != LI_CURSOR_MODE_ERR_NOT_CONNECTED) {
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                     "Failed to synchronize local cursor mode: %d",
                     result);
@@ -398,35 +400,35 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "Ignoring invalid remote cursor shape %u",
                         update.shapeId);
-            return;
         }
-
-        SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormatFrom(
-            const_cast<char*>(update.bgra.constData()),
-            update.width,
-            update.height,
-            32,
-            update.width * 4,
-            SDL_PIXELFORMAT_BGRA32);
-        if (surface == nullptr) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Failed to create remote cursor surface: %s",
-                        SDL_GetError());
-            return;
+        else {
+            SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormatFrom(
+                const_cast<char*>(update.bgra.constData()),
+                update.width,
+                update.height,
+                32,
+                update.width * 4,
+                SDL_PIXELFORMAT_BGRA32);
+            if (surface == nullptr) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "Failed to create remote cursor surface: %s",
+                            SDL_GetError());
+            }
+            else {
+                SDL_Cursor* cursor =
+                    SDL_CreateColorCursor(surface, update.hotspotX, update.hotspotY);
+                SDL_FreeSurface(surface);
+                if (cursor == nullptr) {
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                "Failed to create remote cursor: %s",
+                                SDL_GetError());
+                }
+                else {
+                    resetRemoteCursor();
+                    m_RemoteCursor = cursor;
+                }
+            }
         }
-
-        SDL_Cursor* cursor =
-            SDL_CreateColorCursor(surface, update.hotspotX, update.hotspotY);
-        SDL_FreeSurface(surface);
-        if (cursor == nullptr) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Failed to create remote cursor: %s",
-                        SDL_GetError());
-            return;
-        }
-
-        resetRemoteCursor();
-        m_RemoteCursor = cursor;
     }
 
     if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL && isCaptureActive()) {

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -38,6 +38,10 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_KeyboardCaptureActive(false),
       m_CaptureSystemKeysMode(prefs.captureSysKeysMode),
       m_MouseCursorCapturedVisibilityState(prefs.showLocalCursor ? SDL_ENABLE : SDL_DISABLE),
+      m_LocalCursorMode(prefs.absoluteMouseMode && prefs.showLocalCursor ?
+                            LI_CURSOR_MODE_LOCAL : LI_CURSOR_MODE_VIDEO),
+      m_RemoteCursorVisible(true),
+      m_RemoteCursor(nullptr),
       m_LongPressTimer(0),
       m_StreamWidth(streamWidth),
       m_StreamHeight(streamHeight),
@@ -254,6 +258,7 @@ SdlInputHandler::~SdlInputHandler()
     m_WindowsTouchpadInput.reset();
 #endif
     cancelNativeTouchpadContacts();
+    resetRemoteCursor();
 
     for (int i = 0; i < MAX_GAMEPADS; i++) {
         if (m_GamepadState[i].mouseEmulationTimer != 0) {
@@ -322,6 +327,114 @@ void SdlInputHandler::setWindow(SDL_Window *window)
         ImmAssociateContext(info.info.win.window, NULL);
     }
 #endif
+}
+
+int SdlInputHandler::getLocalCursorMode() const
+{
+    return m_LocalCursorMode.load(std::memory_order_relaxed);
+}
+
+int SdlInputHandler::getCapturedCursorVisibilityState() const
+{
+    if (m_MouseCursorCapturedVisibilityState == SDL_DISABLE) {
+        return SDL_DISABLE;
+    }
+
+    if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL &&
+        (LiGetHostFeatureFlags() & LI_FF_CURSOR_SHAPE) != 0) {
+        return m_RemoteCursorVisible ? SDL_ENABLE : SDL_DISABLE;
+    }
+
+    return SDL_ENABLE;
+}
+
+void SdlInputHandler::resetRemoteCursor()
+{
+    if (m_RemoteCursor == nullptr) {
+        return;
+    }
+
+    if (SDL_GetCursor() == m_RemoteCursor) {
+        SDL_SetCursor(SDL_GetDefaultCursor());
+    }
+    SDL_FreeCursor(m_RemoteCursor);
+    m_RemoteCursor = nullptr;
+}
+
+void SdlInputHandler::synchronizeLocalCursorMode()
+{
+    const int cursorMode = m_AbsoluteMouseMode &&
+                           m_MouseCursorCapturedVisibilityState == SDL_ENABLE ?
+                               LI_CURSOR_MODE_LOCAL : LI_CURSOR_MODE_VIDEO;
+    m_LocalCursorMode.store(cursorMode, std::memory_order_relaxed);
+    const int result = LiSetCursorMode(cursorMode);
+    if (result != 0 && result != -2 && result != -3) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Failed to synchronize local cursor mode: %d",
+                    result);
+    }
+
+    if (cursorMode == LI_CURSOR_MODE_VIDEO) {
+        resetRemoteCursor();
+    }
+    else {
+        // The host will immediately send the authoritative state. Keep the
+        // default cursor visible until that update arrives.
+        m_RemoteCursorVisible = true;
+    }
+}
+
+void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
+{
+    m_RemoteCursorVisible = update.visible;
+
+    if (update.hasShape) {
+        const qsizetype expectedSize =
+            static_cast<qsizetype>(update.width) * update.height * 4;
+        if (update.width == 0 || update.height == 0 ||
+            update.hotspotX < 0 || update.hotspotX >= update.width ||
+            update.hotspotY < 0 || update.hotspotY >= update.height ||
+            update.bgra.size() != expectedSize) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Ignoring invalid remote cursor shape %u",
+                        update.shapeId);
+            return;
+        }
+
+        SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormatFrom(
+            const_cast<char*>(update.bgra.constData()),
+            update.width,
+            update.height,
+            32,
+            update.width * 4,
+            SDL_PIXELFORMAT_BGRA32);
+        if (surface == nullptr) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Failed to create remote cursor surface: %s",
+                        SDL_GetError());
+            return;
+        }
+
+        SDL_Cursor* cursor =
+            SDL_CreateColorCursor(surface, update.hotspotX, update.hotspotY);
+        SDL_FreeSurface(surface);
+        if (cursor == nullptr) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Failed to create remote cursor: %s",
+                        SDL_GetError());
+            return;
+        }
+
+        resetRemoteCursor();
+        m_RemoteCursor = cursor;
+    }
+
+    if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL && isCaptureActive()) {
+        if (m_RemoteCursor != nullptr) {
+            SDL_SetCursor(m_RemoteCursor);
+        }
+        SDL_ShowCursor(getCapturedCursorVisibilityState());
+    }
 }
 
 void SdlInputHandler::raiseAllKeys(bool clearKeys)
@@ -487,10 +600,15 @@ bool SdlInputHandler::isSystemKeyCaptureActive()
 void SdlInputHandler::setCaptureActive(bool active)
 {
     if (active) {
+        if (getLocalCursorMode() == LI_CURSOR_MODE_LOCAL &&
+            m_RemoteCursor != nullptr) {
+            SDL_SetCursor(m_RemoteCursor);
+        }
+
         // If we're in relative mode, try to activate SDL's relative mouse mode
         if (m_AbsoluteMouseMode || SDL_SetRelativeMouseMode(SDL_TRUE) < 0) {
             // Relative mouse mode didn't work or was disabled, so we'll just hide the cursor
-            SDL_ShowCursor(m_MouseCursorCapturedVisibilityState);
+            SDL_ShowCursor(getCapturedCursorVisibilityState());
             m_FakeMouseCaptureActive = true;
         }
 
@@ -525,6 +643,10 @@ void SdlInputHandler::setCaptureActive(bool active)
         // example, when the user explicitly releases input). Ensure Sunshine
         // never retains contacts from the previous capture state.
         cancelNativeTouchpadContacts();
+
+        if (m_RemoteCursor != nullptr && SDL_GetCursor() == m_RemoteCursor) {
+            SDL_SetCursor(SDL_GetDefaultCursor());
+        }
 
         if (m_FakeMouseCaptureActive) {
             // Display the cursor again

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -5,8 +5,11 @@
 
 #include "SDL_compat.h"
 
+#include <QByteArray>
 #include <QHash>
 #include <QSet>
+
+#include <atomic>
 
 #ifdef HAVE_WINDOWS_RAW_TOUCHPAD
 #include <memory>
@@ -94,6 +97,17 @@ struct DualSenseOutputReport{
 #define GAMEPAD_HAPTIC_SIMPLE_HIFREQ_MOTOR_WEIGHT 0.33
 #define GAMEPAD_HAPTIC_SIMPLE_LOWFREQ_MOTOR_WEIGHT 0.8
 
+struct RemoteCursorUpdate {
+    bool hasShape;
+    bool visible;
+    uint32_t shapeId;
+    uint16_t width;
+    uint16_t height;
+    int16_t hotspotX;
+    int16_t hotspotY;
+    QByteArray bgra;
+};
+
 class SdlInputHandler
 {
 public:
@@ -168,6 +182,12 @@ public:
 
     void updatePointerRegionLock();
 
+    void updateRemoteCursor(const RemoteCursorUpdate& update);
+
+    void synchronizeLocalCursorMode();
+
+    int getLocalCursorMode() const;
+
     static
     QString getUnmappedGamepads();
 
@@ -229,6 +249,10 @@ private:
     void selectNativeTouchpadTransport();
 
     void transitionNativeTouchpadToSoftwarePointer();
+
+    int getCapturedCursorVisibilityState() const;
+
+    void resetRemoteCursor();
 
     struct NativeTouchpadContact {
         uint8_t eventType;
@@ -303,6 +327,9 @@ private:
     QStringList m_IgnoreDeviceGuids;
     StreamingPreferences::CaptureSysKeysMode m_CaptureSystemKeysMode;
     int m_MouseCursorCapturedVisibilityState;
+    std::atomic<int> m_LocalCursorMode;
+    bool m_RemoteCursorVisible;
+    SDL_Cursor* m_RemoteCursor;
 
     struct {
         KeyCombo keyCombo;

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -252,6 +252,8 @@ private:
 
     int getCapturedCursorVisibilityState() const;
 
+    void applyCapturedCursorState();
+
     void resetRemoteCursor();
 
     struct NativeTouchpadContact {

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -67,6 +67,7 @@ void SdlInputHandler::performSpecialKeyCombo(KeyCombo combo)
 
         // Toggle mouse mode
         m_AbsoluteMouseMode = !m_AbsoluteMouseMode;
+        synchronizeLocalCursorMode();
 
         // Recapture input
         setCaptureActive(true);
@@ -79,7 +80,8 @@ void SdlInputHandler::performSpecialKeyCombo(KeyCombo combo)
         if (!SDL_GetRelativeMouseMode()) {
             // 切换本地鼠标光标可见性状态
             m_MouseCursorCapturedVisibilityState = !m_MouseCursorCapturedVisibilityState;
-            SDL_ShowCursor(m_MouseCursorCapturedVisibilityState);
+            synchronizeLocalCursorMode();
+            SDL_ShowCursor(getCapturedCursorVisibilityState());
         }
         else {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -81,7 +81,7 @@ void SdlInputHandler::performSpecialKeyCombo(KeyCombo combo)
             // 切换本地鼠标光标可见性状态
             m_MouseCursorCapturedVisibilityState = !m_MouseCursorCapturedVisibilityState;
             synchronizeLocalCursorMode();
-            SDL_ShowCursor(getCapturedCursorVisibilityState());
+            applyCapturedCursorState();
         }
         else {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,

--- a/app/streaming/input/mouse.cpp
+++ b/app/streaming/input/mouse.cpp
@@ -160,7 +160,9 @@ void SdlInputHandler::handleMouseMotionEvent(SDL_MouseMotionEvent* event)
 
         // Adjust the cursor visibility if applicable
         if (mouseInVideoRegion ^ m_MouseWasInVideoRegion) {
-            SDL_ShowCursor((mouseInVideoRegion && m_MouseCursorCapturedVisibilityState == SDL_DISABLE) ? SDL_DISABLE : SDL_ENABLE);
+            SDL_ShowCursor((mouseInVideoRegion &&
+                            getCapturedCursorVisibilityState() == SDL_DISABLE) ?
+                               SDL_DISABLE : SDL_ENABLE);
             if (!mouseInVideoRegion && buttonState != 0) {
                 // If we still have a button pressed on leave, wait for that to come up
                 // before we stop sending mouse position events.

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -39,6 +39,7 @@
 #define SDL_CODE_GAMECONTROLLER_SET_CONTROLLER_LED 104
 #define SDL_CODE_GAMECONTROLLER_SET_ADAPTIVE_TRIGGERS 105
 #define SDL_CODE_FLUSH_TOUCHPAD_FRAME 106
+#define SDL_CODE_CURSOR_UPDATE 107
 
 #include <openssl/rand.h>
 
@@ -85,7 +86,8 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
     Session::clSetControllerLED,
     Session::clSetAdaptiveTriggers,
     nullptr, // resolutionChanged (unused on Qt client)
-    Session::clClipboardData
+    Session::clClipboardData,
+    Session::clCursorUpdate
 };
 
 Session* Session::s_ActiveSession;
@@ -478,6 +480,43 @@ void Session::clClipboardData(const char* data, int length)
 
     // Queues internally; safe to call from the recv thread.
     session->m_ClipboardHelper->handleIncomingFrame(data, length);
+}
+
+void Session::clCursorUpdate(const LI_CURSOR_UPDATE* update)
+{
+    Session* session = s_ActiveSession;
+    if (session == nullptr || update == nullptr) {
+        return;
+    }
+
+    auto pending = std::make_shared<RemoteCursorUpdate>();
+    pending->hasShape = (update->flags & LI_CURSOR_UPDATE_FLAG_SHAPE) != 0;
+    pending->visible = (update->flags & LI_CURSOR_UPDATE_FLAG_VISIBLE) != 0;
+    pending->shapeId = update->shapeId;
+    pending->width = update->width;
+    pending->height = update->height;
+    pending->hotspotX = update->hotspotX;
+    pending->hotspotY = update->hotspotY;
+    if (pending->hasShape && update->pixels != nullptr && update->pixelDataLength != 0) {
+        pending->bgra = QByteArray(
+            reinterpret_cast<const char*>(update->pixels),
+            static_cast<int>(update->pixelDataLength));
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(session->m_CursorUpdateMutex);
+        session->m_PendingCursorUpdate = pending;
+    }
+
+    SDL_Event cursorEvent = {};
+    cursorEvent.type = SDL_USEREVENT;
+    cursorEvent.user.code = SDL_CODE_CURSOR_UPDATE;
+    if (SDL_PushEvent(&cursorEvent) <= 0) {
+        std::lock_guard<std::mutex> lock(session->m_CursorUpdateMutex);
+        if (session->m_PendingCursorUpdate == pending) {
+            session->m_PendingCursorUpdate.reset();
+        }
+    }
 }
 
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
@@ -3161,6 +3200,16 @@ bool Session::startConnectionAsync()
         return false;
     }
 
+    if (m_InputHandler != nullptr) {
+        const int cursorResult =
+            LiSetCursorMode(m_InputHandler->getLocalCursorMode());
+        if (cursorResult != 0 && cursorResult != -2) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Failed to set initial local cursor mode: %d",
+                        cursorResult);
+        }
+    }
+
     emit connectionStarted();
     startSunshineAbr();
     startFileMappingUxProbe();
@@ -3690,6 +3739,18 @@ void Session::exec()
             case SDL_CODE_FLUSH_TOUCHPAD_FRAME:
                 m_InputHandler->flushPendingTouchpadFrameEvent();
                 break;
+            case SDL_CODE_CURSOR_UPDATE:
+            {
+                std::shared_ptr<RemoteCursorUpdate> cursorUpdate;
+                {
+                    std::lock_guard<std::mutex> lock(m_CursorUpdateMutex);
+                    cursorUpdate.swap(m_PendingCursorUpdate);
+                }
+                if (cursorUpdate != nullptr && m_InputHandler != nullptr) {
+                    m_InputHandler->updateRemoteCursor(*cursorUpdate);
+                }
+                break;
+            }
             default:
                 SDL_assert(false);
             }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -503,9 +503,18 @@ void Session::clCursorUpdate(const LI_CURSOR_UPDATE* update)
             static_cast<int>(update->pixelDataLength));
     }
 
+    bool queueCursorEvent = false;
     {
         std::lock_guard<std::mutex> lock(session->m_CursorUpdateMutex);
         session->m_PendingCursorUpdate = pending;
+        if (!session->m_CursorUpdateEventQueued) {
+            session->m_CursorUpdateEventQueued = true;
+            queueCursorEvent = true;
+        }
+    }
+
+    if (!queueCursorEvent) {
+        return;
     }
 
     SDL_Event cursorEvent = {};
@@ -513,9 +522,9 @@ void Session::clCursorUpdate(const LI_CURSOR_UPDATE* update)
     cursorEvent.user.code = SDL_CODE_CURSOR_UPDATE;
     if (SDL_PushEvent(&cursorEvent) <= 0) {
         std::lock_guard<std::mutex> lock(session->m_CursorUpdateMutex);
-        if (session->m_PendingCursorUpdate == pending) {
-            session->m_PendingCursorUpdate.reset();
-        }
+        // Keep the latest mailbox value. A subsequent callback will enqueue
+        // another wakeup after observing the cleared flag.
+        session->m_CursorUpdateEventQueued = false;
     }
 }
 
@@ -3203,7 +3212,8 @@ bool Session::startConnectionAsync()
     if (m_InputHandler != nullptr) {
         const int cursorResult =
             LiSetCursorMode(m_InputHandler->getLocalCursorMode());
-        if (cursorResult != 0 && cursorResult != -2) {
+        if (cursorResult != LI_CURSOR_MODE_OK &&
+            cursorResult != LI_CURSOR_MODE_ERR_UNSUPPORTED) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "Failed to set initial local cursor mode: %d",
                         cursorResult);
@@ -3745,6 +3755,7 @@ void Session::exec()
                 {
                     std::lock_guard<std::mutex> lock(m_CursorUpdateMutex);
                     cursorUpdate.swap(m_PendingCursorUpdate);
+                    m_CursorUpdateEventQueued = false;
                 }
                 if (cursorUpdate != nullptr && m_InputHandler != nullptr) {
                     m_InputHandler->updateRemoteCursor(*cursorUpdate);

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 
 #include <Limelight.h>
 #include <opus_multistream.h>
@@ -266,6 +267,9 @@ private:
     void clClipboardData(const char* data, int length);
 
     static
+    void clCursorUpdate(const LI_CURSOR_UPDATE* update);
+
+    static
     int arInit(int audioConfiguration,
                const POPUS_MULTISTREAM_CONFIGURATION opusConfig,
                void* arContext, int arFlags);
@@ -363,6 +367,8 @@ private:
     QString m_FileMappingSessionId;
     Uint32 m_MenuCloseTicks;       // 菜单关闭时间戳（防抖）
     class ClipboardHelperClient* m_ClipboardHelper; // Bidirectional clipboard sync helper process; nullptr when stream not active
+    std::mutex m_CursorUpdateMutex;
+    std::shared_ptr<RemoteCursorUpdate> m_PendingCursorUpdate;
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -369,6 +369,7 @@ private:
     class ClipboardHelperClient* m_ClipboardHelper; // Bidirectional clipboard sync helper process; nullptr when stream not active
     std::mutex m_CursorUpdateMutex;
     std::shared_ptr<RemoteCursorUpdate> m_PendingCursorUpdate;
+    bool m_CursorUpdateEventQueued = false;
 
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;

--- a/moonlight-common-c/moonlight-common-c.pro
+++ b/moonlight-common-c/moonlight-common-c.pro
@@ -58,6 +58,7 @@ SOURCES += \
     $$COMMON_C_DIR/src/Connection.c \
     $$COMMON_C_DIR/src/ConnectionTester.c \
     $$COMMON_C_DIR/src/ControlStream.c \
+    $$COMMON_C_DIR/src/CursorStream.c \
     $$COMMON_C_DIR/src/FakeCallbacks.c \
     $$COMMON_C_DIR/src/InputStream.c \
     $$COMMON_C_DIR/src/MicrophoneStream.c \
@@ -75,6 +76,7 @@ SOURCES += \
     $$COMMON_C_DIR/src/VideoDepacketizer.c \
     $$COMMON_C_DIR/src/VideoStream.c
 HEADERS += \
+    $$COMMON_C_DIR/src/CursorStream.h \
     $$COMMON_C_DIR/src/Limelight.h
 INCLUDEPATH += \
     $$ENET_DIR/include \


### PR DESCRIPTION
## 改了啥呀

- 根据绝对鼠标模式和本地光标可见性，向 Sunshine 同步本地/视频光标模式。
- 接收 common-c 重组后的 BGRA 光标形态、热点和可见性更新。
- 通过线程安全 latest-value 邮箱把回调送到 SDL 线程，在正确线程创建、替换和释放 `SDL_Cursor`。
- 模式切换、捕获切换和鼠标离开视频区域时统一计算实际可见性，避免双光标和残留指针这些杂鱼状态。
- 更新 common-c 子模块到 qiin2333/moonlight-common-c#16 的协议提交。

## 为啥要改

本地绝对光标能降低移动延迟，但此前始终使用客户端默认箭头，远端进入文本框、窗口边缘或链接时不会改变形态。现在坐标仍由客户端本地保持低延迟，形态、热点和显示状态则跟随主机同步。

## 关联 PR

- qiin2333/moonlight-common-c#16
- AlkaidLab/foundation-sunshine#879

## 验证

- Qt 6.9.2 + MSVC 2022 Release：`nmake /NOLOGO`。
- common-c 与 Moonlight Qt 完整编译、链接生成 `Moonlight.exe`。
- `git diff --check`。
- 真实 VDD 串流环境仍需联调确认各类系统光标的视觉效果。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for receiving, validating, and displaying remote cursor updates during streaming sessions.
* **Bug Fixes**
  * Improved synchronization of local vs remote cursor visibility across session start, mouse capture, and video region transitions.
  * Ensured cursor switching reliably installs/uninstalls the remote cursor and applies the correct captured cursor state.
  * Added stronger validation for incoming remote cursor shape/buffer data to avoid broken cursors.
* **Chores**
  * Updated cursor-streaming build configuration to include cursor stream sources/headers, and refreshed the shared cursor-streaming component revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->