### PR TITLE
chore(deps): 跟进上游依赖升级 —— prebuilts v11 / FFmpeg 9.0 / SDL 3.4.14

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: libsdl-org/SDL
-          ref: c9ad296376ed6091e0fdec9844461fdf09af7845
+          ref: release-3.4.14
           path: deps/SDL
 
       - name: Build SDL3
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: haasn/libplacebo
-          ref: 2d0979fb54e025e904c7372666fffbf5dae40f66
+          ref: 4d82c6898551068d4ae6a6b5538efcddc2c7cf64
           path: deps/libplacebo
           submodules: 'recursive'
 
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: FFmpeg/FFmpeg
-          ref: n8.1.1
+          ref: n9.0
           path: deps/FFmpeg
 
       - name: Build FFmpeg

--- a/app/app.pro
+++ b/app/app.pro
@@ -181,7 +181,7 @@ macx {
     DEFINES += HAVE_MACOS_NATIVE_TOUCHPAD
 
     !disable-prebuilts {
-        LIBS += -lssl.3 -lcrypto.3 -lavcodec.62 -lavutil.60 -lswscale.9 -lopus.0 -lSDL2 -lSDL2_ttf -lplacebo
+        LIBS += -lssl.3 -lcrypto.3 -lavcodec.63 -lavutil.61 -lswscale.10 -lopus.0 -lSDL2 -lSDL2_ttf -lplacebo
         CONFIG += discord-rpc libplacebo
     }
 

--- a/setup-deps.ps1
+++ b/setup-deps.ps1
@@ -4,7 +4,7 @@ $Organization = "moonlight-stream"
 $PrebuiltRepo = "moonlight-qt-deps"
 $TargetDir = Join-Path $PSScriptRoot "libs\windows"
 $Assets = @("windows-x64.zip", "windows-ARM64.zip")
-$Tag = "v10"
+$Tag = "v11"
 
 if (Test-Path $TargetDir) {
     Write-Host "Cleaning target directory..." -ForegroundColor Cyan

--- a/setup-deps.py
+++ b/setup-deps.py
@@ -7,7 +7,7 @@ import shutil
 
 ORGANIZATION = "moonlight-stream"
 PREBUILT_REPO = "moonlight-qt-deps"
-TAG = "v10"
+TAG = "v11"
 
 def get_platform_config():
     system = platform.system()


### PR DESCRIPTION
摘上游 `b5d7f3b9`（`git cherry-pick -x`，作者保留 Cameron Gutman）。这是上游那批更新里唯一有实质风险的一个，所以单独一个 PR 并做了本机验证。

- SDL → release-3.4.14（原来是 pin 的 commit `c9ad2963`）
- FFmpeg → n9.0（原 n8.1.1，avcodec 62→**63**、avutil 60→**61**、swscale 9→**10**）
- libplacebo → `4d82c689`
- 预编译依赖 tag v10 → **v11**（`setup-deps.py` / `setup-deps.ps1`）

必须整体跟：`app.pro` 里的 `-lavcodec.62/-lavutil.60/-lswscale.9` 和 prebuilts 的 tag 是配套的，只改一边直接链接失败。

## 本机验证（macOS arm64）

avcodec 62→63 是 major soname 跳，而我们 fork 在 `streaming/video/ffmpeg-renderers/` 下有不少自己的代码，所以没有只靠 CI：

1. `python3 setup-deps.py` 拉到 v11，确认 `libs/mac/lib` 里是 `libavcodec.63 / libavutil.61 / libswscale.10`。
2. 重跑 qmake + `make -j8`：**0 error**。确认 FFmpeg 相关的 12 个编译单元都真的重编了（`ffmpeg.o` `genhwaccel.o` `swframemapper.o` `pacer.o` `plvk*.o` `vt_base.o` `vt_metal.o` `vt_avsamplelayer.o` `sdlvid.o` `videoenhancement.o`），不是只重链接。
3. `otool -L` 确认产物链的是新版本：`libavcodec.63.dylib` / `libavutil.61.dylib` / `libswscale.10.dylib`。
4. 启动烟测通过，且**解码路径真的走通了** —— 启动时的解码器探测拿 HEVC Main 10 走 VideoToolbox 硬解并解出帧：

       FFmpeg: [hevc] Main 10 profile bitstream
       FFmpeg: [hevc] Format videotoolbox_vld chosen by get_format().
       FFmpeg: [hevc] Decoded frame with POC 0/3.
       SDL Info: FFmpeg-based video decoder chosen
       SDL Info: SDL3 version: 3.4.14
       SDL Info: Using Metal renderer with hardware decoding

## 查过但不需要动的地方

- **打包脚本没有硬编码库版本号**。`app.pro:654` 用的是 `$$files(../libs/mac/lib/*.dylib, true)` 通配，`generate-dmg.sh` 走 macdeployqt，都不会因为 soname 变化漏带库。这是「构建过但产物是坏的」的主要风险来源，确认不存在。
- **`plvk.cpp:591` 的两个 deprecated 警告不用管**。`lock_queue`/`unlock_queue` 在 libavutil 里被标了弃用，但那段代码本来就有守卫 `LIBAVUTIL_VERSION_MAJOR < 62`，现在是 61，仍走这条路径。等 avutil 到 62 才需要改，属于上游代码。
- **`setup-deps.py` 请求的资产名 `macos-universal.zip` 与 release 上的 `macOS-universal.zip` 大小写不一致**，看着像 bug，但实测 GitHub 对资产名不区分大小写（两个 URL 都返回 200），v10 也一直是这样。不动。

## 待 CI 确认

Windows / Linux / SteamLink 三个平台只有 CI 能验。Windows 走 `setup-deps.ps1` 的 v11 预编译包，AppImage 是从源码编 FFmpeg n9.0 + SDL release-3.4.14，这两条是这个 PR 最需要看的。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled multimedia libraries to newer compatible versions.
  * Updated macOS library linkage for the latest FFmpeg versions.
  * Updated Windows dependency downloads to release `v11`.
  * Refreshed AppImage build dependencies, including SDL3, libplacebo, and FFmpeg.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->