### PR TITLE
fix(scripts): upstream-status 的两处 review 意见

### DIFF
--- a/scripts/upstream-status.sh
+++ b/scripts/upstream-status.sh
@@ -20,17 +20,25 @@ if [ "${1:-}" != "--no-fetch" ]; then
     if ! git remote get-url upstream > /dev/null 2>&1; then
         echo "添加 upstream remote..."
         git remote add upstream "$UPSTREAM_URL"
-        # 防手滑往上游推
-        git remote set-url --push upstream DISABLED
     fi
+    # 防手滑往上游推。放在 if 外面：remote 可能是别人先手工加的，那种情况下
+    # push url 还是继承 fetch url，有上游写权限的人一个 git push upstream 就出去了。
+    git remote set-url --push upstream DISABLED
     echo "拉取上游..."
     git fetch upstream --quiet
 fi
 
 # 已经落进 master 的：提交信息里带 cherry-pick 来源
 merged=$(git log "$BASE_BRANCH" --format=%B | grep -oE "cherry picked from commit [0-9a-f]{40}" | awk '{print $5}' || true)
-# 还在别的分支上（PR 进行中）
-inflight=$(git log --all --not "$BASE_BRANCH" --format=%B | grep -oE "cherry picked from commit [0-9a-f]{40}" | awk '{print $5}' || true)
+# 还在别的分支上（PR 进行中）。只看本地分支和 origin 的远端分支 —— 用 --all 会把
+# upstream/* 和 tag 也算进来，上游自己在分支间 cherry-pick 过的提交就会被误判成
+# 「我们正在处理」，从待评估里凭空消失。
+inflight_refs=$(git for-each-ref --format='%(refname)' refs/heads refs/remotes/origin || true)
+if [ -n "$inflight_refs" ]; then
+    inflight=$(git log $inflight_refs --not "$BASE_BRANCH" --format=%B | grep -oE "cherry picked from commit [0-9a-f]{40}" | awk '{print $5}' || true)
+else
+    inflight=""
+fi
 
 pending=0
 while read -r full short subj; do


### PR DESCRIPTION
#152 的 review 意见。我改完时那个 PR 已经合了，所以另开一个。

**1. `git remote set-url --push upstream DISABLED` 挪出 `if` 块**

remote 可能是别人先手工加的（我自己就是先手工加了才写的脚本），那种情况下原来的写法整块跳过，push url 继承 fetch url —— 有上游写权限的人一个 `git push upstream` 就推出去了。

**2. `inflight` 不再用 `--all`**

`--all` 会把 `refs/remotes/upstream/*` 和 tag 也算进来。上游自己在分支间 backport 的提交带着 `cherry picked from commit` 尾注，会被误判成「我们正在处理」，从待评估里凭空消失 —— 这正是这个脚本最不该出的错。改成只看 `refs/heads` 和 `refs/remotes/origin`：

```bash
inflight_refs=$(git for-each-ref --format='%(refname)' refs/heads refs/remotes/origin || true)
```

说明一下：这一条**目前是潜在问题、还没真的误判过** —— `upstream/master` 上现在一条 `cherry picked from commit` 都没有（实测 grep 计数 0）。但 tag 也在 `--all` 范围里，且上游将来 backport 就会踩到。

## 验证

脚本在 #151 合入前后各跑了一次，分档自动跟着变，等于它自己验证了自己：

合入前（色彩范围那 7 个在分支上）：

    进行中   7cf8b46c  Pass the correct renderer to EGLImageFactory
    ...

合入后：

    已合入   7cf8b46c  Pass the correct renderer to EGLImageFactory
    已合入   c1623ff4  Switch the default renderer color range to full
    ...
    已跳过   fcba7df8  Update Windows and macOS build requirements
             └─ README 构建要求；我们的 README 是重写过的中文版……

    没有待评估的上游提交。

另外 `git remote get-url --push upstream` 确认为 `DISABLED`。