### PR TITLE
fix(ui): centralize font fallback handling

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -296,7 +296,8 @@ HEADERS += \
     streaming/video/overlaymenubutton.h \
     streaming/video/overlaytoast.h \
     backend/systemproperties.h \
-    imageutils.h
+    imageutils.h \
+    uifont.h
 
 # Conditional files for non-Steam Link builds
 !config_SL: SOURCES += streaming/micstream.cpp

--- a/app/gui/settings/LegacySettingsPage.qml
+++ b/app/gui/settings/LegacySettingsPage.qml
@@ -12,7 +12,7 @@ import SystemProperties 1.0
 
 // 尚未迁移到新架构的 6 组设置（音频/主机/界面/输入/手柄/高级），
 // 从旧 SettingsView.qml 原样搬运。根节点沿用 settingsPage 这个 id，
-// 好让组内那些 settingsPage.groupBoxTitleFont 引用继续成立。
+// 供组内跨控件绑定继续使用。
 Column {
     id: settingsPage
 
@@ -25,14 +25,6 @@ Column {
     property var bitrateSlider: null
     property var videoEnhancementCheck: null
 
-    readonly property bool useCuteChineseTitleFont: StreamingPreferences.language === StreamingPreferences.LANG_ZH_CN ||
-                                                   StreamingPreferences.language === StreamingPreferences.LANG_ZH_TW ||
-                                                   (StreamingPreferences.language === StreamingPreferences.LANG_AUTO &&
-                                                    Qt.locale().name.indexOf("zh") === 0)
-    property font defaultTitleFont: Qt.font({ weight: Font.Normal, pointSize: 13 })
-    property font cuteChineseTitleFont: Qt.font({ family: "YouYuan", weight: Font.Normal, pointSize: 13 })
-    property font groupBoxTitleFont: useCuteChineseTitleFont ? cuteChineseTitleFont : defaultTitleFont
-
     width: parent ? parent.width : 0
     padding: 0
     spacing: 15
@@ -43,7 +35,6 @@ Column {
             width: (parent.width - (parent.leftPadding + parent.rightPadding))
             padding: 12
             title: "<b><font color=\"#39C5BB\">" + qsTr("Audio Settings") + "</font></b>"
-            font: settingsPage.groupBoxTitleFont
 
             Column {
                 anchors.fill: parent
@@ -151,7 +142,6 @@ Column {
             width: (parent.width - (parent.leftPadding + parent.rightPadding))
             padding: 12
             title: "<b><font color=\"#39C5BB\">" + qsTr("Host Settings") + "</font></b>"
-            font: settingsPage.groupBoxTitleFont
 
             Column {
                 anchors.fill: parent
@@ -308,7 +298,6 @@ Column {
             width: (parent.width - (parent.leftPadding + parent.rightPadding))
             padding: 12
             title: "<b><font color=\"#39C5BB\">" + qsTr("UI Settings") + "</font></b>"
-            font: settingsPage.groupBoxTitleFont
 
             Column {
                 anchors.fill: parent
@@ -673,7 +662,6 @@ Column {
             width: (parent.width - (parent.leftPadding + parent.rightPadding))
             padding: 12
             title: "<b><font color=\"#39C5BB\">" + qsTr("Input Settings") + "</font></b>"
-            font: settingsPage.groupBoxTitleFont
 
             Column {
                 anchors.fill: parent
@@ -870,7 +858,6 @@ Column {
             width: (parent.width - (parent.leftPadding + parent.rightPadding))
             padding: 12
             title: "<b><font color=\"#39C5BB\">" + qsTr("Gamepad Settings") + "</font></b>"
-            font: settingsPage.groupBoxTitleFont
 
             Column {
                 anchors.fill: parent
@@ -1010,7 +997,6 @@ Column {
             width: (parent.width - (parent.leftPadding + parent.rightPadding))
             padding: 12
             title: "<b><font color=\"#39C5BB\">" + qsTr("Advanced Settings") + "</font></b>"
-            font: settingsPage.groupBoxTitleFont
 
             Column {
                 anchors.fill: parent

--- a/app/gui/theme/HardGroupBox.qml
+++ b/app/gui/theme/HardGroupBox.qml
@@ -12,6 +12,11 @@ import "."
 GroupBox {
     id: control
 
+    property font titleFont: Qt.font({
+        family: Theme.fontSans,
+        pointSize: Theme.fontCardTitle
+    })
+
     topPadding: labelText.implicitHeight + Theme.spaceLg
     leftPadding: Theme.spaceLg
     rightPadding: Theme.spaceLg
@@ -25,13 +30,11 @@ GroupBox {
         text: control.title
         textFormat: Text.StyledText
         color: Theme.accent
-        // 字族和字号跟着控件自己的 font 走：旧设置页会把 groupBoxTitleFont 设成
-        // 「幼圆」来给中文标题换脸，写死 Theme.fontSans 就把那个功能弄丢了。
-        font.family: control.font.family
-        font.pointSize: control.font.pointSize
+        font.family: control.titleFont.family
+        font.pointSize: control.titleFont.pointSize
         font.bold: true
         font.capitalization: Font.AllUppercase
-        font.letterSpacing: Theme.tracking(control.font.pointSize, 0.08)
+        font.letterSpacing: Theme.tracking(control.titleFont.pointSize, 0.08)
         elide: Text.ElideRight
     }
 

--- a/app/gui/theme/HardGroupBox.qml
+++ b/app/gui/theme/HardGroupBox.qml
@@ -32,7 +32,7 @@ GroupBox {
         color: Theme.accent
         font.family: control.titleFont.family
         font.pointSize: control.titleFont.pointSize
-        font.bold: true
+        font.weight: Font.ExtraBold
         font.capitalization: Font.AllUppercase
         font.letterSpacing: Theme.tracking(control.titleFont.pointSize, 0.08)
         elide: Text.ElideRight

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -90,6 +90,7 @@ static QString getStartupApplicationDir(const char* argv0)
 #include "settings/streamingpreferences.h"
 #include "gui/sdlgamepadkeynavigation.h"
 #include "imageutils.h"
+#include "uifont.h"
 #include "streaming/macpermissions.h"
 #ifdef Q_OS_DARWIN
 #include "gui/macwindowchrome.h"
@@ -969,27 +970,6 @@ int main(int argc, char *argv[])
     // Move the mouse to the bottom right so it's invisible when using
     // gamepad-only navigation.
     QCursor().setPos(0xFFFF, 0xFFFF);
-#elif defined(Q_OS_WIN32)
-    const QStringList fontFamilies = QFontDatabase::families();
-    QString defaultFontFamily = QStringLiteral("Segoe UI");
-
-    if (shouldUseChineseWindowsUiFont(StreamingPreferences::get()->language)) {
-        if (fontFamilies.contains(QStringLiteral("Microsoft YaHei UI"))) {
-            defaultFontFamily = QStringLiteral("Microsoft YaHei UI");
-        }
-        else if (fontFamilies.contains(QStringLiteral("Microsoft YaHei"))) {
-            defaultFontFamily = QStringLiteral("Microsoft YaHei");
-        }
-    }
-
-    QFont defaultFont(defaultFontFamily, 9);
-    defaultFont.setStyleHint(QFont::SansSerif);
-    if (fontFamilies.contains(defaultFontFamily)) {
-        app.setFont(defaultFont);
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Set default font to %s", qPrintable(defaultFontFamily));
-    } else {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "%s font not found, using system default", qPrintable(defaultFontFamily));
-    }
 #elif !SDL_VERSION_ATLEAST(2, 0, 11) && defined(Q_OS_LINUX) && (defined(__arm__) || defined(__aarch64__))
     if (qgetenv("SDL_VIDEO_GL_DRIVER").isEmpty() && QGuiApplication::platformName() == "eglfs") {
         // Look for Raspberry Pi GLES libraries. SDL 2.0.10 and earlier needs some help finding
@@ -1136,8 +1116,6 @@ int main(int argc, char *argv[])
     // 界面字体：Manrope（正文/标题）+ DM Mono（数字、状态徽标、宽字距微标签），
     // 这是 neo-brutalism 视觉的一半，见 app/res/fonts/README.md。
     //
-    // 必须放在上面那整段样式/palette 块之后：Windows 分支在更前面已经调过一次
-    // app.setFont()，谁最后调谁生效，顺序反了这里就白设了。
     {
         static const char* const kBundledFonts[] = {
             ":/res/fonts/Manrope-Regular.ttf",
@@ -1156,30 +1134,38 @@ int main(int argc, char *argv[])
             }
         }
 
+        QFont uiFont = app.font();
+
+#ifdef Q_OS_WIN32
+        const QStringList installedFamilies = QFontDatabase::families();
+        QString defaultFontFamily = QStringLiteral("Segoe UI");
+        if (shouldUseChineseWindowsUiFont(StreamingPreferences::get()->language)) {
+            for (const QString& family : UiFont::systemHanFallbackFamilies()) {
+                if (installedFamilies.contains(family)) {
+                    defaultFontFamily = family;
+                    break;
+                }
+            }
+        }
+
+        if (installedFamilies.contains(defaultFontFamily)) {
+            uiFont.setFamily(defaultFontFamily);
+            uiFont.setPointSize(9);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Set default font to %s", qPrintable(defaultFontFamily));
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "%s font not found, using system default", qPrintable(defaultFontFamily));
+        }
+#endif
+
         if (haveManrope) {
             // Manrope 和 DM Mono 都没有中文字形，中文交给系统字体回退。
             // Qt 会跳过列表里不存在的 family，所以这里可以无条件把候选都列上。
-            QStringList families;
-            families << QStringLiteral("Manrope");
-#ifdef Q_OS_DARWIN
-            families << QStringLiteral("PingFang SC");
-#elif defined(Q_OS_WIN32)
-            const QStringList preferredHanFamilies = {
-                QStringLiteral("Microsoft YaHei UI"),
-                QStringLiteral("Microsoft YaHei"),
-                QStringLiteral("Noto Sans SC"),
-                QStringLiteral("DengXian"),
-            };
-            families << preferredHanFamilies;
-#else
-            families << QStringLiteral("Noto Sans CJK SC") << QStringLiteral("Source Han Sans SC");
-#endif
+            QStringList families = UiFont::familyChain(QStringLiteral("Manrope"));
             // 最后兜住原本的系统默认字体，别把上面平台分支设好的字号/字形提示丢了
-            QFont uiFont = app.font();
             families << uiFont.family();
             uiFont.setFamilies(families);
             uiFont.setStyleHint(QFont::SansSerif);
-            app.setFont(uiFont);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0) && defined(Q_OS_WIN32)
             // QML controls frequently select Manrope or DM Mono directly.
@@ -1187,8 +1173,7 @@ int main(int argc, char *argv[])
             // choose SimSun for missing Han glyphs. Pin the application-wide
             // Han fallback to modern sans-serif fonts instead.
             QStringList hanFallbackFamilies;
-            const QStringList installedFamilies = QFontDatabase::families();
-            for (const QString &family : preferredHanFamilies) {
+            for (const QString &family : UiFont::systemHanFallbackFamilies()) {
                 if (installedFamilies.contains(family)) {
                     hanFallbackFamilies << family;
                 }
@@ -1202,6 +1187,8 @@ int main(int argc, char *argv[])
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "UI font families: %s",
                         qPrintable(families.join(QLatin1String(", "))));
         }
+
+        app.setFont(uiFont);
     }
 
     QQmlApplicationEngine engine;

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -1,4 +1,5 @@
 #include "overlaymenupanel.h"
+#include "uifont.h"
 
 #include <QScreen>
 #include <QGuiApplication>
@@ -49,16 +50,8 @@ OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
             modeSeven = families.first();
     }
 
-    // Primary: ModeSeven, fallback: Microsoft YaHei UI for elegant Chinese rendering
-    if (!modeSeven.isEmpty()) {
-        m_LabelFont = QFont(modeSeven, 9);
-        m_LabelFont.setFamilies({modeSeven, QStringLiteral("Microsoft YaHei UI"), QStringLiteral("Microsoft YaHei")});
-    } else {
-        // Fallback if ModeSeven fails to load
-        m_LabelFont = QFont(QStringLiteral("Microsoft YaHei UI"), 9);
-        if (!QFontInfo(m_LabelFont).exactMatch())
-            m_LabelFont = QFont(QStringLiteral("Microsoft YaHei"), 9);
-    }
+    m_LabelFont.setFamilies(UiFont::familyChain(modeSeven));
+    m_LabelFont.setPointSize(9);
     m_LabelFont.setWeight(QFont::Normal);
 
     m_DetailFont = QFont(m_LabelFont);

--- a/app/streaming/video/overlaytoast.cpp
+++ b/app/streaming/video/overlaytoast.cpp
@@ -1,4 +1,5 @@
 #include "overlaytoast.h"
+#include "uifont.h"
 
 #include <QScreen>
 #include <QFontMetrics>
@@ -36,16 +37,7 @@ OverlayToast::OverlayToast(QWindow* parent)
     // macOS 和 Linux 上根本没有，实际渲染出来是系统回退字体，三个平台长得不一样。
     // Manrope 由 main.cpp 注册进 QFontDatabase，进程内哪儿都能用；它没有中文字形，
     // 所以后面按平台补 CJK 回退（提示文案是会被翻译的）。
-    QStringList families;
-    families << QStringLiteral("Manrope");
-#ifdef Q_OS_DARWIN
-    families << QStringLiteral("PingFang SC");
-#elif defined(Q_OS_WIN32)
-    families << QStringLiteral("Microsoft YaHei UI") << QStringLiteral("Microsoft YaHei");
-#else
-    families << QStringLiteral("Noto Sans CJK SC") << QStringLiteral("Source Han Sans SC");
-#endif
-    m_Font.setFamilies(families);
+    m_Font.setFamilies(UiFont::familyChain(QStringLiteral("Manrope")));
     m_Font.setPointSize(11);
     m_Font.setWeight(QFont::DemiBold);
     m_Font.setStyleHint(QFont::SansSerif);

--- a/app/uifont.h
+++ b/app/uifont.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+namespace UiFont
+{
+
+inline QStringList systemHanFallbackFamilies()
+{
+#ifdef Q_OS_DARWIN
+    return {QStringLiteral("PingFang SC")};
+#elif defined(Q_OS_WIN32)
+    return {
+        QStringLiteral("Microsoft YaHei UI"),
+        QStringLiteral("Microsoft YaHei"),
+        QStringLiteral("Noto Sans SC"),
+        QStringLiteral("DengXian"),
+    };
+#else
+    return {
+        QStringLiteral("Noto Sans CJK SC"),
+        QStringLiteral("Source Han Sans SC"),
+    };
+#endif
+}
+
+inline QStringList familyChain(const QString& primaryFamily)
+{
+    QStringList families;
+    if (!primaryFamily.isEmpty()) {
+        families << primaryFamily;
+    }
+    families << systemHanFallbackFamilies();
+    return families;
+}
+
+} // namespace UiFont


### PR DESCRIPTION
## 改了啥呀

- 把设置分组的标题字体从 `GroupBox.font` 里拆出来，避免字体继续偷偷传给标签和下拉框
- 删除旧设置页的幼圆特例，让 Windows 中文稳定回退到微软雅黑 UI
- 新增统一的平台中文字体链，主界面、串流 Toast 和串流菜单共用同一份策略
- 合并 Windows 两段分散的默认字体初始化，少一点靠执行顺序撑着的杂鱼逻辑

## 为啥要改

原来的 `groupBoxTitleFont` 看起来只管标题，实际上 Qt Controls 会把它传播给整组子控件，于是幼圆悄悄混进了正文和下拉框。C++ 手绘界面又各自维护一套回退名单，macOS/Linux 还可能撞上 Windows 字体名。现在标题与内容职责分开，平台回退也只有一个来源啦。

## 验证

- `C:\Qt\6.11.1\msvc2022_64\bin\qmllint.exe app/gui/settings/LegacySettingsPage.qml app/gui/theme/HardGroupBox.qml`
- `cmd /d /c .git\codex-build-checkbox.bat`
- `git diff --check`

QML 检查只保留旧设置页已有的运行时单例导入和未限定访问警告；Windows Qt 6.11.1 Release 已成功重新编译并链接。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved font handling across the application with consistent platform-specific and Han-script fallbacks.
  * Enhanced group box title typography with dedicated title styling.
  * Updated video overlays and notifications to use more reliable font fallback behavior.
* **Bug Fixes**
  * Improved font availability and rendering consistency across supported platforms.
  * Preserved readable text sizing and weight across different system configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->