### PR TITLE
chore: 加个脚本盯上游未处理的提交

### DIFF
--- a/scripts/upstream-skip.txt
+++ b/scripts/upstream-skip.txt
@@ -1,0 +1,6 @@
+# 主动决定不跟进的上游提交。格式：<短 sha> <原因>
+#
+# 只记「评估过、决定不要」的。已经 cherry-pick 的不用写在这里 ——
+# upstream-status.sh 靠提交信息里的 (cherry picked from commit ...) 自动识别。
+
+fcba7df8 README 构建要求；我们的 README 是重写过的中文版，对应段落已写明「建议使用与 CI 接近的 Qt 6.11.x」，比上游表述更准

--- a/scripts/upstream-status.sh
+++ b/scripts/upstream-status.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# 列出上游（moonlight-stream/moonlight-qt）有、我们还没处理的提交。
+#
+# 判重不能用 git cherry —— 它比的是 patch-id，而我们的文件和上游有分叉，
+# 同一个改动落到我们这边上下文不同，patch-id 就对不上，已经合入的提交会被
+# 报成新的。这里改用 cherry-pick -x 在提交信息里留下的
+# 「(cherry picked from commit <sha>)」做锚点，所以**摘上游提交时必须带 -x**。
+#
+# 用法：
+#   scripts/upstream-status.sh              拉取上游后列出
+#   scripts/upstream-status.sh --no-fetch   跳过拉取，用本地已有的 upstream/master
+
+set -euo pipefail
+
+UPSTREAM_URL="https://github.com/moonlight-stream/moonlight-qt.git"
+BASE_BRANCH="master"
+SKIP_FILE="$(dirname "$0")/upstream-skip.txt"
+
+if [ "${1:-}" != "--no-fetch" ]; then
+    if ! git remote get-url upstream > /dev/null 2>&1; then
+        echo "添加 upstream remote..."
+        git remote add upstream "$UPSTREAM_URL"
+        # 防手滑往上游推
+        git remote set-url --push upstream DISABLED
+    fi
+    echo "拉取上游..."
+    git fetch upstream --quiet
+fi
+
+# 已经落进 master 的：提交信息里带 cherry-pick 来源
+merged=$(git log "$BASE_BRANCH" --format=%B | grep -oE "cherry picked from commit [0-9a-f]{40}" | awk '{print $5}' || true)
+# 还在别的分支上（PR 进行中）
+inflight=$(git log --all --not "$BASE_BRANCH" --format=%B | grep -oE "cherry picked from commit [0-9a-f]{40}" | awk '{print $5}' || true)
+
+pending=0
+while read -r full short subj; do
+    [ -z "$full" ] && continue
+
+    if grep -q "$full" <<< "$merged"; then
+        printf '  已合入   %s  %s\n' "$short" "$subj"
+        continue
+    fi
+
+    if grep -q "$full" <<< "$inflight"; then
+        printf '  进行中   %s  %s\n' "$short" "$subj"
+        continue
+    fi
+
+    # 主动决定不跟的，原因记在 upstream-skip.txt
+    if [ -f "$SKIP_FILE" ] && reason=$(grep "^$short" "$SKIP_FILE" | head -1 | cut -d' ' -f2-); [ -n "${reason:-}" ]; then
+        printf '  已跳过   %s  %s\n           └─ %s\n' "$short" "$subj" "$reason"
+        continue
+    fi
+
+    printf '★ 待评估   %s  %s\n' "$short" "$subj"
+    pending=$((pending + 1))
+done < <(git log --no-merges --format="%H %h %s" "$BASE_BRANCH..upstream/$BASE_BRANCH")
+
+echo
+if [ "$pending" -eq 0 ]; then
+    echo "没有待评估的上游提交。"
+else
+    echo "$pending 个待评估。跟进后用 git cherry-pick -x <sha>（-x 不能省，判重靠它）；"
+    echo "决定不跟的话把 <短 sha> 和原因写进 $SKIP_FILE。"
+fi


### PR DESCRIPTION
我们没有常规 sync 流程，前几次跟进上游都是临时 `git fetch` 一次再肉眼比对，容易漏。这个 PR 把它变成一条命令。

    scripts/upstream-status.sh

## 为什么不能用 `git cherry`

第一反应是 `git cherry master upstream/master`，但它判重靠 patch-id —— 我们不少文件和上游有分叉，同一个改动落到我们这边上下文不同，patch-id 就对不上。实测把**已经合入的三个提交全报成了「新的」**：

    + b5d7f3b9  Update Windows, macOS, and AppImage dependencies      ← 已经在 master 里
    + 131cb270  Add NSBonjourServices entry to Info.plist             ← 已经在 master 里
    + 5ac25421  Update LSMinimumSystemVersion...                      ← 已经在 master 里

改用 `cherry-pick -x` 写进提交信息的 `(cherry picked from commit <sha>)` 做锚点，这个是精确的。**代价是以后摘上游提交必须带 `-x`**，脚本注释和输出里都写了。

## 分四类

    进行中   7cf8b46c  Pass the correct renderer to EGLImageFactory
    ...
    已跳过   fcba7df8  Update Windows and macOS build requirements
             └─ README 构建要求；我们的 README 是重写过的中文版，对应段落已写明「建议
                使用与 CI 接近的 Qt 6.11.x」，比上游表述更准
    已合入   5ac25421  Update LSMinimumSystemVersion to match Qt 6.10+ and our prebuilts

    没有待评估的上游提交。

「进行中」指已经摘到别的分支、PR 还没合的（现在是色彩范围那 7 个，#151）。

「已跳过」这一类必须单独记 —— 主动决定不跟的提交没有落处的话，每次跑都会重新冒出来当新的。原因写进 `scripts/upstream-skip.txt`，目前只有 README 那一条。

## 顺带

首次运行会自动加 `upstream` remote，并把它的 push url 设成 `DISABLED` 防手滑往上游推。

**注意一个副作用**：加了 `upstream` remote 之后，`gh pr create` 会把默认基仓解析成上游，不加 `--repo` 就会把 PR 开到 moonlight-stream 去（我开这个 PR 时就中招了，已关闭上游那条）。建议本地跑一次：

    gh repo set-default qiin2333/moonlight-qt

## 验证

- 当前仓库状态下跑出来的四类分档与事实一致，「待评估」为 0。
- 边界情况试过：`upstream-skip.txt` 缺失时正常降级（那条变回「待评估」）；master 上一条 cherry-pick 记录都没有的全新克隆场景下，`set -euo pipefail` 下的空变量不会让脚本崩。
- `--no-fetch` 可跳过拉取，离线能跑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status tool that checks upstream changes, identifies already integrated commits, excludes documented skips, and reports pending work.
  * Added an option to review status without fetching remote updates.

* **Documentation**
  * Documented the format and behavior for recording intentionally skipped upstream commits.
  * Recorded a commit as skipped when existing localized guidance provides more precise information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->