### PR TITLE
chore(ci): 收拾 CI 卫生问题（DMG 架构、死 workflow、action 版本）

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -4,6 +4,14 @@ permissions:
   contents: read
 
 on:
+  # 目前没有别的 workflow 调用这一份（发布走 build.yml），加上手动触发至少让它
+  # 可以被单独跑一次验证，而不是躺在仓库里永远不执行。
+  workflow_dispatch:
+    inputs:
+      ci_version:
+        required: false
+        default: manual
+        type: string
   workflow_call:
     inputs:
       ci_version:

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -4,6 +4,14 @@ permissions:
   contents: read
 
 on:
+  # 目前没有别的 workflow 调用这一份（发布走 build.yml），加上手动触发至少让它
+  # 可以被单独跑一次验证，而不是躺在仓库里永远不执行。
+  workflow_dispatch:
+    inputs:
+      ci_version:
+        required: false
+        default: manual
+        type: string
   workflow_call:
     inputs:
       ci_version:

--- a/.github/workflows/build-translate.yml
+++ b/.github/workflows/build-translate.yml
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: '6.11.1'
         arch: 'win64_msvc2022_64'

--- a/.github/workflows/build-win-mac.yml
+++ b/.github/workflows/build-win-mac.yml
@@ -4,6 +4,14 @@ permissions:
   contents: read
 
 on:
+  # 目前没有别的 workflow 调用这一份（发布走 build.yml），加上手动触发至少让它
+  # 可以被单独跑一次验证，而不是躺在仓库里永远不执行。
+  workflow_dispatch:
+    inputs:
+      ci_version:
+        required: false
+        default: manual
+        type: string
   workflow_call:
     inputs:
       ci_version:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
         echo "CI_VERSION=$VERSION" >> $GITHUB_ENV
 
     - name: Install Qt 6.11.1
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: '6.11.1'
         modules: 'qtmultimedia qtimageformats'
@@ -226,7 +226,9 @@ jobs:
         echo "PKG_CONFIG_PATH=$HOME/local/lib/pkgconfig:$HOME/local/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
         echo "UBUNTU_RELEASE=$(lsb_release -rs)" >> $GITHUB_ENV
 
-    # This may still install various Qt packages, but the later install step will override them
+    # 注意顺序：上面的 install-qt-action 已经装好了 6.11.1 并把它的 qmake 放进 PATH，
+    # 这一步在它之后。所以这里不要再 apt 装任何 Qt 包 —— 发行版的 Qt（jammy 上是
+    # 6.2.x）不会被用到，装了只是白下载，还可能在 AppImage 打包阶段被扫进去。
     - name: Install packaged deps
       run: |
         wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
@@ -243,7 +245,7 @@ jobs:
           libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev libxss-dev libxt-dev \
           libxv-dev libxxf86vm-dev libxcb-dri3-dev libx11-xcb-dev libwayland-dev wayland-protocols \
           libxfixes-dev libxtst-dev libpipewire-0.3-dev \
-          libopus-dev libvdpau-dev vulkan-sdk qt6-multimedia-dev cmake
+          libopus-dev libvdpau-dev vulkan-sdk cmake
         
         # Install XCB runtime libraries for Qt6 XCB platform plugin
         echo "Installing XCB runtime libraries..."

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 推荐从本 fork 的 [GitHub Releases](https://github.com/qiin2333/moonlight-qt/releases) 下载 Windows、macOS、Linux AppImage 和 Steam Link 构建产物。
 
+> **macOS 目前只提供 Apple Silicon（arm64）构建**，资产名形如 `Moonlight-<版本>-arm64.dmg`。Intel Mac 需要自行按下面「从源码构建」的步骤编译。
+
 如果你需要上游 Moonlight 的官方发行渠道、移动端客户端、Flatpak、Snap 或发行版软件源，请参考 [Moonlight 官方网站](https://moonlight-stream.org) 和 [上游仓库](https://github.com/moonlight-stream/moonlight-qt)。这些渠道不一定包含本 fork 与 Foundation Sunshine 配套的扩展能力。
 
 ## Foundation Sunshine 协同

--- a/app/backend/autoupdatechecker.cpp
+++ b/app/backend/autoupdatechecker.cpp
@@ -123,6 +123,22 @@ void AutoUpdateChecker::parseStringToVersionQuad(const QString& string, QVector<
     }
 }
 
+QString AutoUpdateChecker::getPreferredAssetSuffix() const
+{
+#if defined(Q_OS_DARWIN)
+    // CI 出的 DMG 现在带架构后缀（Moonlight-<版本>-arm64.dmg）。
+    // QSysInfo::buildCpuArchitecture() 给的是 arm64 / x86_64，和 generate-dmg.sh
+    // 里的 MOONLIGHT_ARCH 用词一致。
+    //
+    // 只是「优先」而不是「必须」：这个后缀是从某个版本才开始有的，旧 release 里是
+    // Moonlight-<版本>.dmg。匹配不到就退回任意 .dmg，否则老版本的用户会看到
+    // 「找不到更新包」。
+    return QStringLiteral("-") + QSysInfo::buildCpuArchitecture() + QStringLiteral(".dmg");
+#else
+    return QString();
+#endif
+}
+
 QString AutoUpdateChecker::getExpectedAssetSuffix() const
 {
 #if defined(Q_OS_WIN32)
@@ -277,8 +293,15 @@ void AutoUpdateChecker::handleUpdateCheckRequestFinished(QNetworkReply* reply)
             QString expectedPrefix = getExpectedAssetPrefix();
             QString expectedSuffix = getExpectedAssetSuffix();
 
+            QString preferredSuffix = getPreferredAssetSuffix();
+
             if (!expectedSuffix.isEmpty() && releaseObj.contains("assets") && releaseObj["assets"].isArray()) {
                 QJsonArray assets = releaseObj["assets"].toArray();
+
+                // 后备候选：后缀对得上但不带本机架构后缀的那个（旧 release 的命名）
+                QString fallbackUrl;
+                QString fallbackName;
+
                 for (const auto& asset : std::as_const(assets)) {
                     if (asset.isObject()) {
                         QJsonObject assetObj = asset.toObject();
@@ -287,12 +310,27 @@ void AutoUpdateChecker::handleUpdateCheckRequestFinished(QNetworkReply* reply)
                                              assetName.startsWith(expectedPrefix, Qt::CaseInsensitive);
                         bool suffixMatches = assetName.endsWith(expectedSuffix, Qt::CaseInsensitive);
 
-                        if (prefixMatches && suffixMatches) {
+                        if (!prefixMatches || !suffixMatches) {
+                            continue;
+                        }
+
+                        if (!preferredSuffix.isEmpty() &&
+                                assetName.endsWith(preferredSuffix, Qt::CaseInsensitive)) {
                             downloadUrl = assetObj["browser_download_url"].toString();
-                            qDebug() << "Found matching asset:" << assetName;
+                            qDebug() << "Found matching asset for this architecture:" << assetName;
                             break;
                         }
+
+                        if (fallbackUrl.isEmpty()) {
+                            fallbackUrl = assetObj["browser_download_url"].toString();
+                            fallbackName = assetName;
+                        }
                     }
+                }
+
+                if (downloadUrl.isEmpty() && !fallbackUrl.isEmpty()) {
+                    downloadUrl = fallbackUrl;
+                    qDebug() << "Found matching asset:" << fallbackName;
                 }
             }
 

--- a/app/backend/autoupdatechecker.cpp
+++ b/app/backend/autoupdatechecker.cpp
@@ -321,7 +321,15 @@ void AutoUpdateChecker::handleUpdateCheckRequestFinished(QNetworkReply* reply)
                             break;
                         }
 
-                        if (fallbackUrl.isEmpty()) {
+                        // 后备只认「没带架构后缀」的旧命名。带了别的架构后缀的资产
+                        // 绝对不能当后备 —— 只发了 arm64 包的 release 会把 arm64 的
+                        // DMG 喂给 Intel 客户端。这种情况下宁可让 downloadUrl 留空，
+                        // 退回打开 release 页面让用户自己看。
+                        bool isOtherArchAsset =
+                                assetName.endsWith(QStringLiteral("-arm64.dmg"), Qt::CaseInsensitive) ||
+                                assetName.endsWith(QStringLiteral("-x86_64.dmg"), Qt::CaseInsensitive);
+
+                        if (fallbackUrl.isEmpty() && !isOtherArchAsset) {
                             fallbackUrl = assetObj["browser_download_url"].toString();
                             fallbackName = assetName;
                         }

--- a/app/backend/autoupdatechecker.h
+++ b/app/backend/autoupdatechecker.h
@@ -33,6 +33,8 @@ private:
     bool isPortableInstall() const;
     QString getExpectedAssetPrefix() const;
     QString getExpectedAssetSuffix() const;
+    // 同一个后缀里再优先挑本机架构的那个资产（macOS 的 DMG 带 -arm64 / -x86_64）
+    QString getPreferredAssetSuffix() const;
     QString getCurrentBuildArch() const;
 
     QVector<int> m_CurrentVersionQuad;

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -143,5 +143,8 @@ if [ "$NOTARY_KEYCHAIN_PROFILE" != "" ]; then
   xcrun stapler staple -v $INSTALLER_FOLDER/Moonlight.dmg || fail "Notary ticket stapling failed!"
 fi
 
-mv $INSTALLER_FOLDER/Moonlight.dmg $INSTALLER_FOLDER/Moonlight-$VERSION.dmg
+# 名字里带上架构。这里只出一个架构的包（见上面 MOONLIGHT_ARCH 的注释），叫
+# Moonlight-<版本>.dmg 的话下载的人无法从名字判断能不能装 —— Intel Mac 上装了
+# 才发现打不开。app 侧的更新器也靠这个后缀挑对应架构的资产。
+mv $INSTALLER_FOLDER/Moonlight.dmg $INSTALLER_FOLDER/Moonlight-$VERSION-$MOONLIGHT_ARCH.dmg
 echo Build successful

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -146,5 +146,5 @@ fi
 # 名字里带上架构。这里只出一个架构的包（见上面 MOONLIGHT_ARCH 的注释），叫
 # Moonlight-<版本>.dmg 的话下载的人无法从名字判断能不能装 —— Intel Mac 上装了
 # 才发现打不开。app 侧的更新器也靠这个后缀挑对应架构的资产。
-mv $INSTALLER_FOLDER/Moonlight.dmg $INSTALLER_FOLDER/Moonlight-$VERSION-$MOONLIGHT_ARCH.dmg
+mv "$INSTALLER_FOLDER/Moonlight.dmg" "$INSTALLER_FOLDER/Moonlight-$VERSION-$MOONLIGHT_ARCH.dmg"
 echo Build successful


### PR DESCRIPTION
起因是想确认「CI 是否和本地一样用 Qt 6.11.1」。**Qt 版本本身没问题** —— Windows / macOS / Linux / 翻译四条线都是 6.11.1，和本地 homebrew 的一致，部署目标也都是 `-mmacosx-version-min=14.0`（来自 Qt 6.11 的 mkspec）。但查的过程里翻出几件该收拾的。

## 1. 发布的 DMG 是 arm64 单架构，名字却看不出来

`generate-dmg.sh` 在没有 `MOONLIGHT_ARCH` 时按 `uname -m` 走，而 macOS runner 是 Apple Silicon，工作流也没设这个变量。实测已发布的 6.3.0 产物：

```
lipo -archs /Applications/Moonlight.app/Contents/MacOS/Moonlight → arm64
```

资产名却是 `Moonlight-6.3.0.dmg`，**Intel Mac 用户下载安装之后才会发现打不开**。

- 资产名带上架构：`Moonlight-<版本>-arm64.dmg`
- README 的下载段写清只提供 Apple Silicon 构建，Intel 需自行编译
- **暂不加 Intel 构建**：会让 macOS CI 时间翻倍，而且需求未必存在。要加的话是一个 matrix 分支的事，随时可以补

## 2. 名字一改，更新器必须认得出来

macOS 侧原来只按 `.dmg` 后缀匹配，取第一个命中的 —— 一个 release 里出现多个 DMG 时会拿错架构的包。改成：

1. 先找 `-<本机架构>.dmg`（`QSysInfo::buildCpuArchitecture()`，实测在 Apple Silicon 上就是 `arm64`，和 `MOONLIGHT_ARCH` 用词一致）
2. 找不到再退回任意 `.dmg`

第 2 步是**必须**的：旧 release 的资产没有架构后缀，不留后路的话老版本用户会看到「找不到更新包」。

## 3. 三个 workflow 永远不会执行

`build-win-mac.yml`、`build-appimage.yml`、`build-steamlink.yml` 都只声明了 `workflow_call`，而全仓库搜 `uses: ./.github/workflows/` 是**空的** —— 没有任何调用点。发布实际走的是 `build.yml`。

有点讽刺的是那三个才是「新版」（windows-2025 / macos-26 / `upload-artifact@v6`），而在跑的 `build.yml` 用的是更旧的 runner。这次只给它们加 `workflow_dispatch`，至少能手动触发验证，不删也不改接线 —— 要不要把 `build.yml` 反过来改成调用它们，是另一个决定。

## 4. `install-qt-action@v3` 升到 v4

`build.yml` 的 Linux 任务和 `build-translate.yml` 还在用 v3（Node 16，GitHub 已在逐步淘汰），升到 v4 和 macOS 任务对齐。Windows 用的是 `jdpurcell/install-qt-action@v5`（另一个 fork），没动。

## 5. Linux 任务混装了发行版的 Qt

顺序是先 `install-qt-action` 装 6.11.1，**之后**才 `apt install ... qt6-multimedia-dev`（jammy 上是 6.2.x）。工作流里那句注释写的是「后面的安装步骤会覆盖它们」，和实际顺序正好相反。发行版那份根本不会被用到（aqt 把自己的 qmake 放进了 PATH），装了只是白下载，还可能在 AppImage 打包阶段被扫进去。去掉该包，注释改成实际情况。

## 验证

- 更新器的资产选择逻辑用一个 harness 打了**真实的 GitHub API**（把 `VERSION_STR` 编成 6.0.0 以触发「有更新」）：当前 release 里没有带架构后缀的 DMG，于是正确走了后备分支 → `Found matching asset: "Moonlight-6.3.0.dmg"`
- `QSysInfo::buildCpuArchitecture()` 实测返回 `arm64`（不是 `aarch64`），所以首选后缀确实是 `-arm64.dmg`，和 `generate-dmg.sh` 产出的名字对得上
- 五个 workflow 的 YAML 都能正常解析，触发器如预期
- 本地构建 + 启动零报错

**这个 PR 本身会触发 `build.yml`**（它监听 `pull_request`），所以第 4、5 两条改动会在合并前由真实 CI 跑一遍 —— 这是我在本地无法验证的部分。合并前请确认那次运行是绿的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added architecture-aware macOS update downloads, including Apple Silicon-specific DMG selection with compatibility fallback.
  * macOS DMG filenames now identify the target architecture.
  * Build workflows can now be started manually with an optional version label.

* **Bug Fixes**
  * Improved Qt setup for Linux and translation builds.

* **Documentation**
  * Clarified that current macOS releases support Apple Silicon, with source builds recommended for Intel Macs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->