### PR TITLE
fix(macos): scale remote cursors for Retina

### DIFF
--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -45,6 +45,8 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
                             LI_CURSOR_MODE_LOCAL : LI_CURSOR_MODE_VIDEO),
       m_RemoteCursorVisible(true),
       m_RemoteCursor(nullptr),
+      m_HasLastCursorShape(false),
+      m_RemoteCursorScale(1.0),
       m_LongPressTimer(0),
       m_StreamWidth(streamWidth),
       m_StreamHeight(streamHeight),
@@ -398,6 +400,56 @@ void SdlInputHandler::synchronizeLocalCursorMode()
     }
 }
 
+qreal SdlInputHandler::getRemoteCursorScale() const
+{
+#ifdef Q_OS_MACOS
+    // SDL 的 Cocoa 后端把 surface 的像素宽高当成 NSImage 的逻辑 point 尺寸，所以
+    // Retina 屏上要先按 backing 比例把光标缩回去。比例从窗口的 point / pixel 尺寸算，
+    // 而不是问屏幕 —— 窗口横跨两块屏时它反映的是实际渲染用的那个 backing store。
+    if (m_Window == nullptr) {
+        return 1.0;
+    }
+
+    int windowWidth = 0;
+    int windowHeight = 0;
+    int pixelWidth = 0;
+    int pixelHeight = 0;
+    SDL_GetWindowSize(m_Window, &windowWidth, &windowHeight);
+    SDL_GetWindowSizeInPixels(m_Window, &pixelWidth, &pixelHeight);
+
+    if (windowWidth <= 0 || windowHeight <= 0 ||
+        pixelWidth < windowWidth || pixelHeight < windowHeight) {
+        return 1.0;
+    }
+
+    return static_cast<qreal>(pixelWidth) / windowWidth;
+#else
+    return 1.0;
+#endif
+}
+
+void SdlInputHandler::refreshRemoteCursorScale()
+{
+#ifdef Q_OS_MACOS
+    // 缩放比例是创建光标那一刻算的，而 updateRemoteCursor() 只在主机推来新形状时才会
+    // 被调用。窗口从 Retina 屏拖到 1x 屏（或反过来）时，光标会一直停在旧比例上 ——
+    // 大一倍或小一倍 —— 直到主机下一次换形状。这里用缓存的那份形状重建一次。
+    if (!m_HasLastCursorShape) {
+        return;
+    }
+
+    const qreal scale = getRemoteCursorScale();
+    if (qFuzzyCompare(scale, m_RemoteCursorScale)) {
+        return;
+    }
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                "Rebuilding remote cursor for backing scale %f -> %f",
+                m_RemoteCursorScale, scale);
+    updateRemoteCursor(m_LastCursorShape);
+#endif
+}
+
 void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
 {
     m_RemoteCursorVisible = update.visible;
@@ -423,22 +475,12 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
 
 #ifdef Q_OS_MACOS
             QImage scaledCursor;
-            int windowWidth = 0;
-            int windowHeight = 0;
-            int pixelWidth = 0;
-            int pixelHeight = 0;
-            if (m_Window != nullptr) {
-                SDL_GetWindowSize(m_Window, &windowWidth, &windowHeight);
-                SDL_GetWindowSizeInPixels(m_Window, &pixelWidth, &pixelHeight);
-            }
-            if (windowWidth > 0 && windowHeight > 0 &&
-                pixelWidth >= windowWidth && pixelHeight >= windowHeight) {
-                const qreal scaleX = static_cast<qreal>(pixelWidth) / windowWidth;
-                const qreal scaleY = static_cast<qreal>(pixelHeight) / windowHeight;
-                cursorWidth = qMax(1, qRound(update.width / scaleX));
-                cursorHeight = qMax(1, qRound(update.height / scaleY));
-                hotspotX = qBound(0, qRound(update.hotspotX / scaleX), cursorWidth - 1);
-                hotspotY = qBound(0, qRound(update.hotspotY / scaleY), cursorHeight - 1);
+            const qreal scale = getRemoteCursorScale();
+            if (scale > 1.0) {
+                cursorWidth = qMax(1, qRound(update.width / scale));
+                cursorHeight = qMax(1, qRound(update.height / scale));
+                hotspotX = qBound(0, qRound(update.hotspotX / scale), cursorWidth - 1);
+                hotspotY = qBound(0, qRound(update.hotspotY / scale), cursorHeight - 1);
 
                 if (cursorWidth != update.width || cursorHeight != update.height) {
                     const QImage source(
@@ -482,6 +524,12 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
                 else {
                     resetRemoteCursor();
                     m_RemoteCursor = cursor;
+
+                    // 记下这一份形状和它用的缩放比例。换显示器时靠它重建 ——
+                    // 主机不会因为我们换了屏就重推一次形状。
+                    m_LastCursorShape = update;
+                    m_HasLastCursorShape = true;
+                    m_RemoteCursorScale = getRemoteCursorScale();
                 }
             }
         }

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -12,6 +12,9 @@
 #include <QtGlobal>
 #include <QDir>
 #include <QGuiApplication>
+#ifdef Q_OS_MACOS
+#include <QImage>
+#endif
 
 // Include SDL_syswm.h after Qt headers to avoid X11 macro conflicts on Linux
 #include <SDL_syswm.h>
@@ -411,12 +414,56 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
                         update.shapeId);
         }
         else {
+            int cursorWidth = update.width;
+            int cursorHeight = update.height;
+            int hotspotX = update.hotspotX;
+            int hotspotY = update.hotspotY;
+            int cursorPitch = update.width * 4;
+            const char* cursorPixels = update.bgra.constData();
+
+#ifdef Q_OS_MACOS
+            QImage scaledCursor;
+            int windowWidth = 0;
+            int windowHeight = 0;
+            int pixelWidth = 0;
+            int pixelHeight = 0;
+            if (m_Window != nullptr) {
+                SDL_GetWindowSize(m_Window, &windowWidth, &windowHeight);
+                SDL_GetWindowSizeInPixels(m_Window, &pixelWidth, &pixelHeight);
+            }
+            if (windowWidth > 0 && windowHeight > 0 &&
+                pixelWidth >= windowWidth && pixelHeight >= windowHeight) {
+                const qreal scaleX = static_cast<qreal>(pixelWidth) / windowWidth;
+                const qreal scaleY = static_cast<qreal>(pixelHeight) / windowHeight;
+                cursorWidth = qMax(1, qRound(update.width / scaleX));
+                cursorHeight = qMax(1, qRound(update.height / scaleY));
+                hotspotX = qBound(0, qRound(update.hotspotX / scaleX), cursorWidth - 1);
+                hotspotY = qBound(0, qRound(update.hotspotY / scaleY), cursorHeight - 1);
+
+                if (cursorWidth != update.width || cursorHeight != update.height) {
+                    const QImage source(
+                        reinterpret_cast<const uchar*>(update.bgra.constData()),
+                        update.width,
+                        update.height,
+                        update.width * 4,
+                        QImage::Format_ARGB32);
+                    scaledCursor = source.scaled(
+                        cursorWidth,
+                        cursorHeight,
+                        Qt::IgnoreAspectRatio,
+                        Qt::SmoothTransformation);
+                    cursorPixels = reinterpret_cast<const char*>(scaledCursor.constBits());
+                    cursorPitch = scaledCursor.bytesPerLine();
+                }
+            }
+#endif
+
             SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormatFrom(
-                const_cast<char*>(update.bgra.constData()),
-                update.width,
-                update.height,
+                const_cast<char*>(cursorPixels),
+                cursorWidth,
+                cursorHeight,
                 32,
-                update.width * 4,
+                cursorPitch,
                 SDL_PIXELFORMAT_BGRA32);
             if (surface == nullptr) {
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
@@ -425,7 +472,7 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
             }
             else {
                 SDL_Cursor* cursor =
-                    SDL_CreateColorCursor(surface, update.hotspotX, update.hotspotY);
+                    SDL_CreateColorCursor(surface, hotspotX, hotspotY);
                 SDL_FreeSurface(surface);
                 if (cursor == nullptr) {
                     SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -184,6 +184,9 @@ public:
 
     void updateRemoteCursor(const RemoteCursorUpdate& update);
 
+    // 显示器变化后按新的 backing 比例重建远端光标（只有 macOS 需要）
+    void refreshRemoteCursorScale();
+
     void synchronizeLocalCursorMode();
 
     int getLocalCursorMode() const;
@@ -220,6 +223,8 @@ public:
     void setGamepadMouse(bool enabled) { m_GamepadMouse = enabled; }
 
 private:
+    qreal getRemoteCursorScale() const;
+
 
     GamepadState*
     findStateForGamepad(SDL_JoystickID id);
@@ -332,6 +337,10 @@ private:
     std::atomic<int> m_LocalCursorMode;
     bool m_RemoteCursorVisible;
     SDL_Cursor* m_RemoteCursor;
+    // 最后一份成功建出光标的形状，以及当时用的 backing 比例
+    RemoteCursorUpdate m_LastCursorShape;
+    bool m_HasLastCursorShape;
+    qreal m_RemoteCursorScale;
 
     struct {
         KeyCombo keyCombo;

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -3796,6 +3796,11 @@ void Session::exec()
             case SDL_WINDOWEVENT_MOVED:
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 syncQtOverlayWindowsWithSdlWindowState();
+                // 远端光标的尺寸是按窗口的 backing 比例算的（见 getRemoteCursorScale()），
+                // 换屏、改分辨率、改缩放都会让它失效。挂在这一组事件上而不是只挂
+                // DISPLAY_CHANGED：同一块屏上改系统缩放只会发 SIZE_CHANGED。
+                // 比例没变时这个调用会直接返回，挂宽一点不亏。
+                m_InputHandler->refreshRemoteCursorScale();
                 break;
             }
 


### PR DESCRIPTION
## 改了啥呀

- macOS 创建远端系统光标前，根据 SDL 窗口逻辑尺寸与 backing-pixel 尺寸计算 Retina 缩放
- 同步缩放光标图像和热点位置
- 仅在确有 HiDPI 比例时生成平滑缩放图像，其他平台路径保持原样

## 为啥

SDL Cocoa 后端把传入 surface 的像素宽高当作 NSImage 的逻辑 point 尺寸。Retina 屏上 64×64 的 Windows 光标因此会显示成 64pt，也就是视觉尺寸放大一倍。现在先换算回逻辑尺寸，杂鱼大光标终于不会挡住半个输入框了。

## 影响

仅影响 macOS 的远端本地光标创建；1x 屏幕及 Windows/Linux 行为不变。

## 验证

- Qt 6.11.1 / MSVC 2022：`release\\input.obj` 编译通过
- 服务端完整链路已实测；该 PR 的 macOS 客户端产物用于最终 Retina 尺寸确认

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote cursor rendering on macOS.
  * Cursor images now scale correctly for high-resolution displays, including accurate size, hotspot positioning, and alignment.
  * Cursor scaling updates automatically when windows move, resize, minimize, restore, or change display scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->