### PR TITLE
perf(ui): improve Windows responsiveness and switch input

### DIFF
--- a/app/backend/boxartmanager.cpp
+++ b/app/backend/boxartmanager.cpp
@@ -3,6 +3,7 @@
 
 #include <QImageReader>
 #include <QImageWriter>
+#include <QMutexLocker>
 
 BoxArtManager::BoxArtManager(QObject *parent) :
     QObject(parent),
@@ -43,6 +44,27 @@ bool BoxArtManager::isPlaceholderBoxArt(const QSize& size)
            size == QSize(200, 266);
 }
 
+bool BoxArtManager::isCachedPlaceholderBoxArt(const QString& cachePath)
+{
+    {
+        QMutexLocker locker(&m_PlaceholderCacheMutex);
+        const auto cached = m_PlaceholderCache.constFind(cachePath);
+        if (cached != m_PlaceholderCache.constEnd()) {
+            return cached.value();
+        }
+    }
+
+    const bool isPlaceholder = isPlaceholderBoxArt(QImageReader(cachePath).size());
+    rememberPlaceholderBoxArt(cachePath, isPlaceholder);
+    return isPlaceholder;
+}
+
+void BoxArtManager::rememberPlaceholderBoxArt(const QString& cachePath, bool isPlaceholder)
+{
+    QMutexLocker locker(&m_PlaceholderCacheMutex);
+    m_PlaceholderCache.insert(cachePath, isPlaceholder);
+}
+
 class NetworkBoxArtLoadTask : public QObject, public QRunnable
 {
     Q_OBJECT
@@ -81,8 +103,7 @@ QUrl BoxArtManager::loadBoxArt(NvComputer* computer, NvApp& app)
     // Try to open the cached file if it exists and contains data
     QFile cacheFile(getFilePathForBoxArt(computer, app.id));
     if (cacheFile.exists() && cacheFile.size() > 0) {
-        QImageReader reader(cacheFile.fileName());
-        if (!app.isAppCollectorGame && isPlaceholderBoxArt(reader.size())) {
+        if (!app.isAppCollectorGame && isCachedPlaceholderBoxArt(cacheFile.fileName())) {
             return QUrl("qrc:/res/no_app_image.png");
         }
         return QUrl::fromLocalFile(cacheFile.fileName());
@@ -128,7 +149,10 @@ QUrl BoxArtManager::loadBoxArtFromNetwork(NvComputer* computer, const NvApp& app
     // Cache the box art on disk if it loaded
     if (!image.isNull()) {
         if (image.save(cachePath)) {
-            if (!app.isAppCollectorGame && isPlaceholderBoxArt(image.size())) {
+            const bool isPlaceholder = !app.isAppCollectorGame &&
+                    isPlaceholderBoxArt(image.size());
+            rememberPlaceholderBoxArt(cachePath, isPlaceholder);
+            if (isPlaceholder) {
                 return QUrl("qrc:/res/no_app_image.png");
             }
             return QUrl::fromLocalFile(cachePath);

--- a/app/backend/boxartmanager.cpp
+++ b/app/backend/boxartmanager.cpp
@@ -149,10 +149,12 @@ QUrl BoxArtManager::loadBoxArtFromNetwork(NvComputer* computer, const NvApp& app
     // Cache the box art on disk if it loaded
     if (!image.isNull()) {
         if (image.save(cachePath)) {
-            const bool isPlaceholder = !app.isAppCollectorGame &&
-                    isPlaceholderBoxArt(image.size());
+            // Cache only the image property. App classification is applied by
+            // the caller so a later classification change cannot poison this
+            // path's cached result.
+            const bool isPlaceholder = isPlaceholderBoxArt(image.size());
             rememberPlaceholderBoxArt(cachePath, isPlaceholder);
-            if (isPlaceholder) {
+            if (!app.isAppCollectorGame && isPlaceholder) {
                 return QUrl("qrc:/res/no_app_image.png");
             }
             return QUrl::fromLocalFile(cachePath);

--- a/app/backend/boxartmanager.cpp
+++ b/app/backend/boxartmanager.cpp
@@ -36,6 +36,13 @@ BoxArtManager::getFilePathForBoxArt(NvComputer* computer, int appId)
     return dir.filePath(QString::number(appId) + ".png");
 }
 
+bool BoxArtManager::isPlaceholderBoxArt(const QSize& size)
+{
+    return size == QSize(130, 180) ||
+           size == QSize(628, 888) ||
+           size == QSize(200, 266);
+}
+
 class NetworkBoxArtLoadTask : public QObject, public QRunnable
 {
     Q_OBJECT
@@ -56,10 +63,10 @@ signals:
 private:
     void run()
     {
-        QUrl image = m_Bam->loadBoxArtFromNetwork(m_Computer, m_App.id);
+        QUrl image = m_Bam->loadBoxArtFromNetwork(m_Computer, m_App);
         if (image.isEmpty()) {
             // Give it another shot if it fails once
-            image = m_Bam->loadBoxArtFromNetwork(m_Computer, m_App.id);
+            image = m_Bam->loadBoxArtFromNetwork(m_Computer, m_App);
         }
         emit boxArtFetchCompleted(m_Computer, m_App, image);
     }
@@ -74,6 +81,10 @@ QUrl BoxArtManager::loadBoxArt(NvComputer* computer, NvApp& app)
     // Try to open the cached file if it exists and contains data
     QFile cacheFile(getFilePathForBoxArt(computer, app.id));
     if (cacheFile.exists() && cacheFile.size() > 0) {
+        QImageReader reader(cacheFile.fileName());
+        if (!app.isAppCollectorGame && isPlaceholderBoxArt(reader.size())) {
+            return QUrl("qrc:/res/no_app_image.png");
+        }
         return QUrl::fromLocalFile(cacheFile.fileName());
     }
 
@@ -104,19 +115,22 @@ void BoxArtManager::handleBoxArtLoadComplete(NvComputer* computer, NvApp app, QU
     }
 }
 
-QUrl BoxArtManager::loadBoxArtFromNetwork(NvComputer* computer, int appId)
+QUrl BoxArtManager::loadBoxArtFromNetwork(NvComputer* computer, const NvApp& app)
 {
     NvHTTP http(computer);
 
-    QString cachePath = getFilePathForBoxArt(computer, appId);
+    QString cachePath = getFilePathForBoxArt(computer, app.id);
     QImage image;
     try {
-        image = http.getBoxArt(appId);
+        image = http.getBoxArt(app.id);
     } catch (...) {}
 
     // Cache the box art on disk if it loaded
     if (!image.isNull()) {
         if (image.save(cachePath)) {
+            if (!app.isAppCollectorGame && isPlaceholderBoxArt(image.size())) {
+                return QUrl("qrc:/res/no_app_image.png");
+            }
             return QUrl::fromLocalFile(cachePath);
         }
         else {

--- a/app/backend/boxartmanager.h
+++ b/app/backend/boxartmanager.h
@@ -34,7 +34,10 @@ private slots:
 
 private:
     QUrl
-    loadBoxArtFromNetwork(NvComputer* computer, int appId);
+    loadBoxArtFromNetwork(NvComputer* computer, const NvApp& app);
+
+    static bool
+    isPlaceholderBoxArt(const QSize& size);
 
     QString
     getFilePathForBoxArt(NvComputer* computer, int appId);

--- a/app/backend/boxartmanager.h
+++ b/app/backend/boxartmanager.h
@@ -3,6 +3,8 @@
 #include "computermanager.h"
 #include <QDir>
 #include <QImage>
+#include <QHash>
+#include <QMutex>
 #include <QThreadPool>
 #include <QRunnable>
 
@@ -39,9 +41,17 @@ private:
     static bool
     isPlaceholderBoxArt(const QSize& size);
 
+    bool
+    isCachedPlaceholderBoxArt(const QString& cachePath);
+
+    void
+    rememberPlaceholderBoxArt(const QString& cachePath, bool isPlaceholder);
+
     QString
     getFilePathForBoxArt(NvComputer* computer, int appId);
 
     QDir m_BoxArtDir;
     QThreadPool m_ThreadPool;
+    QMutex m_PlaceholderCacheMutex;
+    QHash<QString, bool> m_PlaceholderCache;
 };

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.9
 import QtQuick.Controls
+import QtQuick.Window 2.2
 
 import AppModel 1.0
 import ComputerManager 1.0
@@ -416,34 +417,23 @@ CenteredGridView {
 
             Image {
                 property bool isPlaceholder: false
+                readonly property real requestedDpr:
+                    Window.window ? Window.window.devicePixelRatio : 1
 
                 id: appIcon
 
                 // 封面铺满整块 tile，不再是居中的 200×267 + 顶部 10px 偏移
                 anchors.fill: parent
                 source: model.boxart
+                sourceSize: Qt.size(Math.max(1, Math.ceil(width * requestedDpr)),
+                                    Math.max(1, Math.ceil(height * requestedDpr)))
                 fillMode: Image.PreserveAspectCrop
                 asynchronous: true
 
-                onSourceSizeChanged: {
-                    // Nearly all of Nvidia's official box art does not match the dimensions of placeholder
-                    // images, however the one known exception is Overcooked. Therefore, we only execute
-                    // the image size checks if this is not an app collector game. We know the officially
-                    // supported games all have box art, so this check is not required.
-                    if (!model.isAppCollectorGame &&
-                        ((sourceSize.width === 130 && sourceSize.height === 180) || // GFE 2.0 placeholder image
-                         (sourceSize.width === 628 && sourceSize.height === 888) || // GFE 3.0 placeholder image
-                         (sourceSize.width === 200 && sourceSize.height === 266)))  // Our no_app_image.png
-                    {
-                        isPlaceholder = true
-                    }
-                    else
-                    {
-                        isPlaceholder = false
-                    }
-
-                    // 以前这里还会把 width/height 钉成 200×267，现在靠 anchors 铺满，
-                    // 再赋值会把 anchors 打掉。
+                onSourceChanged: {
+                    // BoxArtManager normalizes host placeholders to this resource
+                    // before display, so source-size decoding cannot break detection.
+                    isPlaceholder = source.toString() === "qrc:/res/no_app_image.png"
                 }
 
                 // Display a tooltip with the full name if it's truncated

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -681,10 +681,10 @@ CenteredGridView {
             settings.lastRefreshTime = Date.now()
         }
 
-        function handleImageError(status) {
-            console.error("Background image load failed:", status)
+        function handleImageError(errorMessage) {
+            console.error("Background image load failed:", errorMessage)
             if (!source.toString().startsWith("file://")) {
-                source = "qrc:/res/gura.jpg"
+                source = "qrc:/res/gura.png"
             }
         }
 
@@ -924,6 +924,7 @@ CenteredGridView {
             loadingIndicator.visible = false
             backgroundImage.handleImageError(errorMessage)
         }
+        onBackgroundBusy: loadingIndicator.visible = false
         onSaveCompleted: function(success, message) {
             if (success) {
                 saveNotification.text = qsTr("Image saved to: %1").arg(message)

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -667,15 +667,7 @@ CenteredGridView {
 
         function getBackgroundImage() {
             loadingIndicator.visible = true
-
-            var cachePath = imageUtils.fetchAndSaveRandomBackground("https://img-api.pipw.top/")
-            loadingIndicator.visible = false
-
-            if (cachePath) {
-                handleImageResponse(cachePath)
-            } else {
-                handleImageError("fetchAndSaveRandomBackground returned empty")
-            }
+            imageUtils.fetchAndSaveRandomBackground("https://img-api.pipw.top/")
         }
 
         function handleImageResponse(cachePath) {
@@ -924,6 +916,14 @@ CenteredGridView {
 
     ImageUtils {
         id: imageUtils
+        onBackgroundReady: function(filePath) {
+            loadingIndicator.visible = false
+            backgroundImage.handleImageResponse(filePath)
+        }
+        onBackgroundError: function(errorMessage) {
+            loadingIndicator.visible = false
+            backgroundImage.handleImageError(errorMessage)
+        }
         onSaveCompleted: function(success, message) {
             if (success) {
                 saveNotification.text = qsTr("Image saved to: %1").arg(message)

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -83,14 +83,13 @@ Item {
         }
     }
 
-    // 只为了拿到当前主机的背景图
-    PcView {
-        id: pcViewPage
-    }
-
+    // Reuse the background already owned by the application window. Creating a
+    // hidden PcView here duplicated its model, network work, and scene graph.
     Image {
         anchors.fill: parent
-        source: pcViewPage.currentBgUrl || "qrc:/res/gura.png"
+        source: Window.window && Window.window.backgroundImageUrl !== ""
+                ? Window.window.backgroundImageUrl
+                : "qrc:/res/gura.png"
         opacity: 0.35
         fillMode: Image.PreserveAspectCrop
         z: -2

--- a/app/gui/theme/HardSwitch.qml
+++ b/app/gui/theme/HardSwitch.qml
@@ -59,11 +59,15 @@ Switch {
 
             property real pressStartX: 0
             property real dragPosition: control.visualPosition
+            property real dragOffset: 0
             property bool dragging: false
 
             onPressed: function(mouse) {
                 pressStartX = mouse.x
                 dragPosition = control.visualPosition
+                var travel = width - handle.width - 6
+                var handleCenter = 3 + handle.width / 2 + dragPosition * travel
+                dragOffset = mouse.x - handleCenter
                 dragging = false
                 control.forceActiveFocus(Qt.MouseFocusReason)
             }
@@ -75,7 +79,9 @@ Switch {
                     dragging = true
                 }
                 if (dragging) {
-                    dragPosition = Math.max(0, Math.min(1, mouse.x / width))
+                    var travel = width - handle.width - 6
+                    dragPosition = Math.max(0, Math.min(1,
+                        (mouse.x - dragOffset - 3 - handle.width / 2) / travel))
                 }
             }
             onReleased: function(mouse) {

--- a/app/gui/theme/HardSwitch.qml
+++ b/app/gui/theme/HardSwitch.qml
@@ -7,11 +7,17 @@ Switch {
     id: control
 
     font.family: Theme.fontSans
+    implicitWidth: 44
+    implicitHeight: 22
+    padding: 0
+    spacing: 0
 
     indicator: Rectangle {
+        id: track
         implicitWidth: 44
         implicitHeight: 22
-        x: control.text ? control.leftPadding : control.width - width - control.rightPadding
+        x: control.text ? control.leftPadding
+                        : control.leftPadding + (control.availableWidth - width) / 2
         y: control.topPadding + (control.availableHeight - height) / 2
 
         radius: 0
@@ -27,16 +33,63 @@ Switch {
         }
 
         Rectangle {
+            id: handle
             y: 3
-            x: control.checked ? parent.width - width - 3 : 3
+            x: 3 + (pointerArea.dragging ? pointerArea.dragPosition
+                                         : control.visualPosition) * (parent.width - width - 6)
             width: 16
             height: parent.height - 6
             radius: 0
             color: control.checked ? Theme.ink : Theme.textDim
 
             Behavior on x {
+                enabled: !pointerArea.pressed && !control.down
                 NumberAnimation { duration: Theme.durFast; easing.type: Theme.easing }
             }
+        }
+
+        // Own the pointer gesture on the painted track. This avoids the
+        // FluentWinUI3 Switch regression where a stationary release is ignored,
+        // while retaining both tap-to-toggle and drag-to-select behavior.
+        MouseArea {
+            id: pointerArea
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton
+            cursorShape: Qt.PointingHandCursor
+
+            property real pressStartX: 0
+            property real dragPosition: control.visualPosition
+            property bool dragging: false
+
+            onPressed: function(mouse) {
+                pressStartX = mouse.x
+                dragPosition = control.visualPosition
+                dragging = false
+                control.forceActiveFocus(Qt.MouseFocusReason)
+            }
+            onPositionChanged: function(mouse) {
+                if (!pressed) {
+                    return
+                }
+                if (Math.abs(mouse.x - pressStartX) >= 4) {
+                    dragging = true
+                }
+                if (dragging) {
+                    dragPosition = Math.max(0, Math.min(1, mouse.x / width))
+                }
+            }
+            onReleased: function(mouse) {
+                if (dragging) {
+                    var targetChecked = dragPosition >= 0.5
+                    if (targetChecked !== control.checked) {
+                        control.toggle()
+                    }
+                } else {
+                    control.toggle()
+                }
+                dragging = false
+            }
+            onCanceled: dragging = false
         }
     }
 }

--- a/app/imageutils.cpp
+++ b/app/imageutils.cpp
@@ -1,14 +1,18 @@
 #include "imageutils.h"
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QFile>
-#include <QDir>
-#include <QStandardPaths>
-#include <QEventLoop>
-#include <QFileInfo>
-#include <QDateTime>
-#include <QImage>
+
 #include <QBuffer>
+#include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+#include <QMetaObject>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QPointer>
+#include <QStandardPaths>
+#include <QThread>
 
 #ifdef Q_OS_WIN
 #include <wincodec.h>
@@ -16,157 +20,156 @@
 #pragma comment(lib, "ole32.lib")
 #endif
 
-ImageUtils::ImageUtils(QObject *parent) : QObject(parent)
+ImageUtils::ImageUtils(QObject *parent)
+    : QObject(parent),
+      m_backgroundNetworkManager(this)
 {
 }
 
 void ImageUtils::saveImageToFile(const QString &imageUrl, const QUrl &localPath)
 {
     QNetworkAccessManager *manager = new QNetworkAccessManager(this);
-    QNetworkRequest request((QUrl(imageUrl)));
+    QNetworkReply *reply = manager->get(QNetworkRequest(QUrl(imageUrl)));
 
-    QNetworkReply *reply = manager->get(request);
-    connect(reply, &QNetworkReply::finished, [=]()
-            {
-        if(reply->error() == QNetworkReply::NoError) {
-            QString filePath = localPath.toLocalFile();
+    connect(reply, &QNetworkReply::finished, this, [this, manager, reply, localPath]() {
+        if (reply->error() == QNetworkReply::NoError) {
+            const QString filePath = localPath.toLocalFile();
             QFile file(filePath);
-            if(file.open(QIODevice::WriteOnly)) {
+            if (file.open(QIODevice::WriteOnly)) {
                 file.write(reply->readAll());
                 file.close();
                 emit saveCompleted(true, filePath);
-            } else {
-                emit saveCompleted(false, "无法写入文件");
             }
-        } else {
+            else {
+                emit saveCompleted(false, tr("Unable to write file"));
+            }
+        }
+        else {
             emit saveCompleted(false, reply->errorString());
         }
+
         reply->deleteLater();
-        manager->deleteLater(); });
+        manager->deleteLater();
+    });
 }
 
-QString ImageUtils::saveImageFromUrl(const QString &url)
+void ImageUtils::fetchAndSaveRandomBackground(const QString &apiUrl)
 {
-    QNetworkAccessManager manager;
-    QEventLoop loop;
+    if (m_backgroundFetchInProgress) {
+        return;
+    }
 
-    QNetworkRequest request(url);
-    QNetworkReply *reply = manager.get(request);
+    m_backgroundApiUrl = QUrl(apiUrl);
+    if (!m_backgroundApiUrl.isValid()) {
+        emit backgroundError(tr("Invalid background image URL"));
+        return;
+    }
 
-    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-    loop.exec();
+    m_backgroundAttempt = 0;
+    m_backgroundFetchInProgress = true;
+    startBackgroundRequest();
+}
 
-    if (reply->error() != QNetworkReply::NoError)
-    {
+void ImageUtils::startBackgroundRequest()
+{
+    ++m_backgroundAttempt;
+
+    QNetworkRequest request(m_backgroundApiUrl);
+    request.setRawHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                       "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                       "Chrome/125.0.0.0 Safari/537.36");
+    request.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8");
+    request.setRawHeader("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8");
+    request.setRawHeader("Referer", m_backgroundApiUrl.toEncoded());
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    QNetworkReply *reply = m_backgroundNetworkManager.get(request);
+    connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        if (reply->error() != QNetworkReply::NoError) {
+            const QString errorMessage = reply->errorString();
+            reply->deleteLater();
+            retryOrFailBackground(errorMessage);
+            return;
+        }
+
+        const QByteArray imageData = reply->readAll();
         reply->deleteLater();
+        if (imageData.size() < 1024) {
+            retryOrFailBackground(tr("Background server returned an empty response"));
+            return;
+        }
+
+        const QPointer<ImageUtils> guard(this);
+        QThread *worker = QThread::create([guard, imageData]() {
+            const QString filePath = ImageUtils::decodeAndSaveBackground(imageData);
+            if (!guard) {
+                return;
+            }
+
+            QMetaObject::invokeMethod(guard.data(), [guard, filePath]() {
+                if (!guard) {
+                    return;
+                }
+                if (filePath.isEmpty()) {
+                    guard->retryOrFailBackground(guard->tr("Unable to decode background image"));
+                    return;
+                }
+
+                guard->m_backgroundFetchInProgress = false;
+                emit guard->backgroundReady(filePath);
+            }, Qt::QueuedConnection);
+        });
+        connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+        worker->start();
+    });
+}
+
+void ImageUtils::retryOrFailBackground(const QString &errorMessage)
+{
+    qWarning() << "fetchAndSaveRandomBackground: attempt" << m_backgroundAttempt
+               << "failed:" << errorMessage;
+    if (m_backgroundAttempt < 3) {
+        startBackgroundRequest();
+        return;
+    }
+
+    m_backgroundFetchInProgress = false;
+    emit backgroundError(errorMessage);
+}
+
+QString ImageUtils::decodeAndSaveBackground(const QByteArray &imageData)
+{
+    QByteArray decodableData = imageData;
+    QImage image;
+    if (!image.loadFromData(decodableData)) {
+        decodableData = convertToJpeg(decodableData);
+        if (decodableData.isEmpty() || !image.loadFromData(decodableData)) {
+            return QString();
+        }
+    }
+
+    const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) +
+            "/backgrounds";
+    QDir().mkpath(cacheDir);
+    const QString filePath = cacheDir + "/background_" +
+            QString::number(QDateTime::currentMSecsSinceEpoch()) + ".jpg";
+    if (!image.save(filePath, "JPEG", 90)) {
         return QString();
     }
 
-    QByteArray imageData = reply->readAll();
-    reply->deleteLater();
-
-    // 创建缓存目录
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/backgrounds";
-    QDir().mkpath(cacheDir);
-
-    // 生成文件名
-    QString filePath = cacheDir + "/background.jpg";
-
-    // 保存文件
-    QFile file(filePath);
-    if (file.open(QIODevice::WriteOnly))
-    {
-        file.write(imageData);
-        file.close();
-        return filePath;
+    QDir bgDir(cacheDir);
+    QStringList filters;
+    filters << "background_*.*";
+    const QFileInfoList oldFiles = bgDir.entryInfoList(filters, QDir::Files, QDir::Time);
+    for (int i = 1; i < oldFiles.size(); ++i) {
+        QFile::remove(oldFiles[i].absoluteFilePath());
     }
-
-    return QString();
-}
-
-QString ImageUtils::fetchAndSaveRandomBackground(const QString &apiUrl)
-{
-    QNetworkAccessManager manager;
-    
-    // 最多重试3次（因为部分随机图片可能返回500）
-    for (int attempt = 0; attempt < 3; attempt++) {
-        QNetworkRequest request{QUrl(apiUrl)};
-        request.setRawHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36");
-        request.setRawHeader("Accept", "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8");
-        request.setRawHeader("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8");
-        request.setRawHeader("Referer", QUrl(apiUrl).toEncoded());
-        request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
-                             QNetworkRequest::NoLessSafeRedirectPolicy);
-        
-        QEventLoop loop;
-        QNetworkReply *reply = manager.get(request);
-        QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-        loop.exec();
-
-        if (reply->error() != QNetworkReply::NoError) {
-            qWarning() << "fetchAndSaveRandomBackground: attempt" << (attempt + 1) 
-                       << "failed:" << reply->errorString();
-            reply->deleteLater();
-            continue;
-        }
-
-        QByteArray imageData = reply->readAll();
-        reply->deleteLater();
-
-        if (imageData.isEmpty() || imageData.size() < 1024) {
-            qWarning() << "fetchAndSaveRandomBackground: attempt" << (attempt + 1) 
-                       << "got empty/tiny response";
-            continue;
-        }
-
-        // 尝试用 QImage 加载（支持 jpg/png/gif 等 Qt 内置格式）
-        QImage image;
-        if (!image.loadFromData(imageData)) {
-            // QImage 无法加载（可能是 WebP 等不支持的格式）
-            // 尝试转换为 JPEG
-            QByteArray jpegData = convertToJpeg(imageData);
-            if (jpegData.isEmpty()) {
-                qWarning() << "fetchAndSaveRandomBackground: attempt" << (attempt + 1) 
-                           << "failed to decode image";
-                continue;
-            }
-            imageData = jpegData;
-            // 验证转换结果
-            if (!image.loadFromData(imageData)) {
-                qWarning() << "fetchAndSaveRandomBackground: converted data still unreadable";
-                continue;
-            }
-        }
-
-        // 创建缓存目录
-        QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/backgrounds";
-        QDir().mkpath(cacheDir);
-
-        // 使用时间戳作为文件名
-        QString filePath = cacheDir + "/background_" + QString::number(QDateTime::currentMSecsSinceEpoch()) + ".jpg";
-
-        // 保存为 JPEG（确保 Qt Image 可以加载）
-        if (image.save(filePath, "JPEG", 90)) {
-            // 清理旧的背景图文件（保留最新的）
-            QDir bgDir(cacheDir);
-            QStringList filters;
-            filters << "background_*.*";
-            QFileInfoList oldFiles = bgDir.entryInfoList(filters, QDir::Files, QDir::Time);
-            for (int i = 1; i < oldFiles.size(); i++) {
-                QFile::remove(oldFiles[i].absoluteFilePath());
-            }
-            
-            return filePath;
-        }
-    }
-    
-    qWarning() << "fetchAndSaveRandomBackground: all attempts failed";
-    return QString();
+    return filePath;
 }
 
 QByteArray ImageUtils::convertToJpeg(const QByteArray &imageData)
 {
-    // 首先尝试 QImage（如果安装了 qtimageformats 模块，支持 WebP/TIFF等）
     QImage image;
     if (image.loadFromData(imageData)) {
         QByteArray result;
@@ -177,77 +180,70 @@ QByteArray ImageUtils::convertToJpeg(const QByteArray &imageData)
     }
 
 #ifdef Q_OS_WIN
-    // Windows 后备方案：使用 WIC (Windows Imaging Component)
-    // Windows 10+ 原生支持 WebP 解码
-    CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-    
+    const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    const bool shouldUninitialize = SUCCEEDED(comResult);
+
     QByteArray result;
     IWICImagingFactory *factory = nullptr;
     IWICStream *stream = nullptr;
     IWICBitmapDecoder *decoder = nullptr;
     IWICBitmapFrameDecode *frame = nullptr;
-    
+
     HRESULT hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
                                   IID_PPV_ARGS(&factory));
     if (FAILED(hr)) goto cleanup;
-    
+
     hr = factory->CreateStream(&stream);
     if (FAILED(hr)) goto cleanup;
-    
-    hr = stream->InitializeFromMemory(reinterpret_cast<BYTE*>(const_cast<char*>(imageData.data())),
-                                       imageData.size());
+
+    hr = stream->InitializeFromMemory(reinterpret_cast<BYTE *>(const_cast<char *>(imageData.data())),
+                                      imageData.size());
     if (FAILED(hr)) goto cleanup;
-    
+
     hr = factory->CreateDecoderFromStream(stream, nullptr, WICDecodeMetadataCacheOnDemand, &decoder);
     if (FAILED(hr)) goto cleanup;
-    
+
     hr = decoder->GetFrame(0, &frame);
     if (FAILED(hr)) goto cleanup;
-    
+
     {
-        UINT width, height;
+        UINT width = 0;
+        UINT height = 0;
         frame->GetSize(&width, &height);
-        
-        // 转换为 32bpp BGRA
+
         IWICFormatConverter *converter = nullptr;
         hr = factory->CreateFormatConverter(&converter);
         if (FAILED(hr)) goto cleanup;
-        
+
         hr = converter->Initialize(frame, GUID_WICPixelFormat32bppBGRA,
-                                    WICBitmapDitherTypeNone, nullptr, 0.0,
-                                    WICBitmapPaletteTypeCustom);
+                                   WICBitmapDitherTypeNone, nullptr, 0.0,
+                                   WICBitmapPaletteTypeCustom);
         if (FAILED(hr)) {
             converter->Release();
             goto cleanup;
         }
-        
-        // 读取像素数据
+
         QByteArray pixels(width * height * 4, 0);
         hr = converter->CopyPixels(nullptr, width * 4, pixels.size(),
-                                    reinterpret_cast<BYTE*>(pixels.data()));
+                                   reinterpret_cast<BYTE *>(pixels.data()));
         converter->Release();
         if (FAILED(hr)) goto cleanup;
-        
-        // 创建 QImage 并保存为 JPEG
-        QImage wicImage(reinterpret_cast<const uchar*>(pixels.constData()),
+
+        QImage wicImage(reinterpret_cast<const uchar *>(pixels.constData()),
                         width, height, width * 4, QImage::Format_ARGB32);
-        
         QBuffer buffer(&result);
         buffer.open(QIODevice::WriteOnly);
         wicImage.save(&buffer, "JPEG", 90);
     }
-    
+
 cleanup:
     if (frame) frame->Release();
     if (decoder) decoder->Release();
     if (stream) stream->Release();
     if (factory) factory->Release();
-    
+    if (shouldUninitialize) CoUninitialize();
     return result;
 #else
-    // Linux/macOS: 需要安装 qtimageformats 模块以支持 WebP
-    // Linux: sudo apt install qt6-image-formats-plugins (或对应包管理器)
-    // macOS: brew install qt (通常已包含)
     qWarning() << "convertToJpeg: unsupported image format. Install qtimageformats for WebP support.";
     return QByteArray();
 #endif
@@ -264,20 +260,16 @@ bool ImageUtils::isValidCache(const QString &cachePath)
         return false;
     }
 
-    QFileInfo fileInfo(cachePath);
-    const qint64 twentyFourHours = 24 * 60 * 60;  // 24小时有效期
-    
-    // 检查文件时效性和有效性
+    const QFileInfo fileInfo(cachePath);
+    const qint64 twentyFourHours = 24 * 60 * 60;
     return fileInfo.lastModified().secsTo(QDateTime::currentDateTime()) < twentyFourHours &&
-           fileInfo.size() > 1024 &&          // 文件至少1KB
-           fileInfo.suffix().toLower() == "jpg"; // 验证文件格式
+           fileInfo.size() > 1024 &&
+           fileInfo.suffix().toLower() == "jpg";
 }
 
 bool ImageUtils::validateExtension(const QString &filePath)
 {
     static const QStringList allowedExtensions = {"jpg", "jpeg", "png", "bmp"};
-    QFileInfo fileInfo(filePath);
-    QString extension = fileInfo.suffix().toLower();
-    
+    const QString extension = QFileInfo(filePath).suffix().toLower();
     return !extension.isEmpty() && allowedExtensions.contains(extension);
 }

--- a/app/imageutils.cpp
+++ b/app/imageutils.cpp
@@ -92,9 +92,18 @@ void ImageUtils::startBackgroundRequest()
     request.setRawHeader("Referer", m_backgroundApiUrl.toEncoded());
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
                          QNetworkRequest::NoLessSafeRedirectPolicy);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     request.setTransferTimeout(15000);
+#endif
 
     QNetworkReply *reply = m_backgroundNetworkManager.get(request);
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    QTimer::singleShot(15000, reply, [reply]() {
+        if (reply->isRunning()) {
+            reply->abort();
+        }
+    });
+#endif
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         if (reply->error() != QNetworkReply::NoError) {
             const QString errorMessage = reply->errorString();

--- a/app/imageutils.cpp
+++ b/app/imageutils.cpp
@@ -7,12 +7,14 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QImage>
-#include <QMetaObject>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QPointer>
 #include <QStandardPaths>
 #include <QThread>
+#include <QTimer>
+
+#include <limits>
+#include <memory>
 
 #ifdef Q_OS_WIN
 #include <wincodec.h>
@@ -36,9 +38,15 @@ void ImageUtils::saveImageToFile(const QString &imageUrl, const QUrl &localPath)
             const QString filePath = localPath.toLocalFile();
             QFile file(filePath);
             if (file.open(QIODevice::WriteOnly)) {
-                file.write(reply->readAll());
+                const QByteArray payload = reply->readAll();
+                const bool written = file.write(payload) == payload.size();
                 file.close();
-                emit saveCompleted(true, filePath);
+                if (written && file.error() == QFileDevice::NoError) {
+                    emit saveCompleted(true, filePath);
+                }
+                else {
+                    emit saveCompleted(false, tr("Unable to write file"));
+                }
             }
             else {
                 emit saveCompleted(false, tr("Unable to write file"));
@@ -56,6 +64,7 @@ void ImageUtils::saveImageToFile(const QString &imageUrl, const QUrl &localPath)
 void ImageUtils::fetchAndSaveRandomBackground(const QString &apiUrl)
 {
     if (m_backgroundFetchInProgress) {
+        emit backgroundBusy();
         return;
     }
 
@@ -83,6 +92,7 @@ void ImageUtils::startBackgroundRequest()
     request.setRawHeader("Referer", m_backgroundApiUrl.toEncoded());
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
                          QNetworkRequest::NoLessSafeRedirectPolicy);
+    request.setTransferTimeout(15000);
 
     QNetworkReply *reply = m_backgroundNetworkManager.get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
@@ -100,25 +110,18 @@ void ImageUtils::startBackgroundRequest()
             return;
         }
 
-        const QPointer<ImageUtils> guard(this);
-        QThread *worker = QThread::create([guard, imageData]() {
-            const QString filePath = ImageUtils::decodeAndSaveBackground(imageData);
-            if (!guard) {
+        const auto result = std::make_shared<QString>();
+        QThread *worker = QThread::create([result, imageData]() {
+            *result = ImageUtils::decodeAndSaveBackground(imageData);
+        });
+        connect(worker, &QThread::finished, this, [this, result]() {
+            if (result->isEmpty()) {
+                retryOrFailBackground(tr("Unable to decode background image"));
                 return;
             }
 
-            QMetaObject::invokeMethod(guard.data(), [guard, filePath]() {
-                if (!guard) {
-                    return;
-                }
-                if (filePath.isEmpty()) {
-                    guard->retryOrFailBackground(guard->tr("Unable to decode background image"));
-                    return;
-                }
-
-                guard->m_backgroundFetchInProgress = false;
-                emit guard->backgroundReady(filePath);
-            }, Qt::QueuedConnection);
+            m_backgroundFetchInProgress = false;
+            emit backgroundReady(*result);
         });
         connect(worker, &QThread::finished, worker, &QObject::deleteLater);
         worker->start();
@@ -130,7 +133,9 @@ void ImageUtils::retryOrFailBackground(const QString &errorMessage)
     qWarning() << "fetchAndSaveRandomBackground: attempt" << m_backgroundAttempt
                << "failed:" << errorMessage;
     if (m_backgroundAttempt < 3) {
-        startBackgroundRequest();
+        QTimer::singleShot(500 * m_backgroundAttempt, this, [this]() {
+            startBackgroundRequest();
+        });
         return;
     }
 
@@ -162,8 +167,10 @@ QString ImageUtils::decodeAndSaveBackground(const QByteArray &imageData)
     QStringList filters;
     filters << "background_*.*";
     const QFileInfoList oldFiles = bgDir.entryInfoList(filters, QDir::Files, QDir::Time);
-    for (int i = 1; i < oldFiles.size(); ++i) {
-        QFile::remove(oldFiles[i].absoluteFilePath());
+    for (const QFileInfo &oldFile : oldFiles) {
+        if (oldFile.absoluteFilePath() != filePath) {
+            QFile::remove(oldFile.absoluteFilePath());
+        }
     }
     return filePath;
 }
@@ -211,6 +218,18 @@ QByteArray ImageUtils::convertToJpeg(const QByteArray &imageData)
         UINT height = 0;
         frame->GetSize(&width, &height);
 
+        const qint64 stride = static_cast<qint64>(width) * 4;
+        const qint64 bufferSize = stride * static_cast<qint64>(height);
+        static constexpr qint64 kMaximumDecodedBytes = 512LL * 1024 * 1024;
+        if (width == 0 || height == 0 ||
+                width > static_cast<UINT>((std::numeric_limits<int>::max)()) ||
+                height > static_cast<UINT>((std::numeric_limits<int>::max)()) ||
+                stride > (std::numeric_limits<UINT>::max)() ||
+                bufferSize <= 0 || bufferSize > kMaximumDecodedBytes ||
+                bufferSize > (std::numeric_limits<UINT>::max)()) {
+            goto cleanup;
+        }
+
         IWICFormatConverter *converter = nullptr;
         hr = factory->CreateFormatConverter(&converter);
         if (FAILED(hr)) goto cleanup;
@@ -223,14 +242,16 @@ QByteArray ImageUtils::convertToJpeg(const QByteArray &imageData)
             goto cleanup;
         }
 
-        QByteArray pixels(width * height * 4, 0);
-        hr = converter->CopyPixels(nullptr, width * 4, pixels.size(),
+        QByteArray pixels(static_cast<qsizetype>(bufferSize), 0);
+        hr = converter->CopyPixels(nullptr, static_cast<UINT>(stride),
+                                   static_cast<UINT>(bufferSize),
                                    reinterpret_cast<BYTE *>(pixels.data()));
         converter->Release();
         if (FAILED(hr)) goto cleanup;
 
         QImage wicImage(reinterpret_cast<const uchar *>(pixels.constData()),
-                        width, height, width * 4, QImage::Format_ARGB32);
+                        static_cast<int>(width), static_cast<int>(height),
+                        static_cast<qsizetype>(stride), QImage::Format_ARGB32);
         QBuffer buffer(&result);
         buffer.open(QIODevice::WriteOnly);
         wicImage.save(&buffer, "JPEG", 90);

--- a/app/imageutils.h
+++ b/app/imageutils.h
@@ -32,6 +32,7 @@ signals:
     void saveCompleted(bool success, const QString &message);
     void backgroundReady(const QString &filePath);
     void backgroundError(const QString &errorMessage);
+    void backgroundBusy();
 };
 
 #endif // IMAGEUTILS_H

--- a/app/imageutils.h
+++ b/app/imageutils.h
@@ -4,10 +4,6 @@
 #include <QObject>
 #include <QUrl>
 #include <QNetworkAccessManager>
-#include <QNetworkRequest>
-#include <QNetworkReply>
-#include <QFile>
-#include <QFileInfo>
 
 class ImageUtils : public QObject
 {
@@ -16,14 +12,21 @@ public:
     explicit ImageUtils(QObject *parent = nullptr);
     
     Q_INVOKABLE void saveImageToFile(const QString &imageUrl, const QUrl &localPath);
-    Q_INVOKABLE QString saveImageFromUrl(const QString &url);
-    Q_INVOKABLE QString fetchAndSaveRandomBackground(const QString &apiUrl);
+    Q_INVOKABLE void fetchAndSaveRandomBackground(const QString &apiUrl);
     Q_INVOKABLE bool fileExists(const QString &path);
     Q_INVOKABLE bool isValidCache(const QString &cachePath);
     Q_INVOKABLE bool validateExtension(const QString &filePath);
 
 private:
-    QByteArray convertToJpeg(const QByteArray &imageData);
+    void startBackgroundRequest();
+    void retryOrFailBackground(const QString &errorMessage);
+    static QString decodeAndSaveBackground(const QByteArray &imageData);
+    static QByteArray convertToJpeg(const QByteArray &imageData);
+
+    QNetworkAccessManager m_backgroundNetworkManager;
+    QUrl m_backgroundApiUrl;
+    int m_backgroundAttempt = 0;
+    bool m_backgroundFetchInProgress = false;
 
 signals:
     void saveCompleted(bool success, const QString &message);
@@ -31,4 +34,4 @@ signals:
     void backgroundError(const QString &errorMessage);
 };
 
-#endif // IMAGEUTILS_H 
+#endif // IMAGEUTILS_H

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -682,14 +682,7 @@ int main(int argc, char *argv[])
     }
 #endif
 
-#if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // Qt 6's threaded render loop keeps scene graph synchronization, texture
-    // uploads, and buffer swaps off the Windows GUI thread. The basic loop made
-    // app-grid navigation visibly stall whenever large cover textures arrived.
-    if (!qEnvironmentVariableIsSet("QSG_RENDER_LOOP")) {
-        qputenv("QSG_RENDER_LOOP", "threaded");
-    }
-#elif !defined(Q_OS_WIN32)
+#if !defined(Q_OS_WIN32)
     // Other platforms retain the established non-threaded behavior because
     // streaming code may block the main thread while pumping events.
     if (!qEnvironmentVariableIsSet("QSG_RENDER_LOOP")) {

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -682,16 +682,19 @@ int main(int argc, char *argv[])
     }
 #endif
 
-#if !defined(Q_OS_WIN32) || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // Moonlight requires the non-threaded renderer because we depend
-    // on being able to control the render thread by blocking in the
-    // main thread (and pumping events from the main thread when needed).
-    // That doesn't work with the threaded renderer which causes all
-    // sorts of odd behavior depending on the platform.
-    //
-    // NB: Windows defaults to the "windows" non-threaded render loop on
-    // Qt 5 and the threaded render loop on Qt 6.
-    qputenv("QSG_RENDER_LOOP", "basic");
+#if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Qt 6's threaded render loop keeps scene graph synchronization, texture
+    // uploads, and buffer swaps off the Windows GUI thread. The basic loop made
+    // app-grid navigation visibly stall whenever large cover textures arrived.
+    if (!qEnvironmentVariableIsSet("QSG_RENDER_LOOP")) {
+        qputenv("QSG_RENDER_LOOP", "threaded");
+    }
+#elif !defined(Q_OS_WIN32)
+    // Other platforms retain the established non-threaded behavior because
+    // streaming code may block the main thread while pumping events.
+    if (!qEnvironmentVariableIsSet("QSG_RENDER_LOOP")) {
+        qputenv("QSG_RENDER_LOOP", "basic");
+    }
 #endif
 
 #if defined(Q_OS_DARWIN) && defined(QT_DEBUG) && !defined(HAVE_LIBPLACEBO_VULKAN)


### PR DESCRIPTION
## 改了啥呀

- Windows + Qt 6 默认使用 threaded render loop，同时保留 `QSG_RENDER_LOOP` 环境变量覆盖能力
- 应用封面按实际显示尺寸和 DPR 解码，BoxArtManager 统一识别主机占位封面，减少大纹理上传
- 设置页直接复用全局壁纸，不再偷偷实例化第二个 `PcView`
- 随机壁纸下载改为异步网络请求，图片解码、JPEG 转换和缓存写入放到工作线程
- 自绘 Switch 由可见轨道接管鼠标手势，单击和拖动都能可靠切换，拖动时滑块会实时跟手
- 顺便清掉了未使用的同步图片下载接口，以及 Windows WIC 的 COM 初始化泄漏

## 为啥要改

Windows 版之前把 Qt 6.11.1 强制退回 `basic` render loop，场景图同步、封面纹理上传和交换缓冲都挤在 GUI 线程，切页面时这些卡顿小杂鱼就一起冒出来了。设置页的隐藏 `PcView` 和同步壁纸请求还会继续叠加工作量。

Switch 则是 FluentWinUI3 路径下静止点击可能不提交状态，只有拖动才能交互。现在轨道会明确处理点击和拖动，不再装死啦。

## 验证

- Qt 6.11.1 / MSVC 2022 x64 Release：完整 `qmake` + `jom -j8` 干净构建通过
- Windows 11 / AMD Radeon 780M：日志确认 `threaded render loop` 与 D3D11 RHI
- 实机在设置页对 Sunshine ABR 开关执行两次静止单击，状态正确切换并恢复
- 实机左右拖动同一开关，状态正确切换并恢复
- 进入设置页后壁纸缓存加载日志只有一次，确认没有重复 `PcView`
- 启动与设置页切换没有新增 QML 运行时错误


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Placeholder box art is now replaced with the correct generic artwork for non-collector games, whether loaded from cache or online.
  * Background images load more reliably with automatic retries and clearer loading/error handling.
  * Settings now consistently uses the app’s current background image.

* **Improvements**
  * Artwork and backgrounds load more smoothly across different display pixel densities.
  * Toggle switches provide improved sizing, dragging, tapping, and visual feedback.
  * Platform-specific rendering defaults improve display performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->