### PR TITLE
ci: 加一道 QML 类型解析门禁

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,35 @@ env:
   BUILD_NUMBER: ${{ github.run_number }}
 
 jobs:
+  qml-lint:
+    # QML 的类型解析失败是运行期致命的，但 qmlcachegen 编得过、四平台构建全绿，
+    # 所以必须单独拦一道（见 scripts/qmllint-check.sh 里的说明）。
+    # 只装 Qt、不构建，和四个 build 并行跑。
+    runs-on: ubuntu-latest
+
+    # 这个 job 会执行 PR 版本里的 scripts/qmllint-check.sh。顶层 permissions 给的是
+    # contents: write，这里收回到只读，并且不把 checkout 的 token 写进本地 git 配置 ——
+    # 否则 PR 作者改一行脚本就能拿着仓库的写权限跑任意命令。
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.11.1'
+        modules: 'qtmultimedia qtimageformats'
+        cache: true
+        aqtsource: 'git+https://github.com/miurahr/aqtinstall.git@073e34d7c2ab4ae6961ed7cca690b3abd5ba5a7e'
+
+    - name: Check QML type resolution
+      run: scripts/qmllint-check.sh
+
   build-windows:
     runs-on: windows-2022
     steps:
@@ -449,7 +478,7 @@ jobs:
 
   release:
     if: github.event_name == 'release'
-    needs: [build-windows, build-macos, build-linux, build-steamlink]
+    needs: [qml-lint, build-windows, build-macos, build-linux, build-steamlink]
     runs-on: ubuntu-latest
     
     steps:

--- a/scripts/qmllint-check.sh
+++ b/scripts/qmllint-check.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# QML 类型解析门禁。
+#
+# 只盯一类问题：类型解析失败（「X was not found」/「X is not a type」）。
+# 这一类是运行期致命的 —— qmlcachegen 不做完整类型解析，编译能过、CI 全绿，
+# 但那个 .qml 在运行期根本加载不了。#153 就是这么漏出去的：AppView.qml 写着
+# import QtQuick 2.9 却用了 2.15 才有的 HoverHandler，结果点 PC 完全没反应。
+#
+# 其它 qmllint 警告（unqualified access、deprecated 之类）不在门禁范围内，
+# 那些是风格问题，仓库里存量不少，混进来会让这个检查失去意义。
+#
+# 用法：scripts/qmllint-check.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# 找 qmllint：CI 上 install-qt-action 会设 QT_ROOT_DIR
+if [ -n "${QT_ROOT_DIR:-}" ] && [ -x "$QT_ROOT_DIR/bin/qmllint" ]; then
+    QMLLINT="$QT_ROOT_DIR/bin/qmllint"
+elif command -v qmllint > /dev/null 2>&1; then
+    QMLLINT="$(command -v qmllint)"
+else
+    echo "找不到 qmllint（设 QT_ROOT_DIR 或把它放进 PATH）" >&2
+    exit 1
+fi
+
+echo "qmllint: $QMLLINT"
+
+# 不用 mapfile：macOS 自带的 bash 是 3.2，没有这个内建
+QML_FILES=()
+while IFS= read -r f; do
+    QML_FILES+=("$f")
+done < <(git ls-files 'app/gui/*.qml' 'app/gui/**/*.qml')
+if [ "${#QML_FILES[@]}" -eq 0 ]; then
+    echo "没找到 QML 文件" >&2
+    exit 1
+fi
+echo "检查 ${#QML_FILES[@]} 个 QML 文件"
+
+# C++ 注册给 QML 的类型 qmllint 看不见，只能豁免。名单连同模块名和主版本号
+# 一起从注册处现推，别硬编码 —— 将来注册了新类型不用回来改这个脚本。
+# 每行形如：<QML 类型名> <模块 URI> <主版本号>
+cpp_types=$(grep -rhoE "qmlRegister(Singleton|Uncreatable)?Type<[A-Za-z_]+>\(\"[A-Za-z_.]+\", *[0-9]+, *[0-9]+" app \
+            | sed -E 's/^qmlRegister(Singleton|Uncreatable)?Type<([A-Za-z_]+)>\("([A-Za-z_.]+)", *([0-9]+).*/\2 \3 \4/' \
+            | sort -u)
+if [ -z "$cpp_types" ]; then
+    echo "没能从 C++ 里推出注册类型名单，检查一下 grep 模式是不是过时了" >&2
+    exit 1
+fi
+echo "豁免的 C++ 注册类型："
+echo "$cpp_types" | sed 's/^/  /'
+
+# -I app/gui 让本地组件（Panel / MicroLabel / NavigableDialog 这些）能被解析到。
+# 不给这个参数的话本地组件会刷满同一类警告，真问题就被埋掉了 —— #153 当初
+# 就是这么被我从输出里 grep 掉的。
+raw=$("$QMLLINT" -I app/gui "${QML_FILES[@]}" 2>&1 || true)
+
+resolution_failures=$(echo "$raw" | grep -E "was not found|is not a type" || true)
+
+# 豁免要卡到「这个文件确实 import 了那个模块」为止。只按类型名放行的话，
+# 某个 .qml 忘了写 import AppModel 1.0 也会被一起放过 —— 而那同样是运行期
+# 加载失败。
+remaining=""
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+
+    file=$(echo "$line" | sed -E 's/^[A-Za-z]+: ([^:]+):[0-9]+:[0-9]+:.*/\1/')
+    type=$(echo "$line" | sed -E 's/.*: ([A-Za-z_]+) (was not found|is not a type).*/\1/')
+
+    exempt=0
+    if [ -f "$file" ]; then
+        reg=$(echo "$cpp_types" | awk -v t="$type" '$1 == t {print; exit}')
+        if [ -n "$reg" ]; then
+            uri=$(echo "$reg" | awk '{print $2}')
+            major=$(echo "$reg" | awk '{print $3}')
+            # 接受 import <URI> <major>.<minor>，也接受无版本号的写法
+            if grep -qE "^import ${uri}( ${major}\.[0-9]+)?[[:space:]]*$" "$file"; then
+                exempt=1
+            fi
+        fi
+    fi
+
+    if [ "$exempt" -eq 0 ]; then
+        remaining="${remaining}${line}
+"
+    fi
+done <<< "$resolution_failures"
+remaining=$(echo "$remaining" | sed '/^$/d')
+
+if [ -n "$remaining" ]; then
+    echo
+    echo "==> 有类型解析不了。这些 .qml 在运行期会加载失败："
+    echo
+    echo "$remaining"
+    echo
+    echo "常见原因：用了比文件顶部 import 版本更新的类型（例如 import QtQuick 2.9"
+    echo "配 HoverHandler，那个类型要 2.15）。改成不带版本号的 import 通常就好了。"
+    exit 1
+fi
+
+echo "类型解析检查通过。"


### PR DESCRIPTION
> 叠在 #153 上（base 指向那个分支，#153 合了之后 GitHub 会自动改指 master）。这样做是因为门禁在当前 master 上是**会红的** —— master 里还有 #153 要修的那个 bug。

## 为什么要这道门禁

#153 的回归混过了所有现有门禁：`AppView.qml` 写着 `import QtQuick 2.9` 却用了 2.15 才有的 `HoverHandler`，运行期整个文件加载不了，点 PC 完全没反应，而 `qmlcachegen` 编得过、四平台 CI 全绿。

`qmllint` **其实报了**这个问题。它当初没被看见，是因为不给 `-I app/gui` 的话本地组件（`Panel` / `MicroLabel` / `NavigableDialog`…）会刷出一大堆同一类别的 `was not found`，真问题就埋在噪音里 —— 我在 #145 时正是把整类过滤掉了。给了 `-I` 之后，全仓库只剩 C++ 注册类型那几条。

## 门禁范围

`scripts/qmllint-check.sh` **只盯类型解析失败**（`was not found` / `is not a type`）。这一类是运行期致命的：那个 `.qml` 根本加载不了。

其它 qmllint 警告（unqualified access、deprecated 之类）刻意不进门禁 —— 仓库里存量不少，混进来这个检查马上就会被当成噪音忽略，失去意义。

C++ 注册类型 qmllint 看不见，只能豁免；名单从 `qmlRegister*Type<>` 现推而不是硬编码，将来注册了新类型不用回来改脚本。当前推出来 9 个：

    AppModel AutoUpdateChecker ComputerManager ComputerModel ImageUtils
    SdlGamepadKeyNavigation Session StreamingPreferences SystemProperties

## CI 接法

独立 job `qml-lint`，和四个 build 并行，只装 Qt 不构建（几十秒）。`release` job 的 `needs` 里加上它，所以发版会被它拦。

## 验证

- 干净树（含 #153 的修复）：40 个 QML 文件，**通过**。
- 把 `AppView.qml` 的 import 改回 `2.9`：**精确报出那一行并以 1 退出**，没有夹带其它噪音：

      ==> 有类型解析不了。这些 .qml 在运行期会加载失败：
      Warning: app/gui/AppView.qml:67:9: HoverHandler was not found. ... [import]

- 脚本兼容 macOS 自带的 bash 3.2（没用 `mapfile`），本地和 CI 都能跑。
- workflow YAML 解析验证过，job 列表和 `release` 的 `needs` 都对。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated QML validation to detect unresolved types and missing imports before release builds.
  * Release publishing now waits for QML validation to pass, helping prevent faulty releases.

* **Chores**
  * Added checks for QML files and recognized registered types during continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->