### PR TITLE
fix(video): update FFmpeg for D3D11VA full range

### DIFF
--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -903,12 +903,16 @@ ApplicationWindow {
             // 云主机推广。放在这里是因为「我没有可以串流的主机」正好是打开这个框的
             // 人最可能卡住的地方 —— 手动填 IP 填不出一台主机来。
             //
-            // 没有浏览器可用时整块隐藏（和 QQ 按钮同一个判断），否则按钮点了没反应。
+            // 基地云目前只面向简体中文用户；自动语言模式下跟随系统语言。
+            // 没有浏览器可用时也整块隐藏（和 QQ 按钮同一个判断），否则按钮点了没反应。
             Item {
                 Layout.fillWidth: true
                 Layout.topMargin: Theme.spaceSm
                 implicitHeight: promoColumn.implicitHeight
-                visible: SystemProperties.hasBrowser
+                visible: SystemProperties.hasBrowser &&
+                         (StreamingPreferences.language === StreamingPreferences.LANG_ZH_CN ||
+                          (StreamingPreferences.language === StreamingPreferences.LANG_AUTO &&
+                           Qt.locale().name === "zh_CN"))
 
                 Column {
                     id: promoColumn

--- a/setup-deps.ps1
+++ b/setup-deps.ps1
@@ -4,7 +4,7 @@ $Organization = "moonlight-stream"
 $PrebuiltRepo = "moonlight-qt-deps"
 $TargetDir = Join-Path $PSScriptRoot "libs\windows"
 $Assets = @("windows-x64.zip", "windows-ARM64.zip")
-$Tag = "v11"
+$Tag = "v12"
 
 if (Test-Path $TargetDir) {
     Write-Host "Cleaning target directory..." -ForegroundColor Cyan

--- a/setup-deps.py
+++ b/setup-deps.py
@@ -7,7 +7,7 @@ import shutil
 
 ORGANIZATION = "moonlight-stream"
 PREBUILT_REPO = "moonlight-qt-deps"
-TAG = "v11"
+TAG = "v12"
 
 def get_platform_config():
     system = platform.system()


### PR DESCRIPTION
## 改了啥呀

- 把预编译依赖从 `v11` 更新到 `v12`
- 同步上游针对 8-bit D3D11VA Full Range 解码的 FFmpeg 修复
- 修复 6.3.3 在部分 Intel GPU 上使用 H.264/HEVC 串流时黑屏的问题，杂鱼回归退散～

## 为啥要改

Issue #159 的日志显示 D3D11VA 在初始化硬件帧上下文时持续返回 `-22`，随后 H.264/HEVC 解码反复失败；AV1 不受影响。上游已通过更新预编译 FFmpeg 包修复该兼容性问题。

Fixes #159

## 验证

- PowerShell 脚本语法解析通过
- Python 脚本 AST 解析通过
- `git diff --check` 通过
- 已确认 `moonlight-qt-deps` v12 提供 Windows x64、Windows ARM64 和 macOS 构建资产

CI 产物生成后会请 issue 用户实机验证。杂鱼 Intel 驱动，这次要乖乖出画面哦。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cloud-host promotion options are now shown only when browser support is available and Simplified Chinese is selected or detected automatically.
- **Chores**
  - Updated the dependency release to version `v12` across setup scripts.
  - Deployment completion messaging remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->