### PR TITLE
fix(ui): improve checkbox click reliability

### DIFF
--- a/app/gui/theme/HardCheckBox.qml
+++ b/app/gui/theme/HardCheckBox.qml
@@ -35,7 +35,7 @@ CheckBox {
             cursorShape: Qt.PointingHandCursor
 
             onPressed: control.forceActiveFocus(Qt.MouseFocusReason)
-            onClicked: control.toggle()
+            onClicked: control.click()
         }
 
         Behavior on color {

--- a/app/gui/theme/HardCheckBox.qml
+++ b/app/gui/theme/HardCheckBox.qml
@@ -7,6 +7,8 @@ import "."
 CheckBox {
     id: control
 
+    font.family: Theme.fontSans
+
     indicator: Rectangle {
         implicitWidth: 18
         implicitHeight: 18
@@ -20,6 +22,21 @@ CheckBox {
                     : control.checked ? Theme.accent
                     : (control.hovered || control.visualFocus ? Theme.accent : Theme.lineStrong)
         opacity: control.enabled ? 1.0 : 0.45
+
+        // Own clicks on the painted box. FluentWinUI3 can ignore a stationary
+        // release on a replaced indicator, which makes a normal click appear
+        // to work only after several attempts. Keep the base CheckBox behavior
+        // for its label, keyboard navigation, and accessibility.
+        MouseArea {
+            anchors.fill: parent
+            anchors.margins: -6
+            enabled: control.enabled
+            acceptedButtons: Qt.LeftButton
+            cursorShape: Qt.PointingHandCursor
+
+            onPressed: control.forceActiveFocus(Qt.MouseFocusReason)
+            onClicked: control.toggle()
+        }
 
         Behavior on color {
             ColorAnimation { duration: Theme.durFast }


### PR DESCRIPTION
## 改了啥呀

- 给自绘 `HardCheckBox` 接管 indicator 的鼠标单击，修掉 Windows FluentWinUI3 下静止点击偶发不触发、需要反复点击的坏脾气
- 将 18×18 的可视方框命中区向外扩展 6 px，更容易点中，但不改变布局
- 显式沿用 `Theme.fontSans`，让 checkbox 标签继续使用应用统一的跨平台字体策略

## 为啥要改

FluentWinUI3 在替换 `CheckBox.indicator` 后，可能忽略没有位移的 release，杂鱼点击事件就像溜走了一样。由自绘 indicator 自己处理左键，同时保留基类对标签点击、键盘导航和无障碍功能的处理，可以小范围解决问题，不波及其他控件。

## 验证

- Qt 6.11.1 `qmllint app/gui/theme/HardCheckBox.qml`
- Qt 6.11.1 MSVC 2022 x64 Release 增量构建
- Windows 实机坐标点击 checkbox：单击切换、再次单击恢复
- 回归检查 switch、slider、button、ComboBox 与设置分类栏交互


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox interaction by expanding the clickable indicator area.
  * Checkboxes now receive focus when pressed and toggle reliably with the left mouse button.
  * Preserved standard label, keyboard, and accessibility behavior.

* **Style**
  * Standardized checkbox text rendering with the application’s sans-serif font.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->