### PR TITLE
fix(ui): 点 PC 进不去 —— AppView 因 HoverHandler 类型解析失败而加载不了（#145 回归）

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -1,4 +1,6 @@
-import QtQuick 2.9
+// 不带版本号：HoverHandler 是 QtQuick 2.15 才有的类型，写 2.9 会让整个文件在
+// 运行期加载失败（qmlcachegen 编得过，是运行期的类型解析失败），点 PC 进不来。
+import QtQuick
 import QtQuick.Controls
 import QtQuick.Window 2.2
 

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -1,5 +1,8 @@
-// 不带版本号：HoverHandler 是 QtQuick 2.15 才有的类型，写 2.9 会让整个文件在
-// 运行期加载失败（qmlcachegen 编得过，是运行期的类型解析失败），点 PC 进不来。
+// 不带版本号。原来写的是 2.9，而下面 DisplayChip 用的 HoverHandler 是 QtQuick
+// 2.15（Qt 5.15）才有的类型 —— 运行期类型解析失败，整个文件加载不了，点 PC 进不来
+// （qmlcachegen 不做完整类型解析，所以编译期无感）。
+// 不写具体版本是跟 main.qml 一致：仓库里 35 个文件已经在用无版本号的
+// import QtQuick.Controls，那种写法本身就要求 Qt 5.15+，版本下限早就在那里了。
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Window 2.2

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -101,16 +101,20 @@ CenteredGridView {
 
     function openAppView(computerIndex, computerName, showHiddenGames)
     {
-        var component = Qt.createComponent("AppView.qml")
-
-        // 组件造不出来时 createObject 返回 null，push(null) 只会往日志里丢一句
+        // 造不出来时 createObject 返回 null，push(null) 只会往日志里丢一句
         // 「nothing to push」就完了 —— 界面上表现为「点了没反应」，非常难查。
-        // 把真实原因摆出来。
-        if (component.status !== Component.Ready) {
-            console.error("Failed to load AppView.qml: " + component.errorString())
+        // status 和 createObject 的返回值都要看：status 只说明文件加载成功了，
+        // 实例化本身还可能失败（属性赋值出错等）。
+        function fail(reason) {
+            console.error("Failed to open AppView.qml: " + reason)
             errorDialog.text = qsTr("Unable to open the app list for %1.").arg(computerName)
-            errorDialog.helpText = component.errorString()
+            errorDialog.helpText = reason
             errorDialog.open()
+        }
+
+        var component = Qt.createComponent("AppView.qml")
+        if (component.status !== Component.Ready) {
+            fail(component.errorString())
             return
         }
 
@@ -118,7 +122,14 @@ CenteredGridView {
         if (showHiddenGames === true) {
             properties.showHiddenGames = true
         }
-        stackView.push(component.createObject(stackView, properties))
+
+        var appView = component.createObject(stackView, properties)
+        if (!appView) {
+            fail(component.errorString())
+            return
+        }
+
+        stackView.push(appView)
     }
 
     function showAddressSelectionForComputer(computerIndex, computerName, openAppAfterSelection)
@@ -344,10 +355,16 @@ CenteredGridView {
             id: pcContextMenuLoader
             asynchronous: true
             onLoaded: {
-                // 造好之前有人点过，把那次点击补上
+                // 造好之前有人点过，把那次点击补上。但要确认这一页还在最前面 ——
+                // 点完立刻返回或进入某台主机的话，菜单会弹在新页面上。
                 if (pcContextMenuLoader.parent.pendingMenuRequest !== 0) {
-                    pcContextMenuLoader.parent.openContextMenu(
-                        pcContextMenuLoader.parent.pendingMenuRequest === 2)
+                    if (pcGrid.StackView.status === StackView.Active) {
+                        pcContextMenuLoader.parent.openContextMenu(
+                            pcContextMenuLoader.parent.pendingMenuRequest === 2)
+                    }
+                    else {
+                        pcContextMenuLoader.parent.pendingMenuRequest = 0
+                    }
                 }
             }
             sourceComponent: NavigableMenu {

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -196,6 +196,28 @@ CenteredGridView {
 
         property alias pcContextMenu : pcContextMenuLoader.item
 
+        // 右键菜单是异步 Loader 造的，刚进视野的条目上 item 还是 null。四个调用点
+        // 以前都直接用，读 null 的成员会抛 TypeError，这一次点击就被静默吃掉 ——
+        // 表现正是「点了没反应，再点一次才出来」。这里记下意图，等造好再开。
+        // 0 = 没有待处理，1 = open()，2 = popup()（跟着鼠标位置）
+        property int pendingMenuRequest: 0
+
+        function openContextMenu(atCursor) {
+            if (!pcContextMenuLoader.item) {
+                pendingMenuRequest = atCursor ? 2 : 1
+                return
+            }
+
+            pendingMenuRequest = 0
+            if (atCursor && pcContextMenuLoader.item.popup) {
+                pcContextMenuLoader.item.popup()
+            }
+            else {
+                // Qt 5.9 没有 popup()；键盘触发时也走这条，菜单落在条目上而不是光标处
+                pcContextMenuLoader.item.open()
+            }
+        }
+
         Rectangle {
             id: pcIcon
             anchors.horizontalCenter: parent.horizontalCenter
@@ -310,6 +332,13 @@ CenteredGridView {
         Loader {
             id: pcContextMenuLoader
             asynchronous: true
+            onLoaded: {
+                // 造好之前有人点过，把那次点击补上
+                if (pcContextMenuLoader.parent.pendingMenuRequest !== 0) {
+                    pcContextMenuLoader.parent.openContextMenu(
+                        pcContextMenuLoader.parent.pendingMenuRequest === 2)
+                }
+            }
             sourceComponent: NavigableMenu {
                 id: pcContextMenu
                 initiator: pcContextMenuLoader.parent
@@ -392,19 +421,13 @@ CenteredGridView {
                 }
             } else if (!model.online) {
                 // Using open() here because it may be activated by keyboard
-                pcContextMenu.open()
+                openContextMenu(false)
             }
         }
 
         onPressAndHold: {
             // popup() ensures the menu appears under the mouse cursor
-            if (pcContextMenu.popup) {
-                pcContextMenu.popup()
-            }
-            else {
-                // Qt 5.9 doesn't have popup()
-                pcContextMenu.open()
-            }
+            openContextMenu(true)
         }
 
         MouseArea {
@@ -418,7 +441,7 @@ CenteredGridView {
         Keys.onMenuPressed: {
             // We must use open() here so the menu is positioned on
             // the ItemDelegate and not where the mouse cursor is
-            pcContextMenu.open()
+            openContextMenu(false)
         }
 
         Keys.onDeletePressed: {

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -102,12 +102,23 @@ CenteredGridView {
     function openAppView(computerIndex, computerName, showHiddenGames)
     {
         var component = Qt.createComponent("AppView.qml")
+
+        // 组件造不出来时 createObject 返回 null，push(null) 只会往日志里丢一句
+        // 「nothing to push」就完了 —— 界面上表现为「点了没反应」，非常难查。
+        // 把真实原因摆出来。
+        if (component.status !== Component.Ready) {
+            console.error("Failed to load AppView.qml: " + component.errorString())
+            errorDialog.text = qsTr("Unable to open the app list for %1.").arg(computerName)
+            errorDialog.helpText = component.errorString()
+            errorDialog.open()
+            return
+        }
+
         var properties = {"computerIndex": computerIndex, "objectName": computerName}
         if (showHiddenGames === true) {
             properties.showHiddenGames = true
         }
-        var appView = component.createObject(stackView, properties)
-        stackView.push(appView)
+        stackView.push(component.createObject(stackView, properties))
     }
 
     function showAddressSelectionForComputer(computerIndex, computerName, openAppAfterSelection)


### PR DESCRIPTION
定位到根因了，是 #145 的回归。**这个 PR 现在装的是根因修复**（原本只有下面第 2 条的竞态修复）。

## 根因

#145 在 `AppView.qml` 的 `DisplayChip` 里加了 `HoverHandler`，但这个文件的第一行是 `import QtQuick 2.9`，而 `HoverHandler` 要 QtQuick 2.15 才有。运行期类型解析失败，**整个 `AppView.qml` 加载不了**。

带诊断的构建跑出来是这样：

    [DIAG] openAppView status=3 err=qrc:/gui/AppView.qml:65:9: HoverHandler is not a type
    QQmlComponent: Component is not ready
    [DIAG] createObject -> null
    qrc:/gui/main.qml:168:5: QML StackView: push: nothing to push

`status=3` 就是 `Component.Error`。于是 `createObject` 返回 `null`，`stackView.push(null)` 只往日志里丢一句 `nothing to push` —— **界面上就是点 PC 完全没反应**。

最小用例复现确认过成因：

    import QtQuick 2.9  + HoverHandler  →  HoverHandler is not a type
    import QtQuick 2.15 + HoverHandler  →  OK
    import QtQuick      + HoverHandler  →  OK

## 为什么混过了所有门禁

`qmlcachegen` 不做完整类型解析，所以编译期无感；四平台 CI 全绿。

我在 #145 时其实跑过 `qmllint`，它**报了**这个问题：

    AppView.qml:67:9: HoverHandler was not found. [import]

但我把它 grep 掉了 —— 同一个 `[import]` 类别里混着一堆本地组件找不到的噪音（`NavigableItemDelegate`、`Panel`、`MicroLabel`…），我当成预存在的导入噪音整类过滤了。给对 `-I app/gui` 之后噪音就没了，全仓库只剩 C++ 注册类型那几条。这个门禁我另开一个 PR 加进 CI。

## 改动

1. **`AppView.qml`**：`import QtQuick 2.9` → 不带版本号的 `import QtQuick`（与仓库里 `import QtQuick.Controls` 的写法一致）。
2. **`PcView.qml` 的 `openAppView()`**：检查 `component.status`，不 Ready 就把 `errorString()` 摆到错误框里。之前这里是静默失败的 —— 这正是这个 bug 难查的原因，同一类问题下次不用靠翻日志找。
3. **`PcView.qml` 的右键菜单竞态**（本 PR 原本的内容）：菜单由 `asynchronous: true` 的 Loader 造，`item` 在造好前是 `null`，而四个调用点直接拿它用，读 null 成员抛 `TypeError`，那一次点击被静默吃掉。改成记下意图、`onLoaded` 里补开一次，保留异步加载。这个问题 v6.3.2 上同样存在，不是本次回归。

## 验证

- 加临时自检 `Qt.createComponent("AppView.qml")` 跑真实构建：修复前 `status=3` + `HoverHandler is not a type`，修复后 **`status=1` (Ready)、errorString 为空**。自检代码已撤掉。
- 全仓库扫了同类隐患（带版本号的 QtQuick 导入 + 该版本没有的 Handler 类型）：只有 `HdrBrightnessHandle.qml` 命中（QtQuick 2.12 + DragHandler/HoverHandler），实测 2.12 下两者都能解析，安全。除 AppView 外没有第二处。
- `make -j8` 0 error。