### PR TITLE
feat(video): 跟进上游色彩范围系列 —— 默认改用 full range

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/drm.cpp
+++ b/app/streaming/video/ffmpeg-renderers/drm.cpp
@@ -2068,6 +2068,22 @@ int DrmRenderer::getDecoderColorspace()
     return COLORSPACE_REC_601;
 }
 
+int DrmRenderer::getDecoderColorRange()
+{
+    if (auto prop = m_VideoPlane.property("COLOR_RANGE")) {
+        // Prefer full range if the video plane supports it
+        if (prop->containsValue("YCbCr full range")) {
+            return COLOR_RANGE_FULL;
+        }
+        else if (prop->containsValue("YCbCr limited range")) {
+            return COLOR_RANGE_LIMITED;
+        }
+    }
+
+    // Default to limited if we couldn't find a valid COLOR_RANGE property
+    return COLOR_RANGE_LIMITED;
+}
+
 const char* DrmRenderer::getDrmColorEncodingValue(AVFrame* frame)
 {
     switch (getFrameColorspace(frame)) {

--- a/app/streaming/video/ffmpeg-renderers/drm.cpp
+++ b/app/streaming/video/ffmpeg-renderers/drm.cpp
@@ -164,9 +164,6 @@ DrmRenderer::DrmRenderer(AVHWDeviceType hwDeviceType, IFFmpegRenderer *backendRe
       m_OutputRect{},
       m_SwFrameMapper(this),
       m_CurrentSwFrameIdx(0)
-#ifdef HAVE_EGL
-    , m_EglImageFactory(this)
-#endif
 {
     SDL_zero(m_SwFrame);
 }
@@ -2149,9 +2146,10 @@ AVPixelFormat DrmRenderer::getEGLImagePixelFormat() {
     return AV_PIX_FMT_DRM_PRIME;
 }
 
-bool DrmRenderer::initializeEGL(EGLDisplay display,
+bool DrmRenderer::initializeEGL(IFFmpegRenderer* eglRenderer,
+                                EGLDisplay display,
                                 const EGLExtensions &ext) {
-    return m_EglImageFactory.initializeEGL(display, ext);
+    return m_EglImageFactory.initializeEGL(eglRenderer, display, ext);
 }
 
 ssize_t DrmRenderer::exportEGLImages(AVFrame *frame, EGLDisplay dpy,

--- a/app/streaming/video/ffmpeg-renderers/drm.h
+++ b/app/streaming/video/ffmpeg-renderers/drm.h
@@ -776,7 +776,7 @@ public:
 #ifdef HAVE_EGL
     virtual bool canExportEGL() override;
     virtual AVPixelFormat getEGLImagePixelFormat() override;
-    virtual bool initializeEGL(EGLDisplay dpy, const EGLExtensions &ext) override;
+    virtual bool initializeEGL(IFFmpegRenderer* eglRenderer, EGLDisplay dpy, const EGLExtensions &ext) override;
     virtual ssize_t exportEGLImages(AVFrame *frame, EGLDisplay dpy, EGLImage images[EGL_MAX_PLANES]) override;
 #endif
 

--- a/app/streaming/video/ffmpeg-renderers/drm.h
+++ b/app/streaming/video/ffmpeg-renderers/drm.h
@@ -770,6 +770,7 @@ public:
     virtual bool testRenderFrame(AVFrame* frame) override;
     virtual bool isDirectRenderingSupported() override;
     virtual int getDecoderColorspace() override;
+    virtual int getDecoderColorRange() override;
     virtual void setHdrMode(bool enabled) override;
     virtual void notifyOverlayUpdated(Overlay::OverlayType type) override;
 #ifdef HAVE_EGL

--- a/app/streaming/video/ffmpeg-renderers/dxva2.cpp
+++ b/app/streaming/video/ffmpeg-renderers/dxva2.cpp
@@ -784,6 +784,14 @@ int DXVA2Renderer::getDecoderColorspace()
     }
 }
 
+int DXVA2Renderer::getDecoderColorRange()
+{
+    // StretchRect() assumes limited range on Intel and Qualcomm GPUs.
+    // VideoProcessBlt() should handle either fine, but let's not take
+    // chances on potentially broken DXVA2 GPU drivers for little gain.
+    return COLOR_RANGE_LIMITED;
+}
+
 int DXVA2Renderer::getDecoderCapabilities()
 {
     return CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC |

--- a/app/streaming/video/ffmpeg-renderers/dxva2.h
+++ b/app/streaming/video/ffmpeg-renderers/dxva2.h
@@ -18,6 +18,7 @@ public:
     virtual void renderFrame(AVFrame* frame) override;
     virtual void notifyOverlayUpdated(Overlay::OverlayType type) override;
     virtual int getDecoderColorspace() override;
+    virtual int getDecoderColorRange() override;
     virtual int getDecoderCapabilities() override;
 
 private:

--- a/app/streaming/video/ffmpeg-renderers/eglimagefactory.cpp
+++ b/app/streaming/video/ffmpeg-renderers/eglimagefactory.cpp
@@ -24,8 +24,8 @@
 #define DRM_FORMAT_GR88 fourcc_code('G', 'R', '8', '8')
 #endif
 
-EglImageFactory::EglImageFactory(IFFmpegRenderer* renderer) :
-    m_Renderer(renderer),
+EglImageFactory::EglImageFactory() :
+    m_Renderer(nullptr),
     m_EGLExtDmaBuf(false),
     m_eglCreateImage(nullptr),
     m_eglDestroyImage(nullptr),
@@ -36,9 +36,16 @@ EglImageFactory::EglImageFactory(IFFmpegRenderer* renderer) :
 {
 }
 
-bool EglImageFactory::initializeEGL(EGLDisplay,
+bool EglImageFactory::initializeEGL(IFFmpegRenderer* eglRenderer,
+                                    EGLDisplay,
                                     const EGLExtensions &ext)
 {
+    // The EGL renderer is guaranteed to be alive for any calls to this factory,
+    // since it's the one that calls exportEGLImages() on the backend renderer.
+    SDL_assert(eglRenderer->getRendererType() == IFFmpegRenderer::RendererType::EGL);
+    SDL_assert(!m_Renderer);
+    m_Renderer = eglRenderer;
+
     if (!ext.isSupported("EGL_EXT_image_dma_buf_import")) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "DRM-EGL: DMABUF unsupported");
@@ -75,6 +82,8 @@ void EglImageFactory::resetCache()
 
 ssize_t EglImageFactory::exportDRMImages(AVFrame* frame, EGLDisplay dpy, EGLImage images[EGL_MAX_PLANES])
 {
+    SDL_assert(m_Renderer);
+
     SDL_assert(frame->format == AV_PIX_FMT_DRM_PRIME);
     AVDRMFrameDescriptor* drmFrame = (AVDRMFrameDescriptor*)frame->data[0];
 
@@ -264,6 +273,8 @@ ssize_t EglImageFactory::exportDRMImages(AVFrame* frame, EGLDisplay dpy, EGLImag
 
 ssize_t EglImageFactory::exportVAImages(AVFrame *frame, uint32_t exportFlags, EGLDisplay dpy, EGLImage images[EGL_MAX_PLANES])
 {
+    SDL_assert(m_Renderer);
+
     SDL_assert(frame->format == AV_PIX_FMT_VAAPI);
     auto hwFrameCtx = (AVHWFramesContext*)frame->hw_frames_ctx->data;
     AVVAAPIDeviceContext* vaDeviceContext = (AVVAAPIDeviceContext*)hwFrameCtx->device_ctx->hwctx;

--- a/app/streaming/video/ffmpeg-renderers/eglimagefactory.h
+++ b/app/streaming/video/ffmpeg-renderers/eglimagefactory.h
@@ -41,8 +41,8 @@ class EglImageFactory
     };
 
 public:
-    EglImageFactory(IFFmpegRenderer* renderer);
-    bool initializeEGL(EGLDisplay, const EGLExtensions &ext);
+    EglImageFactory();
+    bool initializeEGL(IFFmpegRenderer* eglRenderer, EGLDisplay, const EGLExtensions &ext);
     void resetCache();
 
 #ifdef HAVE_DRM

--- a/app/streaming/video/ffmpeg-renderers/eglvid.cpp
+++ b/app/streaming/video/ffmpeg-renderers/eglvid.cpp
@@ -523,7 +523,7 @@ bool EGLRenderer::initialize(PDECODER_PARAMETERS params)
         return false;
     }
 
-    if (!m_Backend->initializeEGL(m_EGLDisplay, eglExtensions))
+    if (!m_Backend->initializeEGL(this, m_EGLDisplay, eglExtensions))
         return false;
 
     if (!(m_glEGLImageTargetTexture2DOES = (typeof(m_glEGLImageTargetTexture2DOES))eglGetProcAddress("glEGLImageTargetTexture2DOES"))) {

--- a/app/streaming/video/ffmpeg-renderers/mmal.cpp
+++ b/app/streaming/video/ffmpeg-renderers/mmal.cpp
@@ -242,6 +242,12 @@ int MmalRenderer::getDecoderColorspace()
     return COLORSPACE_REC_709;
 }
 
+int MmalRenderer::getDecoderColorRange()
+{
+    // MMAL_COLOR_SPACE_ITUR_BT709 assumes limited range content
+    return COLOR_RANGE_LIMITED;
+}
+
 void MmalRenderer::InputPortCallback(MMAL_PORT_T*, MMAL_BUFFER_HEADER_T* buffer)
 {
     mmal_buffer_header_release(buffer);

--- a/app/streaming/video/ffmpeg-renderers/mmal.h
+++ b/app/streaming/video/ffmpeg-renderers/mmal.h
@@ -18,6 +18,7 @@ public:
     virtual enum AVPixelFormat getPreferredPixelFormat(int videoFormat) override;
     virtual int getRendererAttributes() override;
     virtual int getDecoderColorspace() override;
+    virtual int getDecoderColorRange() override;
 
 private:
     static void InputPortCallback(MMAL_PORT_T* port, MMAL_BUFFER_HEADER_T* buffer);

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -508,7 +508,8 @@ public:
         return AV_PIX_FMT_NONE;
     }
 
-    virtual bool initializeEGL(EGLDisplay,
+    virtual bool initializeEGL(IFFmpegRenderer*,
+                               EGLDisplay,
                                const EGLExtensions &) {
         return false;
     }

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -247,10 +247,16 @@ public:
     }
 
     virtual bool isFrameFullRange(const AVFrame* frame) {
-        // This handles the case where the color range is unknown,
-        // so that we use Limited color range which is the default
-        // behavior for Moonlight.
-        return frame->color_range == AVCOL_RANGE_JPEG;
+        switch (frame->color_range) {
+        case AVCOL_RANGE_JPEG:
+            return true;
+        case AVCOL_RANGE_MPEG:
+            return false;
+        default:
+            // If the color range is not populated, assume the encoder
+            // is sending the color range that we requested.
+            return getDecoderColorRange() == COLOR_RANGE_FULL;
+        }
     }
 
     virtual bool isRenderThreadSupported() {

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -224,8 +224,8 @@ public:
     }
 
     virtual int getDecoderColorRange() {
-        // Limited is the default
-        return COLOR_RANGE_LIMITED;
+        // Full is the default
+        return COLOR_RANGE_FULL;
     }
 
     virtual int getFrameColorspace(const AVFrame* frame) {

--- a/app/streaming/video/ffmpeg-renderers/sdlvid.cpp
+++ b/app/streaming/video/ffmpeg-renderers/sdlvid.cpp
@@ -352,9 +352,11 @@ ReadbackRetry:
             av_dict_set_int(&options, "srcw", frame->width, 0);
             av_dict_set_int(&options, "srch", frame->height, 0);
             av_dict_set_int(&options, "src_format", frame->format, 0);
+            av_dict_set_int(&options, "src_range", isFrameFullRange(frame) ? 1 : 0, 0);
             av_dict_set_int(&options, "dstw", m_RgbFrame->width, 0);
             av_dict_set_int(&options, "dsth", m_RgbFrame->height, 0);
             av_dict_set_int(&options, "dst_format", m_RgbFrame->format, 0);
+            av_dict_set_int(&options, "dst_range", 1, 0);
             av_dict_set_int(&options, "threads", std::min(SDL_GetCPUCount(), 4), 0); // Up to 4 threads
 
             err = av_opt_set_dict(m_SwsContext, &options);
@@ -637,4 +639,22 @@ bool SdlRenderer::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO info)
 {
     // We can transparently handle size and display changes
     return !(info->stateChangeFlags & ~(WINDOW_STATE_CHANGE_SIZE | WINDOW_STATE_CHANGE_DISPLAY));
+}
+
+int SdlRenderer::getDecoderColorspace()
+{
+    // SDL2 only supports both full and limited range for BT.601. Additionally, libswscale
+    // assumes content is in the BT.601 color space when performing YUV to RGB conversion.
+    return COLORSPACE_REC_601;
+}
+
+int SdlRenderer::getDecoderColorRange()
+{
+    // Prefer full range only on FFmpeg 5.0 or later, since we don't implement
+    // color range handling in the legacy FFmpeg 4.x codepath.
+#if LIBSWSCALE_VERSION_INT >= AV_VERSION_INT(6, 1, 100)
+    return COLOR_RANGE_FULL;
+#else
+    return COLOR_RANGE_LIMITED;
+#endif
 }

--- a/app/streaming/video/ffmpeg-renderers/sdlvid.h
+++ b/app/streaming/video/ffmpeg-renderers/sdlvid.h
@@ -23,6 +23,8 @@ public:
     virtual bool isPixelFormatSupported(int videoFormat, enum AVPixelFormat pixelFormat) override;
     virtual bool testRenderFrame(AVFrame* frame) override;
     virtual bool notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO) override;
+    virtual int getDecoderColorspace() override;
+    virtual int getDecoderColorRange() override;
 
 private:
     void renderOverlay(Overlay::OverlayType type);

--- a/app/streaming/video/ffmpeg-renderers/vaapi.cpp
+++ b/app/streaming/video/ffmpeg-renderers/vaapi.cpp
@@ -648,6 +648,12 @@ int VAAPIRenderer::getDecoderColorspace()
     return COLORSPACE_REC_601;
 }
 
+int VAAPIRenderer::getDecoderColorRange()
+{
+    // vaPutSurface() assumes limited range
+    return COLOR_RANGE_LIMITED;
+}
+
 int VAAPIRenderer::getDecoderCapabilities()
 {
     int caps = 0;

--- a/app/streaming/video/ffmpeg-renderers/vaapi.cpp
+++ b/app/streaming/video/ffmpeg-renderers/vaapi.cpp
@@ -26,8 +26,7 @@ VAAPIRenderer::VAAPIRenderer(int decoderSelectionPass)
       m_RequiresExplicitPixelFormat(false),
       m_OverlayMutex(nullptr)
 #ifdef HAVE_EGL
-    , m_EglExportType(EglExportType::Unknown),
-      m_EglImageFactory(this)
+    , m_EglExportType(EglExportType::Unknown)
 #endif
 {
 #ifdef HAVE_LIBVA_X11
@@ -1082,11 +1081,12 @@ AVPixelFormat VAAPIRenderer::getEGLImagePixelFormat() {
 }
 
 bool
-VAAPIRenderer::initializeEGL(EGLDisplay dpy,
+VAAPIRenderer::initializeEGL(IFFmpegRenderer* eglRenderer,
+                             EGLDisplay dpy,
                              const EGLExtensions &ext) {
     VADRMPRIMESurfaceDescriptor descriptor;
 
-    if (!m_EglImageFactory.initializeEGL(dpy, ext)) {
+    if (!m_EglImageFactory.initializeEGL(eglRenderer, dpy, ext)) {
         return false;
     }
 

--- a/app/streaming/video/ffmpeg-renderers/vaapi.h
+++ b/app/streaming/video/ffmpeg-renderers/vaapi.h
@@ -72,7 +72,7 @@ public:
 #ifdef HAVE_EGL
     virtual bool canExportEGL() override;
     virtual AVPixelFormat getEGLImagePixelFormat() override;
-    virtual bool initializeEGL(EGLDisplay dpy, const EGLExtensions &ext) override;
+    virtual bool initializeEGL(IFFmpegRenderer* eglRenderer, EGLDisplay dpy, const EGLExtensions &ext) override;
     virtual ssize_t exportEGLImages(AVFrame *frame, EGLDisplay dpy, EGLImage images[EGL_MAX_PLANES]) override;
 #endif
 

--- a/app/streaming/video/ffmpeg-renderers/vaapi.h
+++ b/app/streaming/video/ffmpeg-renderers/vaapi.h
@@ -64,6 +64,7 @@ public:
     virtual void renderFrame(AVFrame* frame) override;
     virtual bool isDirectRenderingSupported() override;
     virtual int getDecoderColorspace() override;
+    virtual int getDecoderColorRange() override;
     virtual int getDecoderCapabilities() override;
     virtual void notifyOverlayUpdated(Overlay::OverlayType) override;
     virtual bool notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO) override;

--- a/app/streaming/video/ffmpeg-renderers/vdpau.cpp
+++ b/app/streaming/video/ffmpeg-renderers/vdpau.cpp
@@ -470,6 +470,12 @@ int VDPAURenderer::getDecoderColorspace()
     return COLORSPACE_REC_601;
 }
 
+int VDPAURenderer::getDecoderColorRange()
+{
+    // The default VdpVideoMixer CSC matrix assumes limited range
+    return COLOR_RANGE_LIMITED;
+}
+
 int VDPAURenderer::getDecoderCapabilities()
 {
     return CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC |

--- a/app/streaming/video/ffmpeg-renderers/vdpau.h
+++ b/app/streaming/video/ffmpeg-renderers/vdpau.h
@@ -19,6 +19,7 @@ public:
     virtual void waitToRender() override;
     virtual void renderFrame(AVFrame* frame) override;
     virtual int getDecoderColorspace() override;
+    virtual int getDecoderColorRange() override;
     virtual int getDecoderCapabilities() override;
 
 private:

--- a/app/streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm
@@ -578,6 +578,11 @@ public:
         return COLORSPACE_REC_601;
     }
 
+    int getDecoderColorRange() override
+    {
+        return COLOR_RANGE_LIMITED;
+    }
+
     int getDecoderCapabilities() override
     {
         return CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC |

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -1969,6 +1969,74 @@ void FFmpegVideoDecoder::decoderThreadProc()
                         }
                     }
 
+                    // Some decoders don't propagate color metadata from the bitstream,
+                    // so we will try to guess it here if it was unset.
+                    if (frame->color_range == AVCOL_RANGE_UNSPECIFIED) {
+                        switch (getDecoderColorRange()) {
+                        case COLOR_RANGE_LIMITED:
+                            frame->color_range = AVCOL_RANGE_MPEG;
+                            break;
+                        case COLOR_RANGE_FULL:
+                            frame->color_range = AVCOL_RANGE_JPEG;
+                            break;
+                        }
+                    }
+                    if (frame->colorspace == AVCOL_SPC_UNSPECIFIED) {
+                        switch (getDecoderColorspace()) {
+                        case COLORSPACE_REC_601:
+                            frame->colorspace = AVCOL_SPC_SMPTE170M;
+                            break;
+                        case COLORSPACE_REC_709:
+                            frame->colorspace = AVCOL_SPC_BT709;
+                            break;
+                        case COLORSPACE_REC_2020:
+                            frame->colorspace = AVCOL_SPC_BT2020_NCL;
+                            break;
+                        }
+
+                        // HDR forces BT.2020 regardless of decoder preference
+                        if (LiGetCurrentHostDisplayHdrMode()) {
+                            frame->colorspace = AVCOL_SPC_BT2020_NCL;
+                        }
+                    }
+                    if (frame->color_primaries == AVCOL_PRI_UNSPECIFIED) {
+                        switch (frame->colorspace) {
+                        case AVCOL_SPC_BT709:
+                            frame->color_primaries = AVCOL_PRI_BT709;
+                            break;
+                        case AVCOL_SPC_SMPTE170M:
+                            frame->color_primaries = AVCOL_PRI_SMPTE170M;
+                            break;
+                        case AVCOL_SPC_BT2020_NCL:
+                        case AVCOL_SPC_BT2020_CL:
+                            frame->color_primaries = AVCOL_PRI_BT2020;
+                            break;
+                        default:
+                            break;
+                        }
+                    }
+                    if (frame->color_trc == AVCOL_TRC_UNSPECIFIED) {
+                        switch (frame->colorspace) {
+                        case AVCOL_SPC_BT709:
+                            frame->color_trc = AVCOL_TRC_BT709;
+                            break;
+                        case AVCOL_SPC_SMPTE170M:
+                            frame->color_trc = AVCOL_TRC_SMPTE170M;
+                            break;
+                        case AVCOL_SPC_BT2020_NCL:
+                        case AVCOL_SPC_BT2020_CL:
+                            frame->color_trc = AVCOL_TRC_BT2020_10;
+                            break;
+                        default:
+                            break;
+                        }
+
+                        // HDR forces SMPTE 2084 PQ regardless of decoder preference
+                        if (LiGetCurrentHostDisplayHdrMode()) {
+                            frame->color_trc = AVCOL_TRC_SMPTE2084;
+                        }
+                    }
+
                     // Reset failed decodes count if we reached this far
                     m_ConsecutiveFailedDecodes = 0;
 


### PR DESCRIPTION
摘上游 moonlight-stream/moonlight-qt 的 7 个提交（`git cherry-pick -x`，作者保留 Cameron Gutman），**7 个全部干净应用，无冲突**。

    2bea406f  Guess frame color metadata if left unspecified
    a903c5ce  Explicitly request limited range for renderers that require it
    4570fba8  Add full range handling to SdlRenderer
    3f26217d  Select color range based on plane COLOR_RANGE property values
    b2f0828d  Use requested color range as a fallback in isFrameFullRange()
    c1623ff4  Switch the default renderer color range to full
    7cf8b46c  Pass the correct renderer to EGLImageFactory

## 这是一个行为性改动

渲染器的默认色彩范围从 **limited 翻成 full**。好处是不再被 16-235 截断，黑位更准、带状更少（`plvk` 早就单独这么干了，注释里写的就是"修 OLED 上抬高的黑位"）。

**必须整串合，不能拆。** 只取 `c1623ff4`（翻默认值）而不取 `a903c5ce`（给做不了 full 的渲染器显式补 limited），DXVA2 / VAAPI / VDPAU / MMAL / AVSampleLayer 会直接错色。

## 为什么这个前提成立

`b2f0828d` 让 `isFrameFullRange()` 在帧没带元数据时"假定编码端按我们请求的范围发"。核对过这个请求确实会协商给主机：

    app/streaming/session.cpp:876
    m_StreamConfig.colorRange = decoder->getDecoderColorRange();

再加上 `2bea406f` 会给没打标签的帧按请求值补上 `color_range` / `colorspace` / `color_primaries` / `color_trc`，链路是闭合的。

## 合完之后各渲染器的落点

| 渲染器 | 请求的范围 | 来源 |
|---|---|---|
| dxva2 / vaapi / vdpau / mmal / vt_avsamplelayer | limited | `a903c5ce` 显式补，硬件路径做不了 full |
| slvid (SteamLink) | limited | 本来就显式 |
| plvk | full | 本来就显式 |
| **vt_metal** / d3d11va / sdlvid / eglvid / drm | **full（新默认）** | 按 `isFrameFullRange()` 现算 CSC 矩阵 |

`vt_metal` 是我们 macOS 的主渲染器，它的矩阵来自 `getFramePremultipliedCscConstants()` → `isFrameFullRange()`，会跟着新默认走对。核对过我们 fork 没有绕开这条链自己做 YUV→RGB 的渲染器。

## 验证情况

- 本机 `make -j8`：**0 error**。
- 启动烟测通过，Metal 渲染器 + 硬解正常，解码器探测解出帧。

**没有实机串流验证。** 这是这个 PR 最大的缺口 —— 烟测只走到解码器探测，验不到画面。色彩范围错了的表现是发灰（limited 当 full 解）或死黑压暗部（full 当 limited 解），必须实际串一次看画面才能确认。建议至少在 macOS（vt_metal，新默认生效）上试，有 Windows/Linux 机器的话 d3d11va 和 drm/eglvid 也在受影响之列。

上游是 8 月 5-6 号刚落的这一串，还没进任何发布版本，也值得考虑要不要等它在上游沉淀几天。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video color accuracy by applying more reliable color range and color-space metadata across decoding and rendering paths.
  * Added sensible fallbacks when video metadata is missing.
  * Improved HDR playback metadata handling, including BT.2020 color space and PQ transfer characteristics.
  * Ensured CPU-based video conversion correctly handles source and destination color ranges.
* **Video Playback**
  * Improved EGL-based rendering initialization for more consistent hardware-accelerated video output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->