### PR TITLE
chore(macos): 跟进上游的 Info.plist 两处修正

### DIFF
--- a/app/Info.plist
+++ b/app/Info.plist
@@ -44,6 +44,10 @@
 	<string>Moonlight uses the local network to connect to your gaming PC for streaming.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Moonlight needs access to the microphone to support microphone redirection to the host.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_nvstream._tcp</string>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>VERSION</string>
 	<key>CFBundleShortVersionString</key>

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>11.0.0</string>
+	<string>13.0.0</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>


### PR DESCRIPTION
摘上游 moonlight-stream/moonlight-qt 的两个 Info.plist 提交（`git cherry-pick -x`，作者保留 Cameron Gutman）。

## `NSBonjourServices`（上游 131cb270）

macOS 15+ 的本地网络隐私管控下，除了 `NSLocalNetworkUsageDescription`（我们已有），浏览 mDNS 还必须在 `NSBonjourServices` 里声明服务类型。缺这一项的后果是主机自动发现静默失败，用户只能手动加 IP。

已核对我们 fork 只有一处 mDNS 浏览，服务类型与声明一致：

    app/backend/computermanager.cpp:374
    m_MdnsBrowser = new QMdnsEngine::Browser(m_MdnsServer.data(), "_nvstream._tcp.local.");

（文件映射和剪贴板助手都不走 Bonjour，不需要额外条目。）

冲突解决：这一段我们加过 `NSMicrophoneUsageDescription`，两个键都保留。

## `LSMinimumSystemVersion` 11.0.0 → 13.0.0（上游 5ac25421）

原来那个 11.0.0 是不成立的：`LSMinimumSystemVersion` 完全来自 plist，而实际的 `-mmacosx-version-min` 来自所用 Qt 的 `qconfig.pri`。我们 CI 用 aqt 装的是 Qt 6.11.1，而 [Qt 官方支持矩阵](https://doc.qt.io/qt-6/supported-platforms.html) 写明 Qt 6.11 的目标平台是 **macOS 13 或更高**。所以现状是：plist 允许 macOS 11/12 的用户装上一个跑不起来的包。改成 13.0.0 与实际构建一致。

（本机 Homebrew 的 Qt 报 14.0，那是它按宿主机编译的结果，不代表发布包的下限，所以这里取 13.0.0 而不是 14.0.0。）

## 验证

`plutil -lint app/Info.plist` → OK。纯 plist 改动，不涉及代码。

## 上游另外两个提交没有跟进

- `b5d7f3b9` 依赖大升级（prebuilts v10→v11、FFmpeg 8.1.1→9.0、SDL release-3.4.14、libplacebo）：必须整体跟，`app.pro` 里的 `-lavcodec.62/-lavutil.60/-lswscale.9` 与 prebuilts tag 是配套的。avcodec 62→63 是 major soname 跳，我们 fork 在 `streaming/video/ffmpeg-renderers/` 下有不少自己的代码，需要四平台重新构建加实机验证，单独一个 PR 做。v10 的 release 不会消失，现状不会被上游推进弄坏。
- `fcba7df8` README 构建要求：不适用，我们的 README 是重写过的中文版，对应段落已经写的是「建议使用与 CI 接近的 Qt 6.11.x」。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * The app now requires macOS 13.0 or later.

* **Networking**
  * Added support for discovering compatible services on the local network through Bonjour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->