### PR TITLE
fix(ui): 整体修复手柄导航 —— 设置页焦点分级、弹窗可达性、下拉编辑语义 (#144)

### DIFF
--- a/app/backend/nvcomputer.cpp
+++ b/app/backend/nvcomputer.cpp
@@ -509,6 +509,7 @@ QVector<NvAddress> NvComputer::uniqueAddresses() const
     QVector<NvAddress> uniqueAddressList;
 
     // Start with addresses correctly ordered
+    uniqueAddressList.append(pinnedAddress);
     uniqueAddressList.append(activeAddress);
     uniqueAddressList.append(localAddress);
     uniqueAddressList.append(remoteAddress);
@@ -535,6 +536,39 @@ QVector<NvAddress> NvComputer::uniqueAddresses() const
     Q_ASSERT(!uniqueAddressList.isEmpty());
 
     return uniqueAddressList;
+}
+
+void NvComputer::pinAddress(const NvAddress& address)
+{
+    QWriteLocker writeLocker(&lock);
+    pinnedAddress = address;
+    activeAddress = address;
+}
+
+bool NvComputer::resetToAutomaticAddress()
+{
+    QWriteLocker writeLocker(&lock);
+
+    pinnedAddress = NvAddress();
+
+    // 让 activeAddress 退回自然顺序里的头一个地址，后面的失败回退仍由轮询完成。
+    // 不能直接置空：activeAddress 同时是 NvHTTP 和串流真正使用的地址，置空会留下
+    // 一个到下次轮询为止的窗口期，期间开始串流会连不上。
+    const NvAddress candidates[] = {
+        localAddress,
+        remoteAddress,
+        ipv6Address,
+        manualAddress,
+    };
+    for (const NvAddress& address : candidates) {
+        if (!address.isNull()) {
+            activeAddress = address;
+            return true;
+        }
+    }
+
+    // 一个具体地址都没有（不该发生）。保持现状，别把能用的地址弄丢。
+    return false;
 }
 
 void NvComputer::markAddressTestSucceeded(const NvAddress& address)

--- a/app/backend/nvcomputer.h
+++ b/app/backend/nvcomputer.h
@@ -67,6 +67,12 @@ public:
     uniqueAddresses() const;
 
     void
+    pinAddress(const NvAddress& address);
+
+    bool
+    resetToAutomaticAddress();
+
+    void
     markAddressTestSucceeded(const NvAddress& address);
 
     bool
@@ -97,6 +103,11 @@ public:
     ComputerState state;
     PairState pairState;
     NvAddress activeAddress;
+    // 用户手动固定的连接地址。空表示自动选择。和 activeAddress 一样只活在
+    // 会话内（不序列化）：activeAddress 本来就是重启后靠轮询重建的。
+    // uniqueAddresses() 把它排在最前，所以轮询每次都先试它 —— 固定地址
+    // 短暂掉线回退到别的地址后，恢复可达时会自动固定回来。
+    NvAddress pinnedAddress;
     uint16_t activeHttpsPort;
     int currentGameId;
     QString gfeVersion;

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -880,12 +880,15 @@ CenteredGridView {
 
         onAddressSelected: function(address) {
             if (address.isAuto) {
+                // 只把 QML 里的开关拨回来是不够的 —— 之前选具体地址时写进
+                // appModel 的固定值还在，不清掉的话「自动」有名无实。
                 useAutoAddress = true
+                appModel.resetToAutomaticAddress()
             } else {
                 useAutoAddress = false
                 appModel.setActiveAddress(address.address, address.port)
-                activeAddressInfo = appModel.getActiveAddressInfo()
             }
+            activeAddressInfo = appModel.getActiveAddressInfo()
         }
 
         onClosed: appGrid.forceActiveFocus()

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -132,19 +132,7 @@ CenteredGridView {
 
     // IP选择弹窗
     function openIpDialog() {
-        var addresses = appModel.getConnectionAddresses()
-        ipDialog.addresses = addresses
-
-        // 落在当前生效的那一项上。isActive 由 model 判定：没固定地址时是「自动」
-        // 那一项（固定在第 0 项），否则是被固定的那个地址。
-        var activeIdx = 0
-        for (var i = 0; i < addresses.length; i++) {
-            if (addresses[i].isActive) {
-                activeIdx = i
-                break
-            }
-        }
-        ipDialog.initialIndex = activeIdx
+        ipDialog.addresses = appModel.getConnectionAddresses()
         ipDialog.open()
     }
 

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -46,6 +46,71 @@ CenteredGridView {
     // 是否使用自动选择模式
     property bool useAutoAddress: true
 
+    // 显示器 / VDD 选择按钮。以前是裸 Rectangle + MouseArea，手柄和键盘完全够不到 ——
+    // 而这个弹窗是切换 VDD 的唯一入口。换成 AbstractButton 才能进焦点链。
+    //
+    // 这一页的手柄导航是「普通模式」（uiNavMode 为假，方向键原样发过来，没有 Tab），
+    // 所以四个方向都得自己接：左右在同一排里走，上下进出下面的组合模式下拉。
+    component DisplayChip: AbstractButton {
+        id: chip
+
+        property bool selected: false
+        property color selectedFill: Theme.accent
+        property color selectedBorder: Theme.accentStrong
+
+        implicitWidth: chipLabel.implicitWidth + Theme.spaceXl
+        implicitHeight: 32
+
+        activeFocusOnTab: true
+        hoverEnabled: true
+
+        HoverHandler {
+            cursorShape: Qt.PointingHandCursor
+        }
+
+        background: Rectangle {
+            radius: 0
+            color: chip.selected ? chip.selectedFill
+                                 : (chip.hovered ? Theme.surface : Theme.surface2)
+            // 焦点描边压过选中描边：选中与否已经靠填充色表达了，描边留给「焦点在哪」。
+            border.color: chip.visualFocus ? Theme.text
+                        : (chip.selected ? chip.selectedBorder : Theme.lineStrong)
+            border.width: chip.visualFocus ? 2 : 1
+
+            Behavior on color {
+                ColorAnimation { duration: Theme.durFast }
+            }
+        }
+
+        contentItem: Text {
+            id: chipLabel
+            text: chip.text
+            color: chip.selected ? Theme.ink : Theme.textDim
+            font.family: Theme.fontSans
+            font.pointSize: Theme.fontBody
+            font.bold: chip.selected
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        Keys.onReturnPressed: clicked()
+        Keys.onEnterPressed: clicked()
+        Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onDownPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onUpPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
+    }
+
+    // IP 弹窗按钮行。HardButton 只是块方角按钮，没带方向键处理；这一页不是 UI 导航
+    // 模式，手柄拿到的是原始方向键，所以左右和向上都得自己接。
+    component IpDialogButton: HardButton {
+        Keys.onReturnPressed: clicked()
+        Keys.onEnterPressed: clicked()
+        Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onUpPressed: ipCombo.forceActiveFocus(Qt.TabFocusReason)
+    }
+
     // 加载显示器列表
     function loadDisplays() {
         var displays = appModel.getDisplayList()
@@ -100,6 +165,35 @@ CenteredGridView {
             accentBarWidth: Theme.accentBar
         }
 
+        // focus: true 只是把焦点给弹窗本体，手柄用户还得盲按一下才有高亮。
+        // 开的时候直接落到当前选中的显示器上。
+        onOpened: focusInitialItem()
+
+        // 关掉之后必须把焦点还回去，否则手柄和键盘导航就停在一个已销毁的
+        // 焦点域里，得摸鼠标点一下才恢复 —— 和 NavigableDialog 里那句是同一个原因。
+        onClosed: appGrid.forceActiveFocus()
+
+        function focusInitialItem() {
+            var fallback = null
+            for (var i = 0; i < displayChips.children.length; i++) {
+                var chip = displayChips.children[i]
+                // Repeater 自己也在 children 里，靠 activeFocusOnTab 把它筛掉
+                if (!chip.visible || !chip.enabled || !chip.activeFocusOnTab) {
+                    continue
+                }
+                if (chip.selected) {
+                    chip.forceActiveFocus(Qt.TabFocusReason)
+                    return
+                }
+                if (!fallback) {
+                    fallback = chip
+                }
+            }
+            if (fallback) {
+                fallback.forceActiveFocus(Qt.TabFocusReason)
+            }
+        }
+
         Column {
             anchors.left: parent.left
             anchors.right: parent.right
@@ -129,6 +223,7 @@ CenteredGridView {
             }
 
             Flow {
+                id: displayChips
                 width: parent.width
                 spacing: Theme.spaceSm
 
@@ -136,36 +231,17 @@ CenteredGridView {
                 Repeater {
                     model: ListModel { id: displayListModel }
 
-                    Rectangle {
-                        readonly property bool selected: selectedDisplayId === model.displayGuid
+                    DisplayChip {
+                        text: model.displayName
+                        selected: selectedDisplayId === model.displayGuid
 
-                        width: displayBtnLabel.implicitWidth + Theme.spaceXl
-                        height: 32
-                        color: selected ? Theme.accent : Theme.surface2
-                        border.color: selected ? Theme.accentStrong : Theme.lineStrong
-                        border.width: 1
-
-                        Text {
-                            id: displayBtnLabel
-                            anchors.centerIn: parent
-                            text: model.displayName
-                            color: parent.selected ? Theme.ink : Theme.textDim
-                            font.family: Theme.fontSans
-                            font.pointSize: Theme.fontBody
-                            font.bold: parent.selected
-                        }
-
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                selectedDisplayId = model.displayGuid
-                                var saved = StreamingPreferences.customScreenMode
-                                for (var i = 0; i < physicalModeModel.count; i++) {
-                                    if (physicalModeModel.get(i).val === saved) {
-                                        combinationModeCombo.currentIndex = i
-                                        break
-                                    }
+                        onClicked: {
+                            selectedDisplayId = model.displayGuid
+                            var saved = StreamingPreferences.customScreenMode
+                            for (var i = 0; i < physicalModeModel.count; i++) {
+                                if (physicalModeModel.get(i).val === saved) {
+                                    combinationModeCombo.currentIndex = i
+                                    break
                                 }
                             }
                         }
@@ -173,34 +249,19 @@ CenteredGridView {
                 }
 
                 // VDD 按钮
-                Rectangle {
-                    width: vddBtnLabel.implicitWidth + Theme.spaceXl
-                    height: 32
-                    color: isVddSelected ? Theme.acid : Theme.surface2
-                    border.color: isVddSelected ? Theme.acid : Theme.lineStrong
-                    border.width: 1
+                DisplayChip {
+                    text: qsTr("VDD Display")
+                    selected: isVddSelected
+                    selectedFill: Theme.acid
+                    selectedBorder: Theme.acid
 
-                    Text {
-                        id: vddBtnLabel
-                        anchors.centerIn: parent
-                        text: qsTr("VDD Display")
-                        color: isVddSelected ? Theme.ink : Theme.textDim
-                        font.family: Theme.fontSans
-                        font.pointSize: Theme.fontBody
-                        font.bold: isVddSelected
-                    }
-
-                    MouseArea {
-                        anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            selectedDisplayId = "vdd"
-                            var saved = StreamingPreferences.customVddScreenMode
-                            for (var i = 0; i < vddModeModel.count; i++) {
-                                if (vddModeModel.get(i).val === saved) {
-                                    combinationModeCombo.currentIndex = i
-                                    break
-                                }
+                    onClicked: {
+                        selectedDisplayId = "vdd"
+                        var saved = StreamingPreferences.customVddScreenMode
+                        for (var i = 0; i < vddModeModel.count; i++) {
+                            if (vddModeModel.get(i).val === saved) {
+                                combinationModeCombo.currentIndex = i
+                                break
                             }
                         }
                     }
@@ -229,6 +290,16 @@ CenteredGridView {
                     maximumWidth: parent.width
                     textRole: "text"
                     model: isVddSelected ? vddModeModel : physicalModeModel
+
+                    // ComboBox 自己会吃掉上下键去换选项，不接管的话手柄一旦落到这里
+                    // 就再也回不到上面那排显示器按钮了。展开状态下放行给列表。
+                    Keys.onUpPressed: function(event) {
+                        if (popup.opened) {
+                            event.accepted = false
+                            return
+                        }
+                        nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
+                    }
 
                     Component.onCompleted: {
                         var saved = StreamingPreferences.customScreenMode
@@ -841,6 +912,10 @@ CenteredGridView {
             accentBarWidth: Theme.accentBar
         }
 
+        // 同 displayDialog：开的时候给个明确的初始焦点，关的时候把焦点还给列表。
+        onOpened: ipCombo.forceActiveFocus(Qt.TabFocusReason)
+        onClosed: appGrid.forceActiveFocus()
+
         Column {
             anchors.left: parent.left
             anchors.right: parent.right
@@ -878,6 +953,16 @@ CenteredGridView {
                 maximumWidth: parent.width
                 model: ipDialog.addresses
                 textRole: "display"
+
+                // ComboBox 会吃掉上下键换选项，向下得手动放行到按钮行。
+                // 展开状态下留给列表自己用。
+                Keys.onDownPressed: function(event) {
+                    if (popup.opened) {
+                        event.accepted = false
+                        return
+                    }
+                    ipApplyButton.forceActiveFocus(Qt.TabFocusReason)
+                }
             }
 
             // 地址类型 / 未验证告警：都是机读信息，走等宽
@@ -914,7 +999,8 @@ CenteredGridView {
                 spacing: Theme.spaceMd
                 anchors.horizontalCenter: parent.horizontalCenter
 
-                HardButton {
+                IpDialogButton {
+                    id: ipApplyButton
                     text: qsTr("Apply")
                     onClicked: {
                         if (ipCombo.currentIndex < 0 || ipCombo.currentIndex >= ipDialog.addresses.length) {
@@ -933,7 +1019,7 @@ CenteredGridView {
                     }
                 }
 
-                HardButton {
+                IpDialogButton {
                     text: qsTr("Cancel")
                     onClicked: ipDialog.close()
                 }

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -93,21 +93,29 @@ CenteredGridView {
             verticalAlignment: Text.AlignVCenter
         }
 
+        function moveFocus(forward) {
+            nextItemInFocusChain(forward).forceActiveFocus(Qt.TabFocusReason)
+        }
+
         Keys.onReturnPressed: clicked()
         Keys.onEnterPressed: clicked()
-        Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
-        Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
-        Keys.onDownPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
-        Keys.onUpPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onRightPressed: moveFocus(true)
+        Keys.onDownPressed: moveFocus(true)
+        Keys.onLeftPressed: moveFocus(false)
+        Keys.onUpPressed: moveFocus(false)
     }
 
     // IP 弹窗按钮行。HardButton 只是块方角按钮，没带方向键处理；这一页不是 UI 导航
     // 模式，手柄拿到的是原始方向键，所以左右和向上都得自己接。
     component IpDialogButton: HardButton {
+        function moveFocus(forward) {
+            nextItemInFocusChain(forward).forceActiveFocus(Qt.TabFocusReason)
+        }
+
         Keys.onReturnPressed: clicked()
         Keys.onEnterPressed: clicked()
-        Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
-        Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
+        Keys.onLeftPressed: moveFocus(false)
+        Keys.onRightPressed: moveFocus(true)
         Keys.onUpPressed: ipCombo.forceActiveFocus(Qt.TabFocusReason)
     }
 
@@ -174,24 +182,16 @@ CenteredGridView {
         onClosed: appGrid.forceActiveFocus()
 
         function focusInitialItem() {
-            var fallback = null
             for (var i = 0; i < displayChips.children.length; i++) {
                 var chip = displayChips.children[i]
-                // Repeater 自己也在 children 里，靠 activeFocusOnTab 把它筛掉
-                if (!chip.visible || !chip.enabled || !chip.activeFocusOnTab) {
-                    continue
-                }
+                // Repeater 自己也在 children 里，但它没有 selected，会自动跳过
                 if (chip.selected) {
                     chip.forceActiveFocus(Qt.TabFocusReason)
                     return
                 }
-                if (!fallback) {
-                    fallback = chip
-                }
             }
-            if (fallback) {
-                fallback.forceActiveFocus(Qt.TabFocusReason)
-            }
+            // 没有物理显示器被选中时至少落在 VDD 上：它是静态声明的，一直都在
+            vddChip.forceActiveFocus(Qt.TabFocusReason)
         }
 
         Column {
@@ -250,6 +250,7 @@ CenteredGridView {
 
                 // VDD 按钮
                 DisplayChip {
+                    id: vddChip
                     text: qsTr("VDD Display")
                     selected: isVddSelected
                     selectedFill: Theme.acid
@@ -291,25 +292,10 @@ CenteredGridView {
                     textRole: "text"
                     model: isVddSelected ? vddModeModel : physicalModeModel
 
-                    // ComboBox 自己会吃掉上下键去换选项，不接管的话手柄一旦落到这里
-                    // 就再也回不到上面那排显示器按钮了，而且会静默改掉组合模式。
-                    // 展开状态下放行给列表。这是弹窗里最后一个控件，向下绕回第一颗
-                    // 显示器按钮，不留死键。
-                    Keys.onUpPressed: function(event) {
-                        if (popup.opened) {
-                            event.accepted = false
-                            return
-                        }
-                        nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
-                    }
-
-                    Keys.onDownPressed: function(event) {
-                        if (popup.opened) {
-                            event.accepted = false
-                            return
-                        }
-                        displayDialog.focusInitialItem()
-                    }
+                    // 收起状态下上下键改为导航：不然手柄落到这里就出不去了，
+                    // 而且一路把组合模式静默改掉。向上回到显示器按钮行的末尾；
+                    // 这是弹窗里最后一个控件，向下没有去处，吃掉即可。
+                    navUpItem: vddChip
 
                     Component.onCompleted: {
                         var saved = StreamingPreferences.customScreenMode
@@ -965,23 +951,9 @@ CenteredGridView {
                 textRole: "display"
 
                 // ComboBox 会吃掉上下键换选项，不接管就既走不到按钮行、又会静默改掉
-                // 选中的地址。展开状态下留给列表自己用。
-                Keys.onDownPressed: function(event) {
-                    if (popup.opened) {
-                        event.accepted = false
-                        return
-                    }
-                    ipApplyButton.forceActiveFocus(Qt.TabFocusReason)
-                }
-
-                // 这是弹窗里第一个控件，向上绕回按钮行的末尾（取消）
-                Keys.onUpPressed: function(event) {
-                    if (popup.opened) {
-                        event.accepted = false
-                        return
-                    }
-                    ipCancelButton.forceActiveFocus(Qt.TabFocusReason)
-                }
+                // 选中的地址。这是弹窗里第一个控件，向上绕回按钮行末尾。
+                navUpItem: ipCancelButton
+                navDownItem: ipApplyButton
             }
 
             // 地址类型 / 未验证告警：都是机读信息，走等宽

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -43,8 +43,6 @@ CenteredGridView {
     property bool hasMultipleAddresses: appModel.hasMultipleConnectionAddresses()
     // 当前活动地址信息
     property var activeAddressInfo: appModel.getActiveAddressInfo()
-    // 是否使用自动选择模式
-    property bool useAutoAddress: true
 
     // 显示器 / VDD 选择按钮。以前是裸 Rectangle + MouseArea，手柄和键盘完全够不到 ——
     // 而这个弹窗是切换 VDD 的唯一入口。换成 AbstractButton 才能进焦点链。
@@ -137,15 +135,13 @@ CenteredGridView {
         var addresses = appModel.getConnectionAddresses()
         ipDialog.addresses = addresses
 
-        // 当前用的是自动就落在「自动」那一项（它固定是第 0 项），
-        // 否则落在真正生效的那个地址上。
+        // 落在当前生效的那一项上。isActive 由 model 判定：没固定地址时是「自动」
+        // 那一项（固定在第 0 项），否则是被固定的那个地址。
         var activeIdx = 0
-        if (!useAutoAddress) {
-            for (var i = 0; i < addresses.length; i++) {
-                if (addresses[i].isActive && !addresses[i].isAuto) {
-                    activeIdx = i
-                    break
-                }
+        for (var i = 0; i < addresses.length; i++) {
+            if (addresses[i].isActive) {
+                activeIdx = i
+                break
             }
         }
         ipDialog.initialIndex = activeIdx
@@ -880,12 +876,8 @@ CenteredGridView {
 
         onAddressSelected: function(address) {
             if (address.isAuto) {
-                // 只把 QML 里的开关拨回来是不够的 —— 之前选具体地址时写进
-                // appModel 的固定值还在，不清掉的话「自动」有名无实。
-                useAutoAddress = true
                 appModel.resetToAutomaticAddress()
             } else {
-                useAutoAddress = false
                 appModel.setActiveAddress(address.address, address.port)
             }
             activeAddressInfo = appModel.getActiveAddressInfo()

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -112,20 +112,6 @@ CenteredGridView {
         Keys.onUpPressed: {}
     }
 
-    // IP 弹窗按钮行。HardButton 只是块方角按钮，没带方向键处理；这一页不是 UI 导航
-    // 模式，手柄拿到的是原始方向键，所以左右和向上都得自己接。
-    component IpDialogButton: HardButton {
-        function moveFocus(forward) {
-            nextItemInFocusChain(forward).forceActiveFocus(Qt.TabFocusReason)
-        }
-
-        Keys.onReturnPressed: clicked()
-        Keys.onEnterPressed: clicked()
-        Keys.onLeftPressed: moveFocus(false)
-        Keys.onRightPressed: moveFocus(true)
-        Keys.onUpPressed: ipCombo.forceActiveFocus(Qt.TabFocusReason)
-    }
-
     // 加载显示器列表
     function loadDisplays() {
         var displays = appModel.getDisplayList()
@@ -150,11 +136,11 @@ CenteredGridView {
     function openIpDialog() {
         var addresses = appModel.getConnectionAddresses()
         ipDialog.addresses = addresses
-        // Find current active index
+
+        // 当前用的是自动就落在「自动」那一项（它固定是第 0 项），
+        // 否则落在真正生效的那个地址上。
         var activeIdx = 0
-        if (useAutoAddress) {
-            activeIdx = 0 // "Auto (default)" is always index 0
-        } else {
+        if (!useAutoAddress) {
             for (var i = 0; i < addresses.length; i++) {
                 if (addresses[i].isActive && !addresses[i].isAuto) {
                     activeIdx = i
@@ -162,30 +148,31 @@ CenteredGridView {
                 }
             }
         }
-        ipCombo.currentIndex = activeIdx
+        ipDialog.initialIndex = activeIdx
         ipDialog.open()
     }
 
-    Popup {
+    // 走 NavigableDialog 而不是裸 Popup：方角 Panel、ink 遮罩、宽字距大写标题、
+    // 关闭时归还焦点，这些在那个壳里已经实现过一遍了。
+    NavigableDialog {
         id: displayDialog
-        modal: true
-        focus: true
+
+        title: qsTr("Display Settings")
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-        anchors.centerIn: parent
+
+        // 宽度显式给，别让内容撑：下面的 Column 按 availableWidth 排版，
+        // 两边互相依赖就成环了。
         width: Math.min(500, appGrid.width - 40)
-        padding: Theme.spaceXl
 
-        background: Panel {
-            fill: Theme.surfaceLayer
-            accentBarWidth: Theme.accentBar
-        }
+        // 这个框没有确定 / 取消：选中即生效，靠 B / Esc / 点外面关掉。
+        // NavigableDialog 的 footer 在没有 standardButtons 时不显示。
 
-        // focus: true 只是把焦点给弹窗本体，手柄用户还得盲按一下才有高亮。
+        // 光把焦点给弹窗本体不够，手柄用户还得盲按一下才有高亮。
         // 开的时候直接落到当前选中的显示器上。
         onOpened: focusInitialItem()
 
-        // 关掉之后必须把焦点还回去，否则手柄和键盘导航就停在一个已销毁的
-        // 焦点域里，得摸鼠标点一下才恢复 —— 和 NavigableDialog 里那句是同一个原因。
+        // 基类的 onClosed 会把焦点还给 stackView，这里再收紧到应用网格本身。
+        // QML 的信号处理器是累加的，基类那份仍然会执行。
         onClosed: appGrid.forceActiveFocus()
 
         function focusInitialItem() {
@@ -202,27 +189,10 @@ CenteredGridView {
         }
 
         Column {
-            anchors.left: parent.left
-            anchors.right: parent.right
+            width: displayDialog.availableWidth
             spacing: Theme.spaceLg
 
-            // 标题
-            Text {
-                text: qsTr("Display Settings")
-                color: Theme.text
-                font.family: Theme.fontSans
-                font.pointSize: Theme.fontCardTitle
-                font.weight: Font.ExtraBold
-                font.capitalization: Font.AllUppercase
-                font.letterSpacing: Theme.tracking(Theme.fontCardTitle, 0.08)
-            }
-
-            // 分隔线
-            Rectangle {
-                width: parent.width
-                height: 1
-                color: Theme.line
-            }
+            // 标题和它下面那条分隔线现在由 NavigableDialog 的 header 提供
 
             // 显示器选择区
             MicroLabel {
@@ -901,140 +871,24 @@ CenteredGridView {
         }
     }
 
-    Popup {
+    // 连接 IP 选择框。和 PcView 用的是同一个组件（那边是对某台主机切地址，
+    // 这边是在应用列表里切当前主机的地址），差别只有提示语和「自动」这一项。
+    SelectAddressDialog {
         id: ipDialog
-        property var addresses: []
 
-        modal: true
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-        anchors.centerIn: parent
-        width: Math.min(500, appGrid.width - 40)
-        padding: Theme.spaceXl
+        promptText: qsTr("Select the IP address to connect to this PC:")
 
-        background: Panel {
-            fill: Theme.surfaceLayer
-            accentBarWidth: Theme.accentBar
+        onAddressSelected: function(address) {
+            if (address.isAuto) {
+                useAutoAddress = true
+            } else {
+                useAutoAddress = false
+                appModel.setActiveAddress(address.address, address.port)
+                activeAddressInfo = appModel.getActiveAddressInfo()
+            }
         }
 
-        // 同 displayDialog：开的时候给个明确的初始焦点，关的时候把焦点还给列表。
-        onOpened: ipCombo.forceActiveFocus(Qt.TabFocusReason)
         onClosed: appGrid.forceActiveFocus()
-
-        Column {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            spacing: Theme.spaceLg
-
-            Text {
-                text: qsTr("Connection IP Settings")
-                color: Theme.text
-                font.family: Theme.fontSans
-                font.pointSize: Theme.fontCardTitle
-                font.weight: Font.ExtraBold
-                font.capitalization: Font.AllUppercase
-                font.letterSpacing: Theme.tracking(Theme.fontCardTitle, 0.08)
-            }
-
-            Rectangle {
-                width: parent.width
-                height: 1
-                color: Theme.line
-            }
-
-            MicroLabel {
-                width: parent.width
-                text: qsTr("Select the IP address to connect to this PC:")
-                // 这句比一般微标签长，允许折行（MicroLabel 默认是单行省略）
-                elide: Text.ElideNone
-                wrapMode: Text.Wrap
-            }
-
-            // 走 AutoResizingComboBox 而不是裸 ComboBox：方角背景和方角展开面板
-            // 都在那个文件里统一定义，裸 ComboBox 会退回 FluentWinUI3 的圆角面板。
-            AutoResizingComboBox {
-                id: ipCombo
-                width: parent.width
-                maximumWidth: parent.width
-                model: ipDialog.addresses
-                textRole: "display"
-
-                // ComboBox 会吃掉上下键换选项，不接管就既走不到按钮行、又会静默改掉
-                // 选中的地址。这是弹窗里第一个控件，向上绕回按钮行末尾。
-                navUpItem: ipCancelButton
-                navDownItem: ipApplyButton
-            }
-
-            // 地址类型 / 未验证告警：都是机读信息，走等宽
-            Text {
-                visible: ipCombo.currentIndex >= 0 &&
-                         ipCombo.currentIndex < ipDialog.addresses.length
-                text: visible ? qsTr("Type: %1").arg(ipDialog.addresses[ipCombo.currentIndex].type) : ""
-                color: Theme.textDim
-                font.family: Theme.fontMono
-                font.pointSize: Theme.fontBody
-                wrapMode: Text.Wrap
-                width: parent.width
-            }
-
-            Text {
-                visible: ipCombo.currentIndex > 0 &&
-                         ipCombo.currentIndex < ipDialog.addresses.length &&
-                         !ipDialog.addresses[ipCombo.currentIndex].isTested
-                text: qsTr("Warning: This address has not been verified by polling yet.")
-                color: Theme.danger
-                font.family: Theme.fontMono
-                font.pointSize: Theme.fontCaption
-                wrapMode: Text.Wrap
-                width: parent.width
-            }
-
-            Rectangle {
-                width: parent.width
-                height: 1
-                color: Theme.line
-            }
-
-            Row {
-                spacing: Theme.spaceMd
-                anchors.horizontalCenter: parent.horizontalCenter
-
-                IpDialogButton {
-                    id: ipApplyButton
-                    text: qsTr("Apply")
-                    onClicked: {
-                        if (ipCombo.currentIndex < 0 || ipCombo.currentIndex >= ipDialog.addresses.length) {
-                            return
-                        }
-
-                        var selected = ipDialog.addresses[ipCombo.currentIndex]
-                        if (selected.isAuto) {
-                            useAutoAddress = true
-                        } else {
-                            useAutoAddress = false
-                            appModel.setActiveAddress(selected.address, selected.port)
-                            activeAddressInfo = appModel.getActiveAddressInfo()
-                        }
-                        ipDialog.close()
-                    }
-                }
-
-                IpDialogButton {
-                    id: ipCancelButton
-                    text: qsTr("Cancel")
-                    onClicked: ipDialog.close()
-                }
-            }
-
-            Text {
-                text: qsTr("\"Auto\" uses the default address selection with automatic fallback. Selecting a specific IP will pin the connection to that address.")
-                color: Theme.textFaint
-                font.family: Theme.fontMono
-                font.pointSize: Theme.fontCaption
-                wrapMode: Text.Wrap
-                width: parent.width
-            }
-        }
     }
 
     NavigableMessageDialog {

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -292,13 +292,23 @@ CenteredGridView {
                     model: isVddSelected ? vddModeModel : physicalModeModel
 
                     // ComboBox 自己会吃掉上下键去换选项，不接管的话手柄一旦落到这里
-                    // 就再也回不到上面那排显示器按钮了。展开状态下放行给列表。
+                    // 就再也回不到上面那排显示器按钮了，而且会静默改掉组合模式。
+                    // 展开状态下放行给列表。这是弹窗里最后一个控件，向下绕回第一颗
+                    // 显示器按钮，不留死键。
                     Keys.onUpPressed: function(event) {
                         if (popup.opened) {
                             event.accepted = false
                             return
                         }
                         nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
+                    }
+
+                    Keys.onDownPressed: function(event) {
+                        if (popup.opened) {
+                            event.accepted = false
+                            return
+                        }
+                        displayDialog.focusInitialItem()
                     }
 
                     Component.onCompleted: {
@@ -954,14 +964,23 @@ CenteredGridView {
                 model: ipDialog.addresses
                 textRole: "display"
 
-                // ComboBox 会吃掉上下键换选项，向下得手动放行到按钮行。
-                // 展开状态下留给列表自己用。
+                // ComboBox 会吃掉上下键换选项，不接管就既走不到按钮行、又会静默改掉
+                // 选中的地址。展开状态下留给列表自己用。
                 Keys.onDownPressed: function(event) {
                     if (popup.opened) {
                         event.accepted = false
                         return
                     }
                     ipApplyButton.forceActiveFocus(Qt.TabFocusReason)
+                }
+
+                // 这是弹窗里第一个控件，向上绕回按钮行的末尾（取消）
+                Keys.onUpPressed: function(event) {
+                    if (popup.opened) {
+                        event.accepted = false
+                        return
+                    }
+                    ipCancelButton.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -1020,6 +1039,7 @@ CenteredGridView {
                 }
 
                 IpDialogButton {
+                    id: ipCancelButton
                     text: qsTr("Cancel")
                     onClicked: ipDialog.close()
                 }

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -93,16 +93,23 @@ CenteredGridView {
             verticalAlignment: Text.AlignVCenter
         }
 
+        // 向下的去向。chips 住在一个横向 Flow 里，焦点链的下一项是同一行的下一颗，
+        // 不是「下面那个控件」—— 纵向只能显式指定。为空表示这个方向没有去处，
+        // 吃掉按键。
+        property Item navDownItem: null
+
         function moveFocus(forward) {
             nextItemInFocusChain(forward).forceActiveFocus(Qt.TabFocusReason)
         }
 
         Keys.onReturnPressed: clicked()
         Keys.onEnterPressed: clicked()
+        // 左右沿焦点链走：Flow 的排列顺序就是焦点链顺序，横向是对得上的
         Keys.onRightPressed: moveFocus(true)
-        Keys.onDownPressed: moveFocus(true)
         Keys.onLeftPressed: moveFocus(false)
-        Keys.onUpPressed: moveFocus(false)
+        Keys.onDownPressed: if (navDownItem) navDownItem.forceActiveFocus(Qt.TabFocusReason)
+        // chips 上方没有可聚焦的东西（只有标题和分隔线），吃掉
+        Keys.onUpPressed: {}
     }
 
     // IP 弹窗按钮行。HardButton 只是块方角按钮，没带方向键处理；这一页不是 UI 导航
@@ -234,6 +241,7 @@ CenteredGridView {
                     DisplayChip {
                         text: model.displayName
                         selected: selectedDisplayId === model.displayGuid
+                        navDownItem: combinationModeCombo.visible ? combinationModeCombo : null
 
                         onClicked: {
                             selectedDisplayId = model.displayGuid
@@ -255,6 +263,7 @@ CenteredGridView {
                     selected: isVddSelected
                     selectedFill: Theme.acid
                     selectedBorder: Theme.acid
+                    navDownItem: combinationModeCombo.visible ? combinationModeCombo : null
 
                     onClicked: {
                         selectedDisplayId = "vdd"

--- a/app/gui/AutoResizingComboBox.qml
+++ b/app/gui/AutoResizingComboBox.qml
@@ -56,6 +56,40 @@ ComboBox {
     // so we can adjust the combo box width here too
     onActivated: recalculateWidth()
 
+    // 收起状态下上下键的去向。
+    //
+    // ComboBox 默认拿上下键换值，于是弹窗里的下拉会变成焦点陷阱（走不出去），
+    // 而且一路上还把值静默改了。给任一方向设了目标，这个下拉的上下键就整体改为
+    // 导航语义：有目标就移动焦点，没目标（到头了）就吃掉按键。
+    //
+    // 两个都不设则保持 ComboBox 默认的换值行为 —— 设置页里手柄的上下是
+    // Tab / Shift+Tab，压根到不了这里，键盘用户的上下换值不该被一起砍掉。
+    property Item navUpItem: null
+    property Item navDownItem: null
+
+    readonly property bool arrowNavigation: navUpItem !== null || navDownItem !== null
+
+    // 展开状态下上下归列表（accepted = false 放行给 ComboBox 自己的键处理）
+    Keys.onUpPressed: function(event) {
+        if (popup.opened || !arrowNavigation) {
+            event.accepted = false
+            return
+        }
+        if (navUpItem) {
+            navUpItem.forceActiveFocus(Qt.TabFocusReason)
+        }
+    }
+
+    Keys.onDownPressed: function(event) {
+        if (popup.opened || !arrowNavigation) {
+            event.accepted = false
+            return
+        }
+        if (navDownItem) {
+            navDownItem.forceActiveFocus(Qt.TabFocusReason)
+        }
+    }
+
     // 左右键不再直接换选项。
     //
     // 以前左右就是「改值」，于是手柄用户在设置页里横着扫一下就把分辨率、编解码器
@@ -171,14 +205,14 @@ ComboBox {
 
         // 展开期间挂起 UI 导航模式，让上下键回到真正的方向键，在列表里逐项走
         // （UI 导航模式下上下发的是 Tab / Shift+Tab，驱动不了下拉列表）。
-        // 关闭时必须还原成打开前的值，不能硬置为 true：PcView 和 AppView 里也有
-        // 下拉，那两页本来是普通模式，硬置之后上下就变成 Tab，网格导航直接废掉，
-        // 而且要进一次设置页再退出来才会恢复。
-        property bool savedUiNavMode: false
-
+        //
+        // 用挂起计数而不是「存旧值 - 还原旧值」：PcView 和 AppView 里也有下拉，
+        // 那两页本来跑在普通模式，早先这里是硬置为 true，开合一次下拉就把它们的
+        // 上下键永久变成 Tab，网格导航直接废掉。而存旧值同样不安全 —— 收起和
+        // SettingsView 切页时的 setUiNavMode 谁先谁后不确定，还原会把页面刚设好的
+        // 模式覆盖回去。计数只表达「我要临时借用方向键」，和页面级的开关正交。
         onAboutToShow: {
-            savedUiNavMode = SdlGamepadKeyNavigation.getUiNavMode()
-            SdlGamepadKeyNavigation.setUiNavMode(false)
+            SdlGamepadKeyNavigation.suspendUiNavMode()
 
             // 坐标和窗口高度都通过 Overlay 拿。别用 control.Window.height：
             // 附加属性没法这样从 JS 上取，那句会抛 TypeError，整个处理函数直接中断，
@@ -203,7 +237,7 @@ ComboBox {
         }
 
         onAboutToHide: {
-            SdlGamepadKeyNavigation.setUiNavMode(savedUiNavMode)
+            SdlGamepadKeyNavigation.resumeUiNavMode()
         }
 
         // 面板自带硬投影，右下会溢出一点，这是刻意的：投影必须落在页面上才成立

--- a/app/gui/AutoResizingComboBox.qml
+++ b/app/gui/AutoResizingComboBox.qml
@@ -56,26 +56,21 @@ ComboBox {
     // so we can adjust the combo box width here too
     onActivated: recalculateWidth()
 
-    // 左右键在列表内部换选项，到首尾就把事件放开，交给上层做焦点移动。
-    // QML 的按键处理器默认 accepted = true，而 decrementCurrentIndex() 在第一项上
-    // 是空操作 —— 事件被吃掉又什么都没发生，手柄/键盘用户到了首尾就再也用左右键
-    // 离不开这个下拉了。
+    // 左右键不再直接换选项。
+    //
+    // 以前左右就是「改值」，于是手柄用户在设置页里横着扫一下就把分辨率、编解码器
+    // 这类关键项静默改掉了（issue #144 的另一半）。现在下拉统一走「A 打开列表 →
+    // 上下选 → A 确认 / B 取消」：改值必须是一次明确的操作。
+    // 键盘用户不受影响，ComboBox 自带的上下键换值还在。
+    //
+    // 展开状态下左右在纵向列表里没有意义，吃掉；收起状态下放行给上层做焦点移动
+    // （QML 的按键处理器默认 accepted = true，不显式放行就成了死键）。
     Keys.onLeftPressed: function(event) {
-        if (currentIndex > 0) {
-            decrementCurrentIndex()
-        }
-        else {
-            event.accepted = false
-        }
+        event.accepted = popup.opened
     }
 
     Keys.onRightPressed: function(event) {
-        if (currentIndex < count - 1) {
-            incrementCurrentIndex()
-        }
-        else {
-            event.accepted = false
-        }
+        event.accepted = popup.opened
     }
 
     // 方角化。FluentWinUI3 的圆角来自它自己 __config 里的背景，只能整块替掉。
@@ -174,8 +169,15 @@ ComboBox {
         leftInset: 0
         rightInset: 0
 
+        // 展开期间挂起 UI 导航模式，让上下键回到真正的方向键，在列表里逐项走
+        // （UI 导航模式下上下发的是 Tab / Shift+Tab，驱动不了下拉列表）。
+        // 关闭时必须还原成打开前的值，不能硬置为 true：PcView 和 AppView 里也有
+        // 下拉，那两页本来是普通模式，硬置之后上下就变成 Tab，网格导航直接废掉，
+        // 而且要进一次设置页再退出来才会恢复。
+        property bool savedUiNavMode: false
+
         onAboutToShow: {
-            // 手柄导航切回普通模式，方向键在下拉里选项之间走
+            savedUiNavMode = SdlGamepadKeyNavigation.getUiNavMode()
             SdlGamepadKeyNavigation.setUiNavMode(false)
 
             // 坐标和窗口高度都通过 Overlay 拿。别用 control.Window.height：
@@ -201,7 +203,7 @@ ComboBox {
         }
 
         onAboutToHide: {
-            SdlGamepadKeyNavigation.setUiNavMode(true)
+            SdlGamepadKeyNavigation.setUiNavMode(savedUiNavMode)
         }
 
         // 面板自带硬投影，右下会溢出一点，这是刻意的：投影必须落在页面上才成立

--- a/app/gui/NavigableDialog.qml
+++ b/app/gui/NavigableDialog.qml
@@ -85,8 +85,8 @@ Dialog {
         delegate: HardButton {
             Keys.onReturnPressed: clicked()
             Keys.onEnterPressed: clicked()
-            Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocus)
-            Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+            Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
+            Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
 
             // 向上退回内容区。焦点链的上一项不一定还在对话框里 —— 纯消息框的按钮行
             // 上面没有可聚焦的东西，一路往回会绕到模态遮罩背后的页面上去，所以先确认

--- a/app/gui/NavigableDialog.qml
+++ b/app/gui/NavigableDialog.qml
@@ -87,6 +87,19 @@ Dialog {
             Keys.onEnterPressed: clicked()
             Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocus)
             Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+
+            // 向上退回内容区。焦点链的上一项不一定还在对话框里 —— 纯消息框的按钮行
+            // 上面没有可聚焦的东西，一路往回会绕到模态遮罩背后的页面上去，所以先确认
+            // 它确实在 contentItem 之内，不在就只吃掉按键。
+            Keys.onUpPressed: {
+                var prev = nextItemInFocusChain(false)
+                for (var item = prev; item; item = item.parent) {
+                    if (item === control.contentItem) {
+                        prev.forceActiveFocus(Qt.TabFocusReason)
+                        return
+                    }
+                }
+            }
         }
     }
 

--- a/app/gui/NavigableItemDelegate.qml
+++ b/app/gui/NavigableItemDelegate.qml
@@ -20,7 +20,7 @@ ItemDelegate {
 
         // If we've reached the top of the grid, move focus to the toolbar
         if (grid.currentItem === this) {
-            nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+            nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
         }
     }
     Keys.onReturnPressed: {

--- a/app/gui/NavigableMessageDialog.qml
+++ b/app/gui/NavigableMessageDialog.qml
@@ -19,7 +19,7 @@ NavigableDialog {
     onOpened: {
         // Force keyboard focus on the label so keyboard navigation works
         if (dialogButtonBox.count > 0) {
-            dialogButtonBox.itemAt(dialogButtonBox.count - 1).forceActiveFocus(Qt.TabFocus)
+            dialogButtonBox.itemAt(dialogButtonBox.count - 1).forceActiveFocus(Qt.TabFocusReason)
         }
     }
 
@@ -101,8 +101,8 @@ NavigableDialog {
         delegate: HardButton {
             Keys.onReturnPressed: clicked()
             Keys.onEnterPressed: clicked()
-            Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocus)
-            Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+            Keys.onRightPressed: nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
+            Keys.onLeftPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
         }
 
         onHelpRequested: {

--- a/app/gui/NavigableToolButton.qml
+++ b/app/gui/NavigableToolButton.qml
@@ -52,10 +52,10 @@ ToolButton {
     }
 
     Keys.onRightPressed: {
-        nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocus)
+        nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocusReason)
     }
 
     Keys.onLeftPressed: {
-        nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocus)
+        nextItemInFocusChain(false).forceActiveFocus(Qt.TabFocusReason)
     }
 }

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -113,23 +113,33 @@ CenteredGridView {
     function showAddressSelectionForComputer(computerIndex, computerName, openAppAfterSelection)
     {
         var addresses = computerModel.getConnectionAddressesForComputer(computerIndex)
-        if (addresses.length === 0) {
+
+        // 列表里第一项是「自动」这个伪条目，判断有没有可选地址得数真地址。
+        var realAddressCount = 0
+        for (var i = 0; i < addresses.length; i++) {
+            if (!addresses[i].isAuto) {
+                realAddressCount++
+            }
+        }
+
+        if (realAddressCount === 0) {
             errorDialog.text = qsTr("No connection IP addresses are available for %1.").arg(computerName)
             errorDialog.helpText = ""
             errorDialog.open()
             return
         }
 
-        if (addresses.length === 1) {
+        if (realAddressCount === 1) {
             if (openAppAfterSelection === true) {
                 openAppView(computerIndex, computerName, false)
             }
             return
         }
 
-        // 预选当前生效的那一项
+        // 预选当前生效的那一项。isActive 由 model 判定：没固定地址时是「自动」，
+        // 否则是被固定的那个地址。
         var activeIndex = 0
-        for (var i = 0; i < addresses.length; i++) {
+        for (i = 0; i < addresses.length; i++) {
             if (addresses[i].isActive) {
                 activeIndex = i
                 break
@@ -552,7 +562,10 @@ CenteredGridView {
         property bool openAppAfterSelection: false
 
         onAddressSelected: function(address) {
-            if (!computerModel.setActiveAddressForComputer(pcIndex, address.address, address.port)) {
+            var ok = address.isAuto
+                    ? computerModel.resetToAutomaticAddressForComputer(pcIndex)
+                    : computerModel.setActiveAddressForComputer(pcIndex, address.address, address.port)
+            if (!ok) {
                 errorDialog.text = qsTr("Unable to switch the connection IP for %1.").arg(pcName)
                 errorDialog.helpText = ""
                 errorDialog.open()

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -127,23 +127,21 @@ CenteredGridView {
             return
         }
 
-        var formattedAddresses = []
+        // 预选当前生效的那一项
+        var activeIndex = 0
         for (var i = 0; i < addresses.length; i++) {
-            var address = addresses[i]
-            formattedAddresses.push({
-                "address": address.address,
-                "port": address.port,
-                "displayText": address.display,
-                "type": address.type,
-                "isActive": address.isActive,
-                "isTested": address.isTested
-            })
+            if (addresses[i].isActive) {
+                activeIndex = i
+                break
+            }
         }
 
         selectAddressDialog.pcIndex = computerIndex
         selectAddressDialog.pcName = computerName
         selectAddressDialog.openAppAfterSelection = openAppAfterSelection === true
-        selectAddressDialog.addresses = formattedAddresses
+        selectAddressDialog.addresses = addresses
+        selectAddressDialog.initialIndex = activeIndex
+        selectAddressDialog.promptText = qsTr("Choose the IP address to connect to %1:").arg(computerName)
         selectAddressDialog.open()
     }
 
@@ -546,42 +544,15 @@ CenteredGridView {
         }
     }
 
-    NavigableDialog {
+    // 和 AppView 的地址选择框是同一个组件，只有提示语和落地方式不同
+    SelectAddressDialog {
         id: selectAddressDialog
         property int pcIndex: -1
         property string pcName: ""
         property bool openAppAfterSelection: false
-        property var addresses: []
 
-        title: qsTr("Select Connection IP")
-        standardButtons: DialogButtonBox.Ok | DialogButtonBox.Cancel
-        width: Math.max(320, Math.min(560, pcGrid.width - 40))
-
-        onOpened: {
-            var activeIndex = 0
-            for (var i = 0; i < addresses.length; i++) {
-                if (addresses[i].isActive) {
-                    activeIndex = i
-                    break
-                }
-            }
-            addressCombo.currentIndex = activeIndex
-
-            // 上下键改为导航。不接管的话手柄在这个框里是走不通的：地址下拉是唯一
-            // 一个可聚焦的内容控件，上下会被 ComboBox 拿去换地址（这一页不是 UI
-            // 导航模式，手柄发的是真方向键），底部的确定 / 取消永远到不了。
-            // 按钮由 footer 按 standardButtons 生成，只能在这里取。
-            addressCombo.navDownItem = footer.standardButton(DialogButtonBox.Ok)
-            addressCombo.forceActiveFocus()
-        }
-
-        onAccepted: {
-            if (addressCombo.currentIndex < 0 || addressCombo.currentIndex >= addresses.length) {
-                return
-            }
-
-            var selectedAddress = addresses[addressCombo.currentIndex]
-            if (!computerModel.setActiveAddressForComputer(pcIndex, selectedAddress.address, selectedAddress.port)) {
+        onAddressSelected: function(address) {
+            if (!computerModel.setActiveAddressForComputer(pcIndex, address.address, address.port)) {
                 errorDialog.text = qsTr("Unable to switch the connection IP for %1.").arg(pcName)
                 errorDialog.helpText = ""
                 errorDialog.open()
@@ -598,41 +569,6 @@ CenteredGridView {
             openAppAfterSelection = false
             pcIndex = -1
             pcName = ""
-        }
-
-        ColumnLayout {
-            width: parent.width
-            spacing: 8
-
-            Text {
-                text: qsTr("Choose the IP address to connect to %1:").arg(selectAddressDialog.pcName)
-                color: Theme.text
-                font.family: Theme.fontSans
-                font.pointSize: Theme.fontRowTitle
-                font.weight: Font.DemiBold
-                wrapMode: Text.Wrap
-                Layout.fillWidth: true
-            }
-
-            AutoResizingComboBox {
-                id: addressCombo
-                model: selectAddressDialog.addresses
-                textRole: "displayText"
-                maximumWidth: parent.width
-                popup.width: width
-                Layout.fillWidth: true
-            }
-
-            Label {
-                visible: addressCombo.currentIndex >= 0 &&
-                         addressCombo.currentIndex < selectAddressDialog.addresses.length
-                text: visible ? qsTr("Address type: %1").arg(selectAddressDialog.addresses[addressCombo.currentIndex].type) : ""
-                color: Theme.textDim
-                font.family: Theme.fontMono
-                font.pointSize: Theme.fontBody
-                wrapMode: Text.Wrap
-                Layout.fillWidth: true
-            }
         }
     }
 

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -136,21 +136,11 @@ CenteredGridView {
             return
         }
 
-        // 预选当前生效的那一项。isActive 由 model 判定：没固定地址时是「自动」，
-        // 否则是被固定的那个地址。
-        var activeIndex = 0
-        for (i = 0; i < addresses.length; i++) {
-            if (addresses[i].isActive) {
-                activeIndex = i
-                break
-            }
-        }
-
+        // 预选交给 SelectAddressDialog 自己按 isActive 算
         selectAddressDialog.pcIndex = computerIndex
         selectAddressDialog.pcName = computerName
         selectAddressDialog.openAppAfterSelection = openAppAfterSelection === true
         selectAddressDialog.addresses = addresses
-        selectAddressDialog.initialIndex = activeIndex
         selectAddressDialog.promptText = qsTr("Choose the IP address to connect to %1:").arg(computerName)
         selectAddressDialog.open()
     }

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -566,6 +566,12 @@ CenteredGridView {
                 }
             }
             addressCombo.currentIndex = activeIndex
+
+            // 上下键改为导航。不接管的话手柄在这个框里是走不通的：地址下拉是唯一
+            // 一个可聚焦的内容控件，上下会被 ComboBox 拿去换地址（这一页不是 UI
+            // 导航模式，手柄发的是真方向键），底部的确定 / 取消永远到不了。
+            // 按钮由 footer 按 standardButtons 生成，只能在这里取。
+            addressCombo.navDownItem = footer.standardButton(DialogButtonBox.Ok)
             addressCombo.forceActiveFocus()
         }
 

--- a/app/gui/SelectAddressDialog.qml
+++ b/app/gui/SelectAddressDialog.qml
@@ -94,7 +94,10 @@ NavigableDialog {
         Text {
             width: parent.width
             visible: control.currentAddress !== null
-            text: visible ? qsTr("Type: %1").arg(control.currentAddress.type) : ""
+            // 短路判断直接看 currentAddress，别看 visible：两个绑定都依赖
+            // currentAddress，求值先后没有保证，靠 visible 挡的话在
+            // currentAddress 变成 null 的那一拍可能先算 text 就取空指针成员了。
+            text: control.currentAddress ? qsTr("Type: %1").arg(control.currentAddress.type) : ""
             color: Theme.textDim
             font.family: Theme.fontMono
             font.pointSize: Theme.fontBody

--- a/app/gui/SelectAddressDialog.qml
+++ b/app/gui/SelectAddressDialog.qml
@@ -21,11 +21,18 @@ NavigableDialog {
     // 列表上方那句提示，调用方自己填（PcView 要带主机名）
     property string promptText: ""
 
-    // 打开时预选第几项。两边算法不同（AppView 还要考虑「当前是自动」），
-    // 由调用方算好传进来。
-    property int initialIndex: 0
-
     signal addressSelected(var address)
+
+    // 打开时预选哪一项：model 已经用 isActive 标好了当前生效的条目
+    // （没固定地址时是「自动」，否则是被固定的那个），调用方不用自己算。
+    readonly property int activeIndex: {
+        for (var i = 0; i < addresses.length; i++) {
+            if (addresses[i].isActive) {
+                return i
+            }
+        }
+        return 0
+    }
 
     readonly property var currentAddress:
         addressCombo.currentIndex >= 0 && addressCombo.currentIndex < addresses.length
@@ -50,7 +57,7 @@ NavigableDialog {
     width: Math.max(320, Math.min(560, parent ? parent.width - 80 : 480))
 
     onOpened: {
-        addressCombo.currentIndex = initialIndex
+        addressCombo.currentIndex = activeIndex
 
         // 地址下拉是内容区唯一一个可聚焦的控件。这两页都不跑 UI 导航模式，手柄发的是
         // 真方向键，不接管上下的话会被 ComboBox 拿去换地址，底下的确定 / 取消永远

--- a/app/gui/SelectAddressDialog.qml
+++ b/app/gui/SelectAddressDialog.qml
@@ -1,0 +1,128 @@
+import QtQuick 2.9
+import QtQuick.Controls
+
+import "theme"
+
+// 连接 IP 选择框。PcView（对某台主机切地址）和 AppView（在应用列表里切当前主机的
+// 地址）用的是同一个框：两边 model 给出的条目形状本来就一样
+// （address / port / display / type / isActive / isTested），只有提示语和「自动」
+// 这一项不同，所以做成参数。
+//
+// 选中结果通过 addressSelected 抛给调用方 —— 落地方式两边不一样
+// （computerModel.setActiveAddressForComputer vs appModel.setActiveAddress + 自动开关），
+// 那部分不属于这个框。
+NavigableDialog {
+    id: control
+
+    // 条目数组。约定每项含 address / port / display / type / isActive；
+    // isTested 缺省视为已验证，isAuto 标记「自动选择」这种没有具体地址的伪条目。
+    property var addresses: []
+
+    // 列表上方那句提示，调用方自己填（PcView 要带主机名）
+    property string promptText: ""
+
+    // 打开时预选第几项。两边算法不同（AppView 还要考虑「当前是自动」），
+    // 由调用方算好传进来。
+    property int initialIndex: 0
+
+    signal addressSelected(var address)
+
+    readonly property var currentAddress:
+        addressCombo.currentIndex >= 0 && addressCombo.currentIndex < addresses.length
+            ? addresses[addressCombo.currentIndex]
+            : null
+
+    readonly property bool hasAutoEntry: {
+        for (var i = 0; i < addresses.length; i++) {
+            if (addresses[i].isAuto) {
+                return true
+            }
+        }
+        return false
+    }
+
+    title: qsTr("Select Connection IP")
+    standardButtons: DialogButtonBox.Ok | DialogButtonBox.Cancel
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+    // 宽度显式给，别让内容撑：下面的 Column 要按 availableWidth 排版，
+    // 两边互相依赖就成环了。
+    width: Math.max(320, Math.min(560, parent ? parent.width - 80 : 480))
+
+    onOpened: {
+        addressCombo.currentIndex = initialIndex
+
+        // 地址下拉是内容区唯一一个可聚焦的控件。这两页都不跑 UI 导航模式，手柄发的是
+        // 真方向键，不接管上下的话会被 ComboBox 拿去换地址，底下的确定 / 取消永远
+        // 到不了。按钮由 standardButtons 生成，要等对话框建好才取得到，所以放在这里。
+        addressCombo.navDownItem = standardButton(DialogButtonBox.Ok)
+        addressCombo.forceActiveFocus(Qt.TabFocusReason)
+    }
+
+    onAccepted: {
+        if (control.currentAddress) {
+            control.addressSelected(control.currentAddress)
+        }
+    }
+
+    Column {
+        width: control.availableWidth
+        spacing: Theme.spaceMd
+
+        Text {
+            width: parent.width
+            text: control.promptText
+            color: Theme.text
+            font.family: Theme.fontSans
+            font.pointSize: Theme.fontRowTitle
+            font.weight: Font.DemiBold
+            wrapMode: Text.Wrap
+        }
+
+        // 走 AutoResizingComboBox 而不是裸 ComboBox：方角背景和方角展开面板都在
+        // 那个文件里统一定义，裸 ComboBox 会退回 FluentWinUI3 的圆角面板。
+        AutoResizingComboBox {
+            id: addressCombo
+            width: parent.width
+            maximumWidth: parent.width
+            popup.width: width
+            model: control.addresses
+            textRole: "display"
+        }
+
+        // 地址类型 / 未验证告警：都是机读信息，走等宽
+        Text {
+            width: parent.width
+            visible: control.currentAddress !== null
+            text: visible ? qsTr("Type: %1").arg(control.currentAddress.type) : ""
+            color: Theme.textDim
+            font.family: Theme.fontMono
+            font.pointSize: Theme.fontBody
+            wrapMode: Text.Wrap
+        }
+
+        Text {
+            width: parent.width
+            // isTested 缺省（undefined）当作已验证，不然没提供这个字段的调用方会
+            // 满屏告警。
+            visible: control.currentAddress !== null
+                     && !control.currentAddress.isAuto
+                     && control.currentAddress.isTested === false
+            text: qsTr("Warning: This address has not been verified by polling yet.")
+            color: Theme.danger
+            font.family: Theme.fontMono
+            font.pointSize: Theme.fontCaption
+            wrapMode: Text.Wrap
+        }
+
+        Text {
+            width: parent.width
+            visible: control.hasAutoEntry
+            text: qsTr("\"Auto\" uses the default address selection with automatic fallback. Selecting a specific IP will pin the connection to that address.")
+            color: Theme.textFaint
+            font.family: Theme.fontMono
+            font.pointSize: Theme.fontCaption
+            wrapMode: Text.Wrap
+        }
+    }
+}

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -60,28 +60,22 @@ FocusScope {
     // 焦点在内容区时，B / Esc 先退回分类栏；已经在分类栏了才放行给 main.qml
     // 去弹出整个设置页。之前不分级，手柄用户在内容区随手一个 B 就整页退出了。
     Keys.onEscapePressed: function(event) {
-        if (!rail.railFocused) {
+        event.accepted = !rail.railFocused
+        if (event.accepted) {
             rail.focusCurrent()
-            event.accepted = true
-        }
-        else {
-            event.accepted = false
         }
     }
 
     // 把焦点交给内容区的第一个可聚焦控件。
     //
-    // 不直接引用 basicPage.firstControl：那个只对基本设置页有效，其余六组还在
-    // LegacySettingsPage 里。分类栏在声明顺序上排在内容区前面，所以从它最后一项
-    // 往后走一格 Tab 就是内容区的第一个控件 —— 焦点链本身会跳过不可见的分类。
+    // 不直接引用某个页面的首个控件：那只对基本设置页有效，其余六组还在
+    // LegacySettingsPage 里，而且随分类切换。scrollArea 在声明顺序上排在分类栏
+    // 之后，往后走一格 Tab 就是它内部第一个可聚焦控件 —— 焦点链本身会跳过
+    // 不可见的分类。
     function focusContent() {
-        var last = rail.lastItem()
-        if (!last) {
-            return
-        }
-        var next = last.nextItemInFocusChain(true)
-        if (next) {
-            next.forceActiveFocus(Qt.TabFocusReason)
+        var first = scrollArea.nextItemInFocusChain(true)
+        if (first) {
+            first.forceActiveFocus(Qt.TabFocusReason)
         }
     }
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -13,7 +13,11 @@ import "theme"
 // 设置页外壳：左侧分类 rail + 右侧卡片内容。
 // 「基本设置」已迁移到 settings/BasicSettingsPage.qml；
 // 其余 6 组仍走旧的 GroupBox 路径（settings/LegacySettingsPage.qml），逐步迁移。
-Item {
+// 根用 FocusScope 而不是 Item：工具栏的 Keys.onDownPressed 走的是
+// stackView.currentItem.forceActiveFocus()，落在普通 Item 上会停在一个看不见的
+// 死点上（PcView / AppView 是 GridView + activeFocusOnTab，所以没这问题）。
+// FocusScope 会把焦点转交给内部真正持焦的控件。
+FocusScope {
     id: settingsPage
     // 这一页自带壁纸，main.qml 不用再垫一层
     readonly property bool usesOwnBackground: true
@@ -43,18 +47,41 @@ Item {
         // It is required to shift focus between controls on the settings page.
         SdlGamepadKeyNavigation.setUiNavMode(true)
 
-        // Highlight the first item if a gamepad is connected
+        // 手柄进来时把焦点放在分类栏的当前分类上，而不是内容区第一个控件。
         //
-        // category 会跨次进入保留下来，所以不能无条件去点基本设置页的第一个控件：
-        // 当前分类不是 basic 时那个控件是不可见的，forceActiveFocus() 静默失效，
-        // 手柄用户就一个可用焦点都没有（firstControl 万一是 undefined 还会抛）。
+        // 以前是直接点基本设置页的分辨率下拉，于是用户进设置的第一下左右输入就把
+        // 分辨率改了（issue #144）。落在分类栏上就没这个问题：分类栏不吃左右键，
+        // 而且 category 是跨次保留的，从分类栏出发永远是可见、可用的那一项。
         if (SdlGamepadKeyNavigation.getConnectedGamepads() > 0) {
-            if (settingsPage.category === "basic" && basicPage.firstControl) {
-                basicPage.firstControl.forceActiveFocus(Qt.TabFocus)
-            }
-            else {
-                rail.forceActiveFocus(Qt.TabFocus)
-            }
+            rail.focusCurrent()
+        }
+    }
+
+    // 焦点在内容区时，B / Esc 先退回分类栏；已经在分类栏了才放行给 main.qml
+    // 去弹出整个设置页。之前不分级，手柄用户在内容区随手一个 B 就整页退出了。
+    Keys.onEscapePressed: function(event) {
+        if (!rail.railFocused) {
+            rail.focusCurrent()
+            event.accepted = true
+        }
+        else {
+            event.accepted = false
+        }
+    }
+
+    // 把焦点交给内容区的第一个可聚焦控件。
+    //
+    // 不直接引用 basicPage.firstControl：那个只对基本设置页有效，其余六组还在
+    // LegacySettingsPage 里。分类栏在声明顺序上排在内容区前面，所以从它最后一项
+    // 往后走一格 Tab 就是内容区的第一个控件 —— 焦点链本身会跳过不可见的分类。
+    function focusContent() {
+        var last = rail.lastItem()
+        if (!last) {
+            return
+        }
+        var next = last.nextItemInFocusChain(true)
+        if (next) {
+            next.forceActiveFocus(Qt.TabFocusReason)
         }
     }
 
@@ -71,14 +98,26 @@ Item {
         StreamingPreferences.save()
     }
 
+    // 焦点落到 FocusScope 壳自己身上时（工具栏按向下、或 StackView 切页回来），
+    // 转交给分类栏。停在壳上是个看不见的死点，用户得多按一次才有反应。
+    onActiveFocusChanged: {
+        if (activeFocus && Window.window && Window.window.activeFocusItem === settingsPage) {
+            rail.focusCurrent()
+        }
+    }
+
     // 手柄 LB/RB 映射成 PageUp/PageDown，用来切分类
     Keys.onPressed: {
         if (event.key === Qt.Key_PageUp) {
             rail.step(-1)
+            // 切完分类要把焦点收回分类栏：原来持焦的控件已经随着旧分类隐藏了，
+            // 焦点会凭空消失，手柄看起来就像失灵。
+            rail.focusCurrent()
             event.accepted = true
         }
         else if (event.key === Qt.Key_PageDown) {
             rail.step(1)
+            rail.focusCurrent()
             event.accepted = true
         }
     }
@@ -145,6 +184,7 @@ Item {
                     settingsPage.category = category
                     scrollArea.contentY = 0
                 }
+                onContentRequested: settingsPage.focusContent()
             }
         }
 

--- a/app/gui/appmodel.cpp
+++ b/app/gui/appmodel.cpp
@@ -264,7 +264,7 @@ QVariantList AppModel::getConnectionAddresses()
     NvAddress remoteAddress;
     NvAddress manualAddress;
     NvAddress ipv6Address;
-    NvAddress activeAddress;
+    NvAddress pinnedAddress;
 
     {
         QReadLocker lock(&m_Computer->lock);
@@ -272,7 +272,7 @@ QVariantList AppModel::getConnectionAddresses()
         remoteAddress = m_Computer->remoteAddress;
         manualAddress = m_Computer->manualAddress;
         ipv6Address = m_Computer->ipv6Address;
-        activeAddress = m_Computer->activeAddress;
+        pinnedAddress = m_Computer->pinnedAddress;
     }
 
     // Add "Auto (default)" option
@@ -281,7 +281,9 @@ QVariantList AppModel::getConnectionAddresses()
     autoItem["port"] = 0;
     autoItem["display"] = tr("Auto (default)");
     autoItem["type"] = tr("Automatic selection with fallback");
-    autoItem["isActive"] = false;
+    // 没固定地址就是自动模式。这一位是弹窗预选的依据 —— 光看 activeAddress
+    // 分不出「自动选中的」和「用户固定的」。
+    autoItem["isActive"] = pinnedAddress.isNull();
     autoItem["isAuto"] = true;
     addresses.append(autoItem);
 
@@ -291,7 +293,9 @@ QVariantList AppModel::getConnectionAddresses()
         item["port"] = static_cast<int>(address.port());
         item["display"] = address.toString();
         item["type"] = getAddressType(address, localAddress, remoteAddress, manualAddress, ipv6Address);
-        item["isActive"] = address == activeAddress;
+        // 具体条目只在「被固定」时算选中；自动模式下选中的是上面的「自动」项，
+        // 实际生效的地址交给轮询，不在这里标。
+        item["isActive"] = !pinnedAddress.isNull() && address == pinnedAddress;
         item["isAuto"] = false;
         item["isTested"] = m_Computer->hasAddressTestSucceeded(address);
         addresses.append(item);
@@ -333,10 +337,7 @@ bool AppModel::setActiveAddress(QString address, int port)
         return false;
     }
 
-    {
-        QWriteLocker lock(&m_Computer->lock);
-        m_Computer->activeAddress = selectedAddress;
-    }
+    m_Computer->pinAddress(selectedAddress);
 
     return true;
 }
@@ -347,29 +348,7 @@ bool AppModel::resetToAutomaticAddress()
         return false;
     }
 
-    // 「固定某个地址」的全部机制就是把它放进 activeAddress：uniqueAddresses() 会把
-    // activeAddress 排在最前面，轮询取第一个能连上的（见 computermanager.cpp）。
-    // 所以「回到自动」就是让 activeAddress 退回自然顺序里的头一个地址，
-    // 后面的失败回退仍由轮询自己完成。
-    //
-    // 不能直接置空：activeAddress 同时是 NvHTTP 和串流真正使用的地址，置空会留下
-    // 一个到下次轮询为止的窗口期，期间点开始串流会连不上。
-    QWriteLocker lock(&m_Computer->lock);
-    const NvAddress candidates[] = {
-        m_Computer->localAddress,
-        m_Computer->remoteAddress,
-        m_Computer->ipv6Address,
-        m_Computer->manualAddress,
-    };
-    for (const NvAddress& address : candidates) {
-        if (!address.isNull()) {
-            m_Computer->activeAddress = address;
-            return true;
-        }
-    }
-
-    // 一个具体地址都没有（不该发生）。保持现状，别把能用的地址弄丢。
-    return false;
+    return m_Computer->resetToAutomaticAddress();
 }
 
 QVariantMap AppModel::getActiveAddressInfo()

--- a/app/gui/appmodel.cpp
+++ b/app/gui/appmodel.cpp
@@ -253,12 +253,17 @@ void AppModel::setAppDirectLaunch(int appIndex, bool directLaunch)
 
 QVariantList AppModel::getConnectionAddresses()
 {
+    return buildConnectionAddressList(m_Computer);
+}
+
+QVariantList AppModel::buildConnectionAddressList(NvComputer* computer)
+{
     QVariantList addresses;
-    if (!m_Computer) {
+    if (!computer) {
         return addresses;
     }
 
-    QVector<NvAddress> allAddresses = m_Computer->uniqueAddresses();
+    QVector<NvAddress> allAddresses = computer->uniqueAddresses();
 
     NvAddress localAddress;
     NvAddress remoteAddress;
@@ -267,12 +272,12 @@ QVariantList AppModel::getConnectionAddresses()
     NvAddress pinnedAddress;
 
     {
-        QReadLocker lock(&m_Computer->lock);
-        localAddress = m_Computer->localAddress;
-        remoteAddress = m_Computer->remoteAddress;
-        manualAddress = m_Computer->manualAddress;
-        ipv6Address = m_Computer->ipv6Address;
-        pinnedAddress = m_Computer->pinnedAddress;
+        QReadLocker lock(&computer->lock);
+        localAddress = computer->localAddress;
+        remoteAddress = computer->remoteAddress;
+        manualAddress = computer->manualAddress;
+        ipv6Address = computer->ipv6Address;
+        pinnedAddress = computer->pinnedAddress;
     }
 
     // Add "Auto (default)" option
@@ -297,7 +302,7 @@ QVariantList AppModel::getConnectionAddresses()
         // 实际生效的地址交给轮询，不在这里标。
         item["isActive"] = !pinnedAddress.isNull() && address == pinnedAddress;
         item["isAuto"] = false;
-        item["isTested"] = m_Computer->hasAddressTestSucceeded(address);
+        item["isTested"] = computer->hasAddressTestSucceeded(address);
         addresses.append(item);
     }
 

--- a/app/gui/appmodel.cpp
+++ b/app/gui/appmodel.cpp
@@ -341,6 +341,37 @@ bool AppModel::setActiveAddress(QString address, int port)
     return true;
 }
 
+bool AppModel::resetToAutomaticAddress()
+{
+    if (!m_Computer) {
+        return false;
+    }
+
+    // 「固定某个地址」的全部机制就是把它放进 activeAddress：uniqueAddresses() 会把
+    // activeAddress 排在最前面，轮询取第一个能连上的（见 computermanager.cpp）。
+    // 所以「回到自动」就是让 activeAddress 退回自然顺序里的头一个地址，
+    // 后面的失败回退仍由轮询自己完成。
+    //
+    // 不能直接置空：activeAddress 同时是 NvHTTP 和串流真正使用的地址，置空会留下
+    // 一个到下次轮询为止的窗口期，期间点开始串流会连不上。
+    QWriteLocker lock(&m_Computer->lock);
+    const NvAddress candidates[] = {
+        m_Computer->localAddress,
+        m_Computer->remoteAddress,
+        m_Computer->ipv6Address,
+        m_Computer->manualAddress,
+    };
+    for (const NvAddress& address : candidates) {
+        if (!address.isNull()) {
+            m_Computer->activeAddress = address;
+            return true;
+        }
+    }
+
+    // 一个具体地址都没有（不该发生）。保持现状，别把能用的地址弄丢。
+    return false;
+}
+
 QVariantMap AppModel::getActiveAddressInfo()
 {
     QVariantMap info;

--- a/app/gui/appmodel.h
+++ b/app/gui/appmodel.h
@@ -46,6 +46,14 @@ public:
 
     Q_INVOKABLE QVariantList getConnectionAddresses();
 
+    // 地址选择框的条目列表。PcView 和 AppView 用同一个 QML 组件
+    // （SelectAddressDialog），所以条目形状和「哪一项算选中」的判定必须一致 ——
+    // 放在一处，ComputerModel 也调这里。
+    //
+    // 翻译上下文特意留在 AppModel：这几个字符串在 AppModel 下已经有译文了，
+    // 换个上下文会让它们退回英文。
+    static QVariantList buildConnectionAddressList(NvComputer* computer);
+
     Q_INVOKABLE bool hasMultipleConnectionAddresses();
 
     Q_INVOKABLE bool setActiveAddress(QString address, int port);

--- a/app/gui/appmodel.h
+++ b/app/gui/appmodel.h
@@ -50,6 +50,9 @@ public:
 
     Q_INVOKABLE bool setActiveAddress(QString address, int port);
 
+    // Undo a setActiveAddress() pin and go back to automatic selection.
+    Q_INVOKABLE bool resetToAutomaticAddress();
+
     Q_INVOKABLE QVariantMap getActiveAddressInfo();
 
     // Defensive self-heal: re-read m_Computer->currentGameId and force-emit

--- a/app/gui/computermodel.cpp
+++ b/app/gui/computermodel.cpp
@@ -189,7 +189,7 @@ QVariantList ComputerModel::getConnectionAddressesForComputer(int computerIndex)
     NvAddress remoteAddress;
     NvAddress manualAddress;
     NvAddress ipv6Address;
-    NvAddress activeAddress;
+    NvAddress pinnedAddress;
 
     {
         QReadLocker lock(&computer->lock);
@@ -197,8 +197,20 @@ QVariantList ComputerModel::getConnectionAddressesForComputer(int computerIndex)
         remoteAddress = computer->remoteAddress;
         manualAddress = computer->manualAddress;
         ipv6Address = computer->ipv6Address;
-        activeAddress = computer->activeAddress;
+        pinnedAddress = computer->pinnedAddress;
     }
+
+    // 「自动」放第一项，语义和 AppView 那份一致：没固定地址时它就是选中项。
+    // 之前这个列表没有自动项 —— 从这里固定过地址后，同一个入口反而没有解除的
+    // 手段，只能绕去应用列表。
+    QVariantMap autoItem;
+    autoItem["address"] = "";
+    autoItem["port"] = 0;
+    autoItem["display"] = tr("Auto (default)");
+    autoItem["type"] = tr("Automatic selection with fallback");
+    autoItem["isActive"] = pinnedAddress.isNull();
+    autoItem["isAuto"] = true;
+    addresses.append(autoItem);
 
     for (const NvAddress& address : selectableAddresses) {
         QVariantMap item;
@@ -206,7 +218,7 @@ QVariantList ComputerModel::getConnectionAddressesForComputer(int computerIndex)
         item["port"] = static_cast<int>(address.port());
         item["display"] = address.toString();
         item["type"] = getAddressType(address, localAddress, remoteAddress, manualAddress, ipv6Address);
-        item["isActive"] = address == activeAddress;
+        item["isActive"] = !pinnedAddress.isNull() && address == pinnedAddress;
         item["isTested"] = computer->hasAddressTestSucceeded(address);
         addresses.append(item);
     }
@@ -252,9 +264,21 @@ bool ComputerModel::setActiveAddressForComputer(int computerIndex, QString addre
         return false;
     }
 
-    {
-        QWriteLocker lock(&computer->lock);
-        computer->activeAddress = selectedAddress;
+    computer->pinAddress(selectedAddress);
+
+    emit dataChanged(createIndex(computerIndex, 0), createIndex(computerIndex, 0));
+    return true;
+}
+
+bool ComputerModel::resetToAutomaticAddressForComputer(int computerIndex)
+{
+    if (computerIndex < 0 || computerIndex >= m_Computers.count()) {
+        qWarning() << "Invalid computer index for resetToAutomaticAddressForComputer:" << computerIndex;
+        return false;
+    }
+
+    if (!m_Computers[computerIndex]->resetToAutomaticAddress()) {
+        return false;
     }
 
     emit dataChanged(createIndex(computerIndex, 0), createIndex(computerIndex, 0));

--- a/app/gui/computermodel.cpp
+++ b/app/gui/computermodel.cpp
@@ -1,4 +1,5 @@
 #include "computermodel.h"
+#include "appmodel.h"
 #include "backend/nvcomputer.h"
 
 #include <QDebug>
@@ -6,36 +7,6 @@
 #include <QThreadPool>
 #include <QWriteLocker>
 
-namespace {
-QString getAddressType(const NvAddress& address,
-                       const NvAddress& localAddress,
-                       const NvAddress& remoteAddress,
-                       const NvAddress& manualAddress,
-                       const NvAddress& ipv6Address)
-{
-    if (address == localAddress) {
-        return ComputerModel::tr("Local network");
-    }
-    if (address == remoteAddress) {
-        return ComputerModel::tr("Remote network");
-    }
-    if (address == manualAddress) {
-        return ComputerModel::tr("Manual");
-    }
-    if (address == ipv6Address) {
-        return ComputerModel::tr("IPv6 network");
-    }
-
-    return ComputerModel::tr("Other network");
-}
-
-QVector<NvAddress> getSelectableAddresses(NvComputer* computer)
-{
-    // Return all unique addresses, not just tested ones,
-    // so the user can always select from all known addresses.
-    return computer->uniqueAddresses();
-}
-}
 
 ComputerModel::ComputerModel(QObject* object)
     : QAbstractListModel(object) {}
@@ -182,48 +153,9 @@ QVariantList ComputerModel::getConnectionAddressesForComputer(int computerIndex)
         return addresses;
     }
 
-    NvComputer* computer = m_Computers[computerIndex];
-    const QVector<NvAddress> selectableAddresses = getSelectableAddresses(computer);
-
-    NvAddress localAddress;
-    NvAddress remoteAddress;
-    NvAddress manualAddress;
-    NvAddress ipv6Address;
-    NvAddress pinnedAddress;
-
-    {
-        QReadLocker lock(&computer->lock);
-        localAddress = computer->localAddress;
-        remoteAddress = computer->remoteAddress;
-        manualAddress = computer->manualAddress;
-        ipv6Address = computer->ipv6Address;
-        pinnedAddress = computer->pinnedAddress;
-    }
-
-    // 「自动」放第一项，语义和 AppView 那份一致：没固定地址时它就是选中项。
-    // 之前这个列表没有自动项 —— 从这里固定过地址后，同一个入口反而没有解除的
-    // 手段，只能绕去应用列表。
-    QVariantMap autoItem;
-    autoItem["address"] = "";
-    autoItem["port"] = 0;
-    autoItem["display"] = tr("Auto (default)");
-    autoItem["type"] = tr("Automatic selection with fallback");
-    autoItem["isActive"] = pinnedAddress.isNull();
-    autoItem["isAuto"] = true;
-    addresses.append(autoItem);
-
-    for (const NvAddress& address : selectableAddresses) {
-        QVariantMap item;
-        item["address"] = address.address();
-        item["port"] = static_cast<int>(address.port());
-        item["display"] = address.toString();
-        item["type"] = getAddressType(address, localAddress, remoteAddress, manualAddress, ipv6Address);
-        item["isActive"] = !pinnedAddress.isNull() && address == pinnedAddress;
-        item["isTested"] = computer->hasAddressTestSucceeded(address);
-        addresses.append(item);
-    }
-
-    return addresses;
+    // 和 AppView 那边共用一份构造逻辑：两边喂的是同一个 QML 组件，
+    // 条目形状和「哪一项算选中」的判定必须一致。
+    return AppModel::buildConnectionAddressList(m_Computers[computerIndex]);
 }
 
 bool ComputerModel::hasMultipleConnectionAddresses(int computerIndex) const
@@ -233,7 +165,8 @@ bool ComputerModel::hasMultipleConnectionAddresses(int computerIndex) const
         return false;
     }
 
-    return getSelectableAddresses(m_Computers[computerIndex]).count() > 1;
+    // 数的是全部已知地址，不只是验证过的 —— 用户应该总能从所有地址里挑。
+    return m_Computers[computerIndex]->uniqueAddresses().count() > 1;
 }
 
 bool ComputerModel::setActiveAddressForComputer(int computerIndex, QString address, int port)

--- a/app/gui/computermodel.h
+++ b/app/gui/computermodel.h
@@ -52,6 +52,9 @@ public:
 
     Q_INVOKABLE bool setActiveAddressForComputer(int computerIndex, QString address, int port);
 
+    // Undo a setActiveAddressForComputer() pin and go back to automatic selection.
+    Q_INVOKABLE bool resetToAutomaticAddressForComputer(int computerIndex);
+
 signals:
     void pairingCompleted(QVariant error);
     void connectionTestCompleted(int result, QString blockedPorts);

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -451,7 +451,7 @@ ApplicationWindow {
                 onClicked: goBack()
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -529,7 +529,7 @@ ApplicationWindow {
                 onClicked: Qt.openUrlExternally("https://qm.qq.com/cgi-bin/qm/qr?k=wI7aTvDQdd900n1L_wjjJw3qNP0yOgUa&jump_from=webapi&authKey=CDBn7sGy7HpCKYTcFmoEdNuG/zmkrBWUC/W5A/oZZycKzXwuO/XFCA97IpJRktj3");
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -555,7 +555,7 @@ ApplicationWindow {
                 }
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -617,7 +617,7 @@ ApplicationWindow {
                 }
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -642,7 +642,7 @@ ApplicationWindow {
                 onClicked: Qt.openUrlExternally("https://github.com/moonlight-stream/moonlight-docs/wiki/Setup-Guide");
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -660,7 +660,7 @@ ApplicationWindow {
                 onClicked: navigateTo("qrc:/gui/GamepadMapper.qml", GamepadMapper)
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -683,7 +683,7 @@ ApplicationWindow {
                 }
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -705,7 +705,7 @@ ApplicationWindow {
                 }
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
             }
 
@@ -717,7 +717,7 @@ ApplicationWindow {
                 onClicked: navigateTo("qrc:/gui/SettingsView.qml", SettingsView)
 
                 Keys.onDownPressed: {
-                    stackView.currentItem.forceActiveFocus(Qt.TabFocus)
+                    stackView.currentItem.forceActiveFocus(Qt.TabFocusReason)
                 }
 
                 Shortcut {

--- a/app/gui/sdlgamepadkeynavigation.cpp
+++ b/app/gui/sdlgamepadkeynavigation.cpp
@@ -303,6 +303,11 @@ void SdlGamepadKeyNavigation::setUiNavMode(bool uiNavMode)
     m_UiNavMode = uiNavMode;
 }
 
+bool SdlGamepadKeyNavigation::getUiNavMode()
+{
+    return m_UiNavMode;
+}
+
 int SdlGamepadKeyNavigation::getConnectedGamepads()
 {
     Q_ASSERT(m_Enabled);

--- a/app/gui/sdlgamepadkeynavigation.cpp
+++ b/app/gui/sdlgamepadkeynavigation.cpp
@@ -12,6 +12,7 @@ SdlGamepadKeyNavigation::SdlGamepadKeyNavigation(StreamingPreferences* prefs)
     : m_Prefs(prefs),
       m_Enabled(false),
       m_UiNavMode(false),
+      m_UiNavSuspendCount(0),
       m_FirstPoll(false),
       m_HasFocus(false),
       m_LastAxisNavigationEventTime(0)
@@ -150,7 +151,7 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
 
             switch (event.cbutton.button) {
             case SDL_CONTROLLER_BUTTON_DPAD_UP:
-                if (m_UiNavMode) {
+                if (uiNavModeActive()) {
                     // Back-tab
                     sendKey(type, Qt::Key_Tab, Qt::ShiftModifier);
                 }
@@ -159,7 +160,7 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
                 }
                 break;
             case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-                if (m_UiNavMode) {
+                if (uiNavModeActive()) {
                     sendKey(type, Qt::Key_Tab);
                 }
                 else {
@@ -173,7 +174,7 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
                 sendKey(type, Qt::Key_Right);
                 break;
             case SDL_CONTROLLER_BUTTON_A:
-                if (m_UiNavMode) {
+                if (uiNavModeActive()) {
                     sendKey(type, Qt::Key_Space);
                 }
                 else {
@@ -194,13 +195,13 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
                 sendKey(type, Qt::Key_Hangup);
                 break;
             case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
-                if (m_UiNavMode) {
+                if (uiNavModeActive()) {
                     // Used by SettingsView to switch to the previous category
                     sendKey(type, Qt::Key_PageUp);
                 }
                 break;
             case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
-                if (m_UiNavMode) {
+                if (uiNavModeActive()) {
                     // Used by SettingsView to switch to the next category
                     sendKey(type, Qt::Key_PageDown);
                 }
@@ -237,7 +238,7 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
             // Do nothing
         }
         else if (leftY < -30000) {
-            if (m_UiNavMode) {
+            if (uiNavModeActive()) {
                 // Back-tab
                 sendKey(QEvent::Type::KeyPress, Qt::Key_Tab, Qt::ShiftModifier);
                 sendKey(QEvent::Type::KeyRelease, Qt::Key_Tab, Qt::ShiftModifier);
@@ -250,7 +251,7 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
             m_LastAxisNavigationEventTime = SDL_GetTicks();
         }
         else if (leftY > 30000) {
-            if (m_UiNavMode) {
+            if (uiNavModeActive()) {
                 sendKey(QEvent::Type::KeyPress, Qt::Key_Tab);
                 sendKey(QEvent::Type::KeyRelease, Qt::Key_Tab);
             }
@@ -303,9 +304,23 @@ void SdlGamepadKeyNavigation::setUiNavMode(bool uiNavMode)
     m_UiNavMode = uiNavMode;
 }
 
-bool SdlGamepadKeyNavigation::getUiNavMode()
+void SdlGamepadKeyNavigation::suspendUiNavMode()
 {
-    return m_UiNavMode;
+    m_UiNavSuspendCount++;
+}
+
+void SdlGamepadKeyNavigation::resumeUiNavMode()
+{
+    // 夹住下界：QML 侧的 Popup 在某些时序下会重复发 aboutToHide，
+    // 计数掉到负数之后就再也回不到挂起状态了。
+    if (m_UiNavSuspendCount > 0) {
+        m_UiNavSuspendCount--;
+    }
+}
+
+bool SdlGamepadKeyNavigation::uiNavModeActive() const
+{
+    return m_UiNavMode && m_UiNavSuspendCount == 0;
 }
 
 int SdlGamepadKeyNavigation::getConnectedGamepads()

--- a/app/gui/sdlgamepadkeynavigation.h
+++ b/app/gui/sdlgamepadkeynavigation.h
@@ -24,11 +24,19 @@ public:
 
     Q_INVOKABLE void setUiNavMode(bool settingsMode);
 
-    Q_INVOKABLE bool getUiNavMode();
+    // 临时挂起 UI 导航模式（下拉展开这类场景要拿回真正的方向键）。
+    // 用计数而不是存旧值：挂起和恢复的配对由调用方保证，但和页面切换时的
+    // setUiNavMode 谁先谁后不确定，存旧值会把页面刚设好的模式覆盖回去。
+    Q_INVOKABLE void suspendUiNavMode();
+
+    Q_INVOKABLE void resumeUiNavMode();
 
     Q_INVOKABLE int getConnectedGamepads();
 
 private:
+    // 实际生效的模式：页面要求开启，且当前没有被挂起
+    bool uiNavModeActive() const;
+
     void sendKey(QEvent::Type type, Qt::Key key, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 
     void updateTimerState();
@@ -42,6 +50,7 @@ private:
     QList<SDL_GameController*> m_Gamepads;
     bool m_Enabled;
     bool m_UiNavMode;
+    int m_UiNavSuspendCount;
     bool m_FirstPoll;
     bool m_HasFocus;
     Uint32 m_LastAxisNavigationEventTime;

--- a/app/gui/sdlgamepadkeynavigation.h
+++ b/app/gui/sdlgamepadkeynavigation.h
@@ -24,6 +24,8 @@ public:
 
     Q_INVOKABLE void setUiNavMode(bool settingsMode);
 
+    Q_INVOKABLE bool getUiNavMode();
+
     Q_INVOKABLE int getConnectedGamepads();
 
 private:

--- a/app/gui/settings/BasicSettingsPage.qml
+++ b/app/gui/settings/BasicSettingsPage.qml
@@ -19,9 +19,6 @@ Column {
     property alias bitrateSlider: bitrateSlider
     property alias videoEnhancementCheck: videoEnhancementSwitch
 
-    // 手柄进入设置页时的初始焦点
-    property alias firstControl: resolutionComboBox
-
     width: parent ? parent.width : 0
     spacing: Theme.spaceLg
 

--- a/app/gui/settings/CategoryRail.qml
+++ b/app/gui/settings/CategoryRail.qml
@@ -4,6 +4,10 @@ import "."
 import "../theme"
 
 // 左侧分类导航。窄窗口时 compact 置真，变成横向 tab 条。
+//
+// 焦点模型：每一项都在 Tab 焦点链里（设置页的手柄上下键发的就是 Tab / Shift+Tab），
+// 所以「上下走分类」是白送的。移动焦点本身不切分类 —— 切分类要按 A（Space）或
+// 朝内容区的方向键，这样浏览分类不会把右边的内容翻来翻去。
 Item {
     id: rail
 
@@ -11,7 +15,13 @@ Item {
     property string currentCategory: ""
     property bool compact: false
 
+    // 焦点是否落在分类栏里。ListView 本身是焦点域，所以它的 activeFocus
+    // 在任意一个代理持焦时都为真。
+    readonly property bool railFocused: list.activeFocus
+
     signal categoryPicked(string category)
+    // 用户在分类栏里确认了选择，希望焦点进到右边的内容区
+    signal contentRequested()
 
     function step(delta) {
         var index = indexOf(currentCategory)
@@ -37,6 +47,37 @@ Item {
         return -1
     }
 
+    // 把焦点放到当前分类那一项上。进入设置页、以及从内容区按 B 退回来时用。
+    function focusCurrent() {
+        var index = indexOf(currentCategory)
+        if (index < 0) {
+            index = 0
+        }
+        list.currentIndex = index
+        list.positionViewAtIndex(index, ListView.Contain)
+
+        var item = list.itemAtIndex(index)
+        if (item) {
+            item.forceActiveFocus(Qt.TabFocusReason)
+        }
+        else {
+            // 刚进页面时代理可能还没排版出来，下一帧再试一次
+            Qt.callLater(focusIndexLater, index)
+        }
+    }
+
+    function focusIndexLater(index) {
+        var item = list.itemAtIndex(index)
+        if (item) {
+            item.forceActiveFocus(Qt.TabFocusReason)
+        }
+    }
+
+    // 分类栏在 Tab 链里的最后一项。SettingsView 靠它找到内容区的第一个控件。
+    function lastItem() {
+        return list.itemAtIndex(list.count - 1)
+    }
+
     implicitHeight: compact ? 46 : 0
 
     ListView {
@@ -48,6 +89,9 @@ Item {
         boundsBehavior: Flickable.StopAtBounds
         model: rail.categories
 
+        // 方向键由代理自己处理（要区分横竖两种排布），ListView 别再抢一遍
+        keyNavigationEnabled: false
+
         delegate: ItemDelegate {
             id: item
 
@@ -56,14 +100,77 @@ Item {
             width: rail.compact ? Math.max(96, label.implicitWidth + Theme.spaceXl + Theme.spaceLg) : list.width
             height: rail.compact ? list.height : 44
 
+            // 进焦点链。设置页的手柄上下键 = Tab / Shift+Tab，所以这一行就等于
+            // 「上下能走到分类栏」。ItemDelegate 默认是 NoFocus，改成 StrongFocus
+            // 之后 Tab 和鼠标点击都会把焦点带过来（Control 会顺带打开
+            // activeFocusOnTab）。
+            focusPolicy: Qt.StrongFocus
+
             onClicked: rail.categoryPicked(modelData.key)
+
+            // 焦点落到哪一项，ListView 的 currentIndex 就跟到哪 —— 只是同步高亮，
+            // 不切分类。
+            onActiveFocusChanged: {
+                if (activeFocus) {
+                    list.currentIndex = index
+                }
+            }
+
+            // 确认这一项并把焦点交给内容区
+            function activate() {
+                rail.categoryPicked(modelData.key)
+                rail.contentRequested()
+            }
+
+            function moveFocus(forward) {
+                nextItemInFocusChain(forward).forceActiveFocus(Qt.TabFocusReason)
+            }
+
+            Keys.onReturnPressed: activate()
+            Keys.onEnterPressed: activate()
+            // 手柄 A 在 UI 导航模式下发的是 Space
+            Keys.onSpacePressed: activate()
+
+            // 方向键按实际排布走：竖着的 rail 上下换项、右进内容；
+            // 横着的 tab 条左右换项、下进内容。
+            Keys.onUpPressed: {
+                if (rail.compact) {
+                    return
+                }
+                moveFocus(false)
+            }
+            Keys.onDownPressed: {
+                if (rail.compact) {
+                    activate()
+                    return
+                }
+                moveFocus(true)
+            }
+            Keys.onLeftPressed: {
+                if (rail.compact) {
+                    moveFocus(false)
+                }
+            }
+            Keys.onRightPressed: {
+                if (rail.compact) {
+                    moveFocus(true)
+                    return
+                }
+                activate()
+            }
 
             // 方角 + 当前项左侧一条 accent 粗条（横向 tab 条时改成底部一条）。
             // 原来靠一圈描边表示当前项，方角化之后描边和卡片边框太像，粗条读起来更明确。
+            //
+            // 「当前分类」和「焦点在哪」是两件事，必须分开表达：粗条 + 软填充表示
+            // 当前分类，一圈亮描边表示焦点。只用键盘/手柄来的焦点才画描边
+            // （visualFocus），鼠标点一下不该冒出个框。
             background: Rectangle {
                 radius: 0
                 color: item.current ? Theme.accentSoft
-                                    : (item.hovered ? Theme.surface2 : "transparent")
+                                    : (item.hovered || item.visualFocus ? Theme.surface2 : "transparent")
+                border.width: item.visualFocus ? 1 : 0
+                border.color: Theme.text
 
                 Rectangle {
                     anchors {

--- a/app/gui/settings/CategoryRail.qml
+++ b/app/gui/settings/CategoryRail.qml
@@ -56,26 +56,19 @@ Item {
         list.currentIndex = index
         list.positionViewAtIndex(index, ListView.Contain)
 
+        if (!focusIndex(index)) {
+            // 刚进页面时代理还没排版出来，下一帧再试一次
+            Qt.callLater(focusIndex, index)
+        }
+    }
+
+    // 聚焦第 index 项，返回是否成功（代理可能还没实例化）
+    function focusIndex(index) {
         var item = list.itemAtIndex(index)
         if (item) {
             item.forceActiveFocus(Qt.TabFocusReason)
         }
-        else {
-            // 刚进页面时代理可能还没排版出来，下一帧再试一次
-            Qt.callLater(focusIndexLater, index)
-        }
-    }
-
-    function focusIndexLater(index) {
-        var item = list.itemAtIndex(index)
-        if (item) {
-            item.forceActiveFocus(Qt.TabFocusReason)
-        }
-    }
-
-    // 分类栏在 Tab 链里的最后一项。SettingsView 靠它找到内容区的第一个控件。
-    function lastItem() {
-        return list.itemAtIndex(list.count - 1)
+        return !!item
     }
 
     implicitHeight: compact ? 46 : 0
@@ -133,31 +126,10 @@ Item {
 
             // 方向键按实际排布走：竖着的 rail 上下换项、右进内容；
             // 横着的 tab 条左右换项、下进内容。
-            Keys.onUpPressed: {
-                if (rail.compact) {
-                    return
-                }
-                moveFocus(false)
-            }
-            Keys.onDownPressed: {
-                if (rail.compact) {
-                    activate()
-                    return
-                }
-                moveFocus(true)
-            }
-            Keys.onLeftPressed: {
-                if (rail.compact) {
-                    moveFocus(false)
-                }
-            }
-            Keys.onRightPressed: {
-                if (rail.compact) {
-                    moveFocus(true)
-                    return
-                }
-                activate()
-            }
+            Keys.onUpPressed:    if (!rail.compact) moveFocus(false)
+            Keys.onLeftPressed:  if (rail.compact)  moveFocus(false)
+            Keys.onDownPressed:  rail.compact ? activate() : moveFocus(true)
+            Keys.onRightPressed: rail.compact ? moveFocus(true) : activate()
 
             // 方角 + 当前项左侧一条 accent 粗条（横向 tab 条时改成底部一条）。
             // 原来靠一圈描边表示当前项，方角化之后描边和卡片边框太像，粗条读起来更明确。

--- a/app/qml.qrc
+++ b/app/qml.qrc
@@ -9,6 +9,7 @@
         <file>gui/GamepadMapper.qml</file>
         <file>gui/QuitSegue.qml</file>
         <file>gui/NavigableToolButton.qml</file>
+        <file>gui/SelectAddressDialog.qml</file>
         <file>gui/WindowControlButton.qml</file>
         <file>gui/NavigableItemDelegate.qml</file>
         <file>gui/NavigableMenuItem.qml</file>


### PR DESCRIPTION
修 #144，以及顺着它排查出来的一批同类手柄操作问题。

## #144 是什么问题

用手柄进设置页，焦点直接落到第一个 ComboBox（分辨率）上。这一页跑的是 UI 导航模式，D-pad 上下被翻译成 Tab / Shift+Tab —— 但焦点已经在 ComboBox 里，上下就被它拿去换值了。结果是「进设置页随便按两下方向键，分辨率就被改了」，而且用户不知道是自己改的。

修法是给这一页的焦点分级：进页面先落在左侧分类栏（`CategoryRail`）上，那里上下是切分类；要进右侧表单得显式往右。ComboBox 本身也改成明确的编辑操作 —— 上下不再直接换值，得先按 A 展开，展开后上下才是选项间移动。

## 一并修的同类问题

排查时按「手柄能不能到、到了能不能出来」过了一遍主要页面，发现几处同一类的死路：

- **AppView 的显示器 / VDD 选择按钮**以前是裸 `Rectangle` + `MouseArea`，完全不在焦点链里 —— 而那个弹窗是切换 VDD 的唯一入口，手柄用户根本进不去。换成 `AbstractButton`。
- **AppView 的 IP 选择弹窗**同样够不到。
- **PcView 的地址选择框**是新发现的死路，和 #144 同一个成因：弹窗内容区只有一个 ComboBox 可聚焦，而 PcView 不跑 UI 导航模式（手柄发的是真方向键），上下被 ComboBox 吃掉，底下的确定 / 取消永远到不了。
- **`uiNavMode` 泄漏**：这个标志位是全局的，弹窗打开时挂起、关闭时恢复的配对在某些路径上漏了，导致离开设置页后手柄语义还停在 UI 导航模式。改成引用计数的挂起 / 恢复。
- **显示器 chip 的纵向导航**：chips 住在横向 `Flow` 里，焦点链的下一项是同一行的下一颗，不是「下面那个控件」，所以纵向必须显式指定目标。

## 顺带的清理

- 两个裸 `Popup`（显示器设置、IP 选择）收编进 `NavigableDialog`，拿到统一的方角 Panel、ink 遮罩、关闭时归还焦点。
- AppView 和 PcView 各有一份几乎一样的 IP 选择框，合并成 `SelectAddressDialog.qml`。副作用是 PcView 现在也会显示「该地址尚未经轮询验证」的告警。
- 18 处 `forceActiveFocus(Qt.TabFocus)` 改成 `Qt.TabFocusReason`。前者是 `FocusPolicy` 的值，后者是 `FocusReason` 的值 —— 两个都等于 1，所以一直是靠数值巧合在工作。

## 地址固定的语义修复

评审过程中发现「自动」选项是有名无实的：`useAutoAddress` 只是 QML 里的一个本地布尔，选回「自动」时后端那份固定值没人清。

顺着后端看，所谓「固定」原本没有独立状态，全部实现就是往 `activeAddress` 里写 —— 而这个字段同时是 NvHTTP 和串流真正使用的地址，还会被每次轮询覆写，所以分不出「自动恰好选中了这个地址」和「用户固定了这个地址」。

改成在 `NvComputer` 上加独立的 `pinnedAddress`：

- `uniqueAddresses()` 把它排在 `activeAddress` 前面。轮询逻辑一行没动（仍是取第一个能连上的），所以固定的地址短暂掉线会自动回退到别的地址，恢复可达后下一次轮询又会固定回来。
- 不序列化。`activeAddress` 本来就是重启后靠轮询重建的临时状态，固定值跟着它走。
- `NvComputer::update()` 刻意不复制这个字段：轮询构造的临时对象里它是空的，复制进来会把用户的选择冲掉。

两个 model 的 `setActiveAddress*` 统一走 `NvComputer::pinAddress()`，各配一个 `resetToAutomaticAddress*()`。另外 PcView 的地址列表以前根本没有「自动」项 —— 从那个入口固定过地址之后，同一个入口没有解除的手段，只能绕去应用列表。现在两边同一份语义。

## 关于 `uiNavMode`（更正我早先的说法）

我在最初的描述里把 `uiNavMode` 本身称为根因，并建议换成真正的二维 `KeyNavigation`。**这个判断是错的，予以撤回。**

`uiNavMode` 存在的目的正是让手柄拿到和键盘不同的方向键语义，并且施加在唯一知道输入设备是什么的那一层（SDL）。如果到处都发真方向键，手柄的上下又会掉进 ComboBox 改值 —— 也就是把 #144 重新引入一遍。真正的缺陷是这个标志位是全局的、会泄漏，已由引用计数的挂起修掉。

## 验证情况

- 四平台 CI 全绿（linux / macOS / windows / steamlink），每个提交本地都过了 `make -j8`（0 error）。`CONFIG += qtquickcompiler`，所以编译成功意味着全部 QML 过了 qmlcachegen 的校验。
- qmllint 无新增告警。
- **没有真机验证**。所有改动都是靠读代码 + 编译期校验确认的，没有拿手柄实际走过 UI。希望重点试两处：设置页的焦点分级（#144 报的场景），以及 `pinnedAddress` 的掉线回退 / 恢复重固定（需要一台有多个可达地址的主机）。

## 改动规模

21 个文件，+658 / −361。
