### PR TITLE
fix(macos): 物理按压触控板时把按钮状态挂到真实触点上

### DIFF
--- a/app/streaming/input/touchpad.cpp
+++ b/app/streaming/input/touchpad.cpp
@@ -237,54 +237,41 @@ bool SdlInputHandler::sendMacTouchpadButtonState(bool down)
 {
     const uint8_t buttonState = down ? LI_TOUCHPAD_BUTTON_PRIMARY : 0;
 
-    if (m_NativeTouchpadTransport == NTT_FRAME) {
-        int rc = LiSendTouchpadFrameEvent(0, nullptr, nullptr, nullptr, nullptr,
-                                          nullptr, LI_ROT_UNKNOWN, 0, 0,
-                                          buttonState);
-        if (rc == 0) {
-            return true;
-        }
-        if (rc != LI_ERR_UNSUPPORTED) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "LiSendTouchpadFrameEvent for macOS button failed: %d", rc);
-            return false;
-        }
+    // 先把攒着的那一帧发出去，保证主机已经建立了对应的触点。这一帧带的仍然是变化
+    // 之前的按钮状态 —— 状态是在它之后才变的，顺序正确。
+    sendPendingTouchpadFrame();
 
-        if (LiGetHostFeatureFlags() & LI_FF_TOUCHPAD_EVENTS) {
-            m_NativeTouchpadTransport = NTT_INDIVIDUAL;
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Native touchpad transport downgraded: frame -> individual");
-        }
-        else {
-            m_NativeTouchpadTransport = NTT_SOFTWARE_POINTER;
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Native touchpad transport downgraded: frame -> software-pointer");
-            transitionNativeTouchpadToSoftwarePointer();
-            return false;
-        }
+    // 按钮状态必须挂在一个真实存在的触点上：
+    //   - Frame 模式：Sunshine 看到 contactCount == 0 直接返回，零触点帧里的
+    //     按钮状态永远不会被处理
+    //   - Individual 模式：BUTTON_ONLY 只能更新一个已经存在、且 pointerId 相同的
+    //     活动触点，写死的 0 通常匹配不到任何触点
+    // 所以这里复制当前的活动触点，把事件类型改成 MOVE（位置不变，只是借这一帧把
+    // 按钮状态带过去），Windows 的触控板路径也是这个思路。
+    NativeTouchpadContact contacts[MAX_TOUCHPAD_FRAME_CONTACTS];
+    int contactCount = 0;
+    for (auto it = m_ActiveTouchpadContacts.cbegin();
+         it != m_ActiveTouchpadContacts.cend() &&
+         contactCount < MAX_TOUCHPAD_FRAME_CONTACTS;
+         ++it) {
+        NativeTouchpadContact contact = it.value();
+        contact.eventType = LI_TOUCH_EVENT_MOVE;
+        contacts[contactCount++] = contact;
     }
 
-    if (m_NativeTouchpadTransport == NTT_INDIVIDUAL) {
-        int rc = LiSendTouchpadEvent(LI_TOUCH_EVENT_BUTTON_ONLY, 0,
-                                     0.0f, 0.0f, 0.0f,
-                                     0.0f, 0.0f, LI_ROT_UNKNOWN,
-                                     0, 0, buttonState);
-        if (rc == 0) {
-            return true;
-        }
-        if (rc == LI_ERR_UNSUPPORTED) {
-            m_NativeTouchpadTransport = NTT_SOFTWARE_POINTER;
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "Native touchpad transport downgraded: individual -> software-pointer");
-            transitionNativeTouchpadToSoftwarePointer();
-        }
-        else {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "LiSendTouchpadEvent for macOS button failed: %d", rc);
-        }
+    if (contactCount == 0) {
+        // 没有活动触点就没法把按钮状态送到主机。报告失败，调用方不会拦截原始的
+        // SDL 鼠标事件，点击照常从普通鼠标通道发出去 —— 总比两边都收不到强。
+        SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                     "No active touchpad contact for macOS button state; "
+                     "leaving the mouse event to the pointer path");
+        return false;
     }
 
-    return false;
+    sendNativeTouchpadContacts(contacts, contactCount, true, buttonState);
+
+    // 降级到软件指针说明主机压根不支持触控板协议，这次按钮状态没送到。
+    return m_NativeTouchpadTransport != NTT_SOFTWARE_POINTER;
 }
 
 bool SdlInputHandler::shouldSuppressMacTouchpadMouseButtonEvent(
@@ -773,6 +760,12 @@ void SdlInputHandler::sendPendingTouchpadFrame()
     }
     uint8_t buttonState = 0;
 #ifdef HAVE_MACOS_NATIVE_TOUCHPAD
+    // 最后一根手指抬起时强制带上「按钮已松开」。Mac 触控板的物理按压离不开手指，
+    // 手指走了按钮必然是松的；而且这时候再收到 SDL 的鼠标释放也已经没有活动触点
+    // 可挂，那条释放就发不出去 —— 主机会一直以为按着。
+    if (m_MacTouchpadButtonDown && m_ActiveTouchpadContacts.isEmpty()) {
+        m_MacTouchpadButtonDown = false;
+    }
     buttonState = m_MacTouchpadButtonDown ? LI_TOUCHPAD_BUTTON_PRIMARY : 0;
 #endif
     sendNativeTouchpadContacts(m_PendingTouchpadContacts,


### PR DESCRIPTION
Fixes #140。#130 之后 macOS 上物理按压触控板不再有反应，只有轻触还能点。

## 根因

启用原生触控板后，物理按压时 macOS 会同时产生触点事件和提升后的鼠标按键事件。客户端检测到触点仍在，就调用 `sendMacTouchpadButtonState()` 走触控板通道发按钮状态，然后**拦掉**原始鼠标事件。但那条消息主机根本不会处理：

| 传输模式 | 发的是什么 | Sunshine 侧 |
| --- | --- | --- |
| Frame | `LiSendTouchpadFrameEvent(0, nullptr, …)` —— contactCount = 0 | 看到零触点直接返回，帧里的 buttonState 永远不被处理 |
| Individual | `BUTTON_ONLY`，但 `pointerId` 写死 `0` | 只允许更新一个已存在、且 id 相同的活动触点，通常匹配不到 |

而 `LiSend*` 返回 `0` 只表示**数据已入发送队列**，不代表主机处理了。客户端据此判定成功并拦掉原始鼠标事件 —— 于是触控板通道和鼠标通道两条路都没了，点击彻底丢失。

轻触不受影响，是因为它靠正常的触点 Down/Up 序列，不依赖这条单独的按钮状态消息。

## 改法

- **发按钮状态前先 flush 攒着的那一帧**，保证主机已经建立了对应触点。这一帧带的仍是变化之前的按钮状态 —— 状态在它之后才变，顺序正确。
- **复制当前活动触点、事件类型改成 `MOVE`**（位置不变，只借这一帧把按钮状态带过去），两种传输模式共用这一条路径。Individual 模式因此天然用的是**真实 pointerId**，不再需要 `BUTTON_ONLY` + 写死 0。Windows 的触控板路径本来就是这个思路。
- **没有活动触点时返回失败**，调用方就不拦截原始 SDL 鼠标事件，点击照常从普通鼠标通道发出去 —— 总比两边都收不到强。
- **最后一根手指抬起时强制在那一帧里带上「按钮已松开」**：Mac 触控板的物理按压离不开手指，手指走了按钮必然是松的；不这样做的话，等 SDL 的鼠标释放事件到达时已经没有活动触点可挂，那条释放就发不出去，主机会一直以为按着。

顺带修好了 `resetMacTouchpadState()` 里那次释放：它在 `cancelSdlTouchpadContacts()` 中于清空触点**之前**调用，现在会发出一帧真正带得动按钮状态的 `MOVE`，而不是被忽略的零触点帧。

## 为什么不加开关

issue 里提到「或许应该做成可开关的选项」。现有的 **Use precision touchpad input when available** 已经是这个开关 —— 关掉就回到软件指针路径，物理按压照常工作，可以作为临时解法。再加一个「是否拦截点击」的独立开关只是把 bug 包装成配置项，这里选择直接修正发送方式。

## 验证

- 构建通过（macOS arm64，`HAVE_MACOS_NATIVE_TOUCHPAD` 路径真实参与编译），启动日志无报错
- **没有做真机串流验证** —— 需要 MacBook 内置触控板 / Magic Trackpad 对着支持触控板协议的 Sunshine 主机实测，这部分留给作者。建议覆盖：
  - 轻触、物理按压、按压拖动、双指右键、真实双击、外接鼠标
  - 分别对 Frame 模式、仅 Individual 模式、完全不支持触控板协议的主机
  - 开启和关闭「原生触控板」设置两种情况
  - 手指提前离开触控板、取消串流、释放输入时，远端有没有残留按下状态

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS touchpad button-state handling during contact movement.
  * Button presses and releases are now reported more reliably alongside active touch contacts.
  * Resolved cases where button release states could remain pending after the final touch ended.
  * Improved failure handling when touchpad input cannot be associated with an active contact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->