### PR TITLE
feat(input): 本地光标认出标准形状后换成系统原生指针

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -214,6 +214,7 @@ SOURCES += \
     settings/mappingfetcher.cpp \
     settings/streamingpreferences.cpp \
     streaming/input/abstouch.cpp \
+    streaming/input/cursorshapeclassifier.cpp \
     streaming/input/gamepad.cpp \
     streaming/input/input.cpp \
     streaming/input/keyboard.cpp \
@@ -270,6 +271,7 @@ HEADERS += \
     cli/quitstream.h \
     cli/startstream.h \
     settings/streamingpreferences.h \
+    streaming/input/cursorshapeclassifier.h \
     streaming/input/input.h \
     streaming/session.h \
     streaming/filemappingclient.h \

--- a/app/streaming/input/cursorshapeclassifier.cpp
+++ b/app/streaming/input/cursorshapeclassifier.cpp
@@ -1,0 +1,350 @@
+#include "cursorshapeclassifier.h"
+
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+// alpha 高于这个值算不透明。抗锯齿的边缘像素 alpha 很低，一并当透明处理，
+// 免得包围盒被一圈几乎看不见的羽化撑大。
+constexpr int OpaqueAlphaThreshold = 32;
+
+// 正常的光标不会比这更大。超过就当成不认识，走位图。
+constexpr int MaxCursorDimension = 128;
+
+qreal medianOf(QVector<int> values)
+{
+    if (values.isEmpty()) {
+        return 0.0;
+    }
+
+    std::sort(values.begin(), values.end());
+    const int mid = values.size() / 2;
+    if (values.size() % 2 != 0) {
+        return values[mid];
+    }
+    return (values[mid - 1] + values[mid]) / 2.0;
+}
+
+} // namespace
+
+CursorShapeMetrics measureCursorShape(int width,
+                                      int height,
+                                      int hotspotX,
+                                      int hotspotY,
+                                      const QByteArray& bgra)
+{
+    CursorShapeMetrics metrics;
+
+    if (width <= 0 || height <= 0 ||
+        width > MaxCursorDimension || height > MaxCursorDimension) {
+        return metrics;
+    }
+
+    if (bgra.size() != static_cast<qsizetype>(width) * height * 4) {
+        return metrics;
+    }
+
+    const uchar* pixels = reinterpret_cast<const uchar*>(bgra.constData());
+
+    int left = width;
+    int top = height;
+    int right = -1;
+    int bottom = -1;
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            const qsizetype alphaIndex =
+                (static_cast<qsizetype>(y) * width + x) * 4 + 3;
+            if (pixels[alphaIndex] <= OpaqueAlphaThreshold) {
+                continue;
+            }
+            left = qMin(left, x);
+            top = qMin(top, y);
+            right = qMax(right, x);
+            bottom = qMax(bottom, y);
+        }
+    }
+
+    if (right < 0) {
+        // 整张全透明。主机偶尔会用它表示"光标不可见"。
+        return metrics;
+    }
+
+    const int boxWidth = right - left + 1;
+    const int boxHeight = bottom - top + 1;
+
+    QVector<quint8> box(boxWidth * boxHeight, 0);
+    int opaqueCount = 0;
+    for (int y = 0; y < boxHeight; y++) {
+        for (int x = 0; x < boxWidth; x++) {
+            const qsizetype alphaIndex =
+                (static_cast<qsizetype>(y + top) * width + (x + left)) * 4 + 3;
+            if (pixels[alphaIndex] > OpaqueAlphaThreshold) {
+                box[y * boxWidth + x] = 1;
+                opaqueCount++;
+            }
+        }
+    }
+
+    metrics.boxWidth = boxWidth;
+    metrics.boxHeight = boxHeight;
+    metrics.fill = static_cast<qreal>(opaqueCount) / (boxWidth * boxHeight);
+    metrics.hotspotX = boxWidth > 1
+                           ? qBound(0.0,
+                                    static_cast<qreal>(hotspotX - left) / (boxWidth - 1),
+                                    1.0)
+                           : 0.0;
+    metrics.hotspotY = boxHeight > 1
+                           ? qBound(0.0,
+                                    static_cast<qreal>(hotspotY - top) / (boxHeight - 1),
+                                    1.0)
+                           : 0.0;
+
+    int matchV = 0;
+    int matchH = 0;
+    int matchRot180 = 0;
+    for (int y = 0; y < boxHeight; y++) {
+        for (int x = 0; x < boxWidth; x++) {
+            if (box[y * boxWidth + x] == box[y * boxWidth + (boxWidth - 1 - x)]) {
+                matchV++;
+            }
+            if (box[y * boxWidth + x] == box[(boxHeight - 1 - y) * boxWidth + x]) {
+                matchH++;
+            }
+            if (box[y * boxWidth + x] ==
+                box[(boxHeight - 1 - y) * boxWidth + (boxWidth - 1 - x)]) {
+                matchRot180++;
+            }
+        }
+    }
+    metrics.symV = static_cast<qreal>(matchV) / (boxWidth * boxHeight);
+    metrics.symH = static_cast<qreal>(matchH) / (boxWidth * boxHeight);
+    metrics.symRot180 = static_cast<qreal>(matchRot180) / (boxWidth * boxHeight);
+
+    qreal sumX = 0.0;
+    qreal sumY = 0.0;
+    qreal sumXX = 0.0;
+    qreal sumYY = 0.0;
+    qreal sumXY = 0.0;
+    for (int y = 0; y < boxHeight; y++) {
+        for (int x = 0; x < boxWidth; x++) {
+            if (box[y * boxWidth + x] == 0) {
+                continue;
+            }
+            sumX += x;
+            sumY += y;
+            sumXX += static_cast<qreal>(x) * x;
+            sumYY += static_cast<qreal>(y) * y;
+            sumXY += static_cast<qreal>(x) * y;
+        }
+    }
+    const qreal meanX = sumX / opaqueCount;
+    const qreal meanY = sumY / opaqueCount;
+    const qreal varX = sumXX / opaqueCount - meanX * meanX;
+    const qreal varY = sumYY / opaqueCount - meanY * meanY;
+    if (varX > 0.0 && varY > 0.0) {
+        const qreal covXY = sumXY / opaqueCount - meanX * meanY;
+        metrics.diagonalCorrelation =
+            qBound(-1.0, covXY / std::sqrt(varX * varY), 1.0);
+    }
+
+    // 正中那块的不透明占比。圆环中间是空的，四向箭头和十字的臂在中心交汇是实的。
+    const int centerLeft = boxWidth * 3 / 8;
+    const int centerTop = boxHeight * 3 / 8;
+    const int centerWidth = qMax(1, boxWidth / 4);
+    const int centerHeight = qMax(1, boxHeight / 4);
+    int centerOpaque = 0;
+    for (int y = centerTop; y < centerTop + centerHeight; y++) {
+        for (int x = centerLeft; x < centerLeft + centerWidth; x++) {
+            if (box[y * boxWidth + x] != 0) {
+                centerOpaque++;
+            }
+        }
+    }
+    metrics.centerFill =
+        static_cast<qreal>(centerOpaque) / (centerWidth * centerHeight);
+
+    QVector<int> rowWidths(boxHeight, 0);
+    for (int y = 0; y < boxHeight; y++) {
+        for (int x = 0; x < boxWidth; x++) {
+            if (box[y * boxWidth + x] != 0) {
+                rowWidths[y]++;
+            }
+        }
+    }
+
+    const qreal medianRow = medianOf(rowWidths);
+    const auto widestRow = std::max_element(rowWidths.cbegin(), rowWidths.cend());
+    const int maxRow = *widestRow;
+    const int widestRowIndex =
+        static_cast<int>(std::distance(rowWidths.cbegin(), widestRow));
+
+    const int topRows = qMax(1, boxHeight * 15 / 100);
+    int topSum = 0;
+    for (int y = 0; y < topRows; y++) {
+        topSum += rowWidths[y];
+    }
+    if (medianRow > 0.0) {
+        metrics.topWidthRatio = (static_cast<qreal>(topSum) / topRows) / medianRow;
+    }
+    if (maxRow > 0) {
+        metrics.firstRowRatio = static_cast<qreal>(rowWidths[0]) / maxRow;
+    }
+    if (boxHeight > 1) {
+        metrics.widestRowPosition =
+            static_cast<qreal>(widestRowIndex) / (boxHeight - 1);
+    }
+
+    const int upperHalf = qMax(1, boxHeight / 2);
+    for (int y = 0; y + 1 < upperHalf; y++) {
+        if (rowWidths[y + 1] < rowWidths[y]) {
+            metrics.topMonotoneViolations++;
+        }
+    }
+
+    metrics.valid = true;
+    return metrics;
+}
+
+NativeCursorShape classifyCursorShape(const CursorShapeMetrics& metrics)
+{
+    if (!metrics.valid) {
+        return NativeCursorShape::Unknown;
+    }
+
+    // >1 表示竖着长
+    const qreal tallness =
+        static_cast<qreal>(metrics.boxHeight) / metrics.boxWidth;
+    const bool centeredHotspot =
+        metrics.hotspotX >= 0.30 && metrics.hotspotX <= 0.70 &&
+        metrics.hotspotY >= 0.30 && metrics.hotspotY <= 0.70;
+    const bool nearSquare = tallness >= 0.80 && tallness <= 1.25;
+
+    // I 型：细长、左右对称、热点居中，而且第一行就是最宽的那道衬线。
+    // 最后那条不能松——上下双箭头同样细长、左右对称、热点也居中，两者只能靠
+    // "顶端是齐平的衬线"还是"顶端是尖的、最宽处在箭头根部"分开。
+    //
+    // tallness 这一档是照实测定的：Windows 64×64 的 I 型包围盒是 21×36，比值只有
+    // 1.71 —— 衬线相对整体高度比想象的宽。原先按 1.8 卡，真货全被挡在外面。
+    if (tallness >= 1.5 && metrics.fill <= 0.60 && metrics.symV >= 0.85 &&
+        centeredHotspot &&
+        metrics.firstRowRatio >= 0.90 && metrics.topWidthRatio >= 1.5) {
+        return NativeCursorShape::IBeam;
+    }
+
+    // 箭头：热点钉在左上角，顶端是尖的、三角头部自上而下变宽，左右明显不对称
+    if (metrics.hotspotX <= 0.20 && metrics.hotspotY <= 0.20 &&
+        tallness >= 1.15 && tallness <= 2.6 &&
+        metrics.symV <= 0.65 &&
+        metrics.firstRowRatio <= 0.35 &&
+        metrics.topMonotoneViolations <= 2) {
+        return NativeCursorShape::Arrow;
+    }
+
+    // 「后台忙」的箭头 + 转圈（IDC_APPSTARTING）。热点还钉在箭头尖上（包围盒最左），
+    // 但右上角多出来的圆环把盒子撑宽、也把热点在盒内的纵向位置压过了箭头那条
+    // hotspotY ≤ 0.20，所以跟上面的箭头天然互斥。
+    //
+    // 实测（Windows 64×64）：box=44x53 fill=0.446 hotspot=(0.00,0.29) symV=0.409
+    // corr=-0.540。corr 是负的，因为质量分成两坨——箭头在左侧竖着铺，圆环在右上角。
+    // 圈是转的，逐帧会抖，所以卡得紧的都是不随转动变化的量（包围盒、热点），corr 这
+    // 类会抖的只当个方向性的粗筛。
+    if (metrics.hotspotX <= 0.15 &&
+        metrics.hotspotY > 0.20 && metrics.hotspotY <= 0.45 &&
+        tallness >= 0.90 && tallness <= 1.60 &&
+        metrics.fill >= 0.25 && metrics.fill <= 0.65 &&
+        metrics.symV <= 0.70 &&
+        metrics.diagonalCorrelation <= -0.25) {
+        return NativeCursorShape::AppStarting;
+    }
+
+    // 手型：热点是食指指尖，在顶端偏中；从指尖往下张开成拳头，所以顶端窄、上半部分
+    // 基本单调变宽、最宽处落在下半部分。这是几条里最容易误判的一条，阈值卡得比别的
+    // 紧——没有后三项，任何一块顶部带热点的不规则色块都会被认成手型。
+    // symV 只用来挡掉左右完全对称的形状；真实的手型有拇指，本来就不对称。
+    if (tallness >= 0.85 && tallness <= 1.45 &&
+        metrics.hotspotY <= 0.20 &&
+        metrics.hotspotX >= 0.15 && metrics.hotspotX <= 0.60 &&
+        metrics.fill >= 0.35 && metrics.fill <= 0.80 &&
+        metrics.symV <= 0.90 &&
+        metrics.firstRowRatio <= 0.50 &&
+        metrics.widestRowPosition >= 0.40 &&
+        metrics.topMonotoneViolations <= 2) {
+        return NativeCursorShape::Hand;
+    }
+
+    // 剩下几种缩放光标的热点都在正中
+    if (!centeredHotspot) {
+        return NativeCursorShape::Unknown;
+    }
+
+    // 等待光标（IDC_WAIT）：一个中空的圈。
+    //
+    // 实测（Windows 64×64）：box=40x40 fill=0.570 hotspot=(0.51,0.51)
+    // symV=symH=symRot180=1.000 corr=0.000 widestRow=0.205。转的是亮度、alpha 掩码
+    // 是静止的整圈，所以逐帧度量完全一致，不用担心动画抖动。
+    //
+    // 十字和四向箭头同样是"近方形 + 四重对称 + 热点居中"，跟这条挤在一起，靠两点
+    // 分开：圈的填充率高得多，而且中心是空的（centerFill≈0，它们的臂在中心交汇）。
+    if (nearSquare &&
+        metrics.symV >= 0.90 && metrics.symH >= 0.90 &&
+        metrics.symRot180 >= 0.90 &&
+        metrics.fill >= 0.40 && metrics.fill <= 0.80 &&
+        metrics.centerFill <= 0.15) {
+        return NativeCursorShape::Wait;
+    }
+
+    // 左右双箭头
+    if (tallness <= 1.0 / 1.8 && metrics.symV >= 0.85 && metrics.symH >= 0.80) {
+        return NativeCursorShape::SizeWE;
+    }
+
+    // 上下双箭头。firstRowRatio 小说明顶端是尖的，把 I 型排除在外。
+    if (tallness >= 1.8 && metrics.symH >= 0.85 && metrics.symV >= 0.80 &&
+        metrics.firstRowRatio <= 0.60) {
+        return NativeCursorShape::SizeNS;
+    }
+
+    // 对角双箭头：整块质量沿某一条对角线铺开，用带符号的相关系数定方向。
+    // 十字、四向箭头、实心块这类没有方向性的形状相关系数接近 0，会落到
+    // Unknown 去画位图——正是我们要的保守行为。
+    if (nearSquare && metrics.fill <= 0.45 && metrics.symRot180 >= 0.85) {
+        if (metrics.diagonalCorrelation >= 0.70) {
+            return NativeCursorShape::SizeNWSE;
+        }
+        if (metrics.diagonalCorrelation <= -0.70) {
+            return NativeCursorShape::SizeNESW;
+        }
+    }
+
+    return NativeCursorShape::Unknown;
+}
+
+NativeCursorShape classifyCursorShape(int width,
+                                      int height,
+                                      int hotspotX,
+                                      int hotspotY,
+                                      const QByteArray& bgra)
+{
+    return classifyCursorShape(
+        measureCursorShape(width, height, hotspotX, hotspotY, bgra));
+}
+
+const char* nativeCursorShapeName(NativeCursorShape shape)
+{
+    switch (shape) {
+    case NativeCursorShape::Arrow:    return "arrow";
+    case NativeCursorShape::AppStarting: return "app-starting";
+    case NativeCursorShape::Wait:     return "wait";
+    case NativeCursorShape::IBeam:    return "ibeam";
+    case NativeCursorShape::Hand:     return "hand";
+    case NativeCursorShape::SizeWE:   return "size-we";
+    case NativeCursorShape::SizeNS:   return "size-ns";
+    case NativeCursorShape::SizeNWSE: return "size-nwse";
+    case NativeCursorShape::SizeNESW: return "size-nesw";
+    case NativeCursorShape::Unknown:  break;
+    }
+    return "unknown";
+}

--- a/app/streaming/input/cursorshapeclassifier.cpp
+++ b/app/streaming/input/cursorshapeclassifier.cpp
@@ -43,7 +43,7 @@ CursorShapeMetrics measureCursorShape(int width,
         return metrics;
     }
 
-    if (bgra.size() != static_cast<qsizetype>(width) * height * 4) {
+    if (bgra.size() != static_cast<qint64>(width) * height * 4) {
         return metrics;
     }
 
@@ -55,8 +55,7 @@ CursorShapeMetrics measureCursorShape(int width,
     int bottom = -1;
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-            const qsizetype alphaIndex =
-                (static_cast<qsizetype>(y) * width + x) * 4 + 3;
+            const int alphaIndex = (y * width + x) * 4 + 3;
             if (pixels[alphaIndex] <= OpaqueAlphaThreshold) {
                 continue;
             }
@@ -79,8 +78,7 @@ CursorShapeMetrics measureCursorShape(int width,
     int opaqueCount = 0;
     for (int y = 0; y < boxHeight; y++) {
         for (int x = 0; x < boxWidth; x++) {
-            const qsizetype alphaIndex =
-                (static_cast<qsizetype>(y + top) * width + (x + left)) * 4 + 3;
+            const int alphaIndex = ((y + top) * width + (x + left)) * 4 + 3;
             if (pixels[alphaIndex] > OpaqueAlphaThreshold) {
                 box[y * boxWidth + x] = 1;
                 opaqueCount++;

--- a/app/streaming/input/cursorshapeclassifier.h
+++ b/app/streaming/input/cursorshapeclassifier.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <QByteArray>
+
+// 主机推来的光标只有裸 BGRA 位图和一个不透明的 shapeId，协议里没有"这是箭头还是
+// I 型"的语义。为了在本地能换成系统原生光标（风格跟客户端一致、Retina 下天然清晰），
+// 我们只能从位图本身把标准形状认出来。
+//
+// 识别用的是尺度无关的几何特征——包围盒长宽比、填充率、热点在包围盒里的相对位置、
+// 各轴对称性、行宽剖面——而不是逐像素指纹。主机的光标会随 Windows 主题和 DPI 缩放
+// 在 32/48/64 像素几档之间变化，指纹匹配在这几档之间不成立，几何特征则基本恒定。
+//
+// 只认几何签名足够分得开的那几种：箭头、"箭头 + 转圈"、转圈、I 型、手型、上下/左右/
+// 两个对角的缩放箭头。十字（IDC_CROSS）和四向箭头（IDC_SIZEALL）都是"近方形 + 四重
+// 对称 + 细线"，几何上挤在一起分不干净，故意不认，让它们走位图。判不准就返回
+// Unknown，调用方回退到画主机位图——宁可回退，不要给错形状。
+
+enum class NativeCursorShape {
+    Unknown,
+    Arrow,
+    // IDC_APPSTARTING：箭头右上角挂个转圈。macOS 有对应的原生货（HIServices 里的
+    // busybutclickable），SDL 的 SDL_SYSTEM_CURSOR_WAITARROW 就是它。
+    AppStarting,
+    // IDC_WAIT：只有一个转圈，没有箭头
+    Wait,
+    IBeam,
+    Hand,
+    SizeWE,
+    SizeNS,
+    SizeNWSE,
+    SizeNESW,
+};
+
+// 分类用到的中间量。单独暴露出来是为了能在单测里断言，以及在流里按日志打出来——
+// 现场遇到误判时，照着日志调阈值比重新猜一遍要快。
+struct CursorShapeMetrics {
+    bool valid = false;
+
+    // 不透明像素的包围盒尺寸
+    int boxWidth = 0;
+    int boxHeight = 0;
+    // 包围盒内不透明像素占比
+    qreal fill = 0.0;
+    // 热点在包围盒内的归一化坐标，[0,1]；落在盒外时会被裁到边界
+    qreal hotspotX = 0.0;
+    qreal hotspotY = 0.0;
+    // 对称度，[0,1]：竖轴镜像、横轴镜像、绕中心旋转 180°
+    qreal symV = 0.0;
+    qreal symH = 0.0;
+    qreal symRot180 = 0.0;
+    // 不透明像素坐标的皮尔逊相关系数，[-1,1]。沿左上-右下方向的形状为正，
+    // 右上-左下为负，十字/方块/四向箭头这类无方向性的接近 0。
+    //
+    // 注意不能用"对某条对角线转置是否不变"来区分两个对角光标：绕任一条对角线
+    // 做镜像，两条对角线都映射回自身，两者的转置对称度都是 1。方向性只能靠
+    // 相关系数这种带符号的量来测。
+    qreal diagonalCorrelation = 0.0;
+    // 包围盒正中那块（各边取 1/4 宽高）的不透明占比。用来分辨"中空"和"中心是实的"：
+    // 圆环（等待光标）中间是空的，而四向箭头和十字的臂在中心交汇，是实的。
+    qreal centerFill = 0.0;
+    // 顶部 15% 的平均行宽 / 中位行宽
+    qreal topWidthRatio = 0.0;
+    // 第一行行宽 / 最大行宽。I 型的顶端就是最宽的那道衬线（≈1），而上下双箭头的
+    // 顶端是尖的、最宽处在箭头根部（明显 <1）。这两种都是细长 + 左右对称 + 热点
+    // 居中，全靠这一项分开。手型和箭头的顶端也都是尖的。
+    qreal firstRowRatio = 0.0;
+    // 最宽那一行的位置，归一化到 [0,1]。手型是"食指压在拳头上"，最宽处在下半部分；
+    // I 型最宽处在第 0 行，上下双箭头在靠近顶端的箭头根部。
+    qreal widestRowPosition = 0.0;
+    // 上半部分行宽出现"变窄"的次数。箭头的三角头部应该接近单调变宽
+    int topMonotoneViolations = 0;
+};
+
+CursorShapeMetrics measureCursorShape(int width,
+                                      int height,
+                                      int hotspotX,
+                                      int hotspotY,
+                                      const QByteArray& bgra);
+
+NativeCursorShape classifyCursorShape(const CursorShapeMetrics& metrics);
+
+// bgra 为紧打包的 BGRA8888，长度须等于 width * height * 4
+NativeCursorShape classifyCursorShape(int width,
+                                      int height,
+                                      int hotspotX,
+                                      int hotspotY,
+                                      const QByteArray& bgra);
+
+const char* nativeCursorShapeName(NativeCursorShape shape);

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -431,10 +431,16 @@ void SdlInputHandler::applyCapturedCursorState()
     SDL_ShowCursor(getCapturedCursorVisibilityState());
 }
 
-Uint32 SdlInputHandler::remoteCursorHideTimerCallback(Uint32, void*)
+Uint32 SdlInputHandler::remoteCursorHideTimerCallback(Uint32 interval, void*)
 {
     // 定时器跑在 SDL 的定时器线程上，macOS 要求光标接口只在主线程调，绕回主循环去做
-    Session::queueCursorVisibilityFlush();
+    if (!Session::queueCursorVisibilityFlush()) {
+        // 事件队列满了。这里必须重试而不是就此收工：定时器一停，
+        // m_RemoteCursorHideTimer 就永远卡在一个已过期的 ID 上，
+        // updateRemoteCursorVisibility() 之后每次隐藏请求都会被那道
+        // "已经在等了" 的短路挡掉，直到主机下次说要显示才解开。
+        return interval;
+    }
     return 0;
 }
 

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -25,6 +25,60 @@
 #pragma comment(lib, "imm32.lib")
 #endif
 
+namespace {
+
+// 主机推来的标准光标默认换成本机的系统光标。设 MOONLIGHT_NATIVE_CURSOR=0 可以不
+// 重编就退回旧行为，用来确认某个形状是不是被认错了。
+bool nativeCursorSubstitutionEnabled()
+{
+    static const bool enabled =
+        qEnvironmentVariable("MOONLIGHT_NATIVE_CURSOR") != QStringLiteral("0");
+    return enabled;
+}
+
+bool toSdlSystemCursor(NativeCursorShape shape, SDL_SystemCursor& systemCursor)
+{
+    switch (shape) {
+    case NativeCursorShape::Arrow:
+        systemCursor = SDL_SYSTEM_CURSOR_ARROW;
+        return true;
+    case NativeCursorShape::AppStarting:
+        // SDL 的 Cocoa 后端把它映射到 HIServices 的 busybutclickable —— 正是 macOS
+        // 自己那只"箭头 + 转圈"。不会转（SDL 不支持动画光标），但风格是对的。
+        systemCursor = SDL_SYSTEM_CURSOR_WAITARROW;
+        return true;
+    case NativeCursorShape::Wait:
+        // SDL 的 Cocoa 后端把 WAIT 和 WAITARROW 映射到同一只 busybutclickable，所以
+        // 主机只有一个圈时，本机显示的是"箭头 + 转圈"。macOS 没有纯转圈的公开光标
+        // （沙滩球由 WindowServer 画，设不了），这已经是最接近的原生表达。
+        systemCursor = SDL_SYSTEM_CURSOR_WAIT;
+        return true;
+    case NativeCursorShape::IBeam:
+        systemCursor = SDL_SYSTEM_CURSOR_IBEAM;
+        return true;
+    case NativeCursorShape::Hand:
+        systemCursor = SDL_SYSTEM_CURSOR_HAND;
+        return true;
+    case NativeCursorShape::SizeWE:
+        systemCursor = SDL_SYSTEM_CURSOR_SIZEWE;
+        return true;
+    case NativeCursorShape::SizeNS:
+        systemCursor = SDL_SYSTEM_CURSOR_SIZENS;
+        return true;
+    case NativeCursorShape::SizeNWSE:
+        systemCursor = SDL_SYSTEM_CURSOR_SIZENWSE;
+        return true;
+    case NativeCursorShape::SizeNESW:
+        systemCursor = SDL_SYSTEM_CURSOR_SIZENESW;
+        return true;
+    case NativeCursorShape::Unknown:
+        break;
+    }
+    return false;
+}
+
+} // namespace
+
 SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, int streamHeight)
     : m_MultiController(prefs.multiController),
       m_GamepadMouse(prefs.gamepadMouse),
@@ -45,8 +99,10 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
                             LI_CURSOR_MODE_LOCAL : LI_CURSOR_MODE_VIDEO),
       m_RemoteCursorVisible(true),
       m_RemoteCursor(nullptr),
+      m_LastCursorClass(NativeCursorShape::Unknown),
       m_HasLastCursorShape(false),
       m_RemoteCursorScale(1.0),
+      m_RemoteCursorHideTimer(0),
       m_LongPressTimer(0),
       m_StreamWidth(streamWidth),
       m_StreamHeight(streamHeight),
@@ -297,7 +353,7 @@ SdlInputHandler::~SdlInputHandler()
     SDL_RemoveTimer(m_LeftButtonReleaseTimer);
     SDL_RemoveTimer(m_RightButtonReleaseTimer);
     SDL_RemoveTimer(m_DragTimer);
-
+    SDL_RemoveTimer(m_RemoteCursorHideTimer);
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_QuitSubSystem(SDL_INIT_HAPTIC);
     SDL_assert(!SDL_WasInit(SDL_INIT_HAPTIC));
@@ -375,8 +431,63 @@ void SdlInputHandler::applyCapturedCursorState()
     SDL_ShowCursor(getCapturedCursorVisibilityState());
 }
 
+Uint32 SdlInputHandler::remoteCursorHideTimerCallback(Uint32, void*)
+{
+    // 定时器跑在 SDL 的定时器线程上，macOS 要求光标接口只在主线程调，绕回主循环去做
+    Session::queueCursorVisibilityFlush();
+    return 0;
+}
+
+void SdlInputHandler::cancelPendingRemoteCursorHide()
+{
+    if (m_RemoteCursorHideTimer != 0) {
+        SDL_RemoveTimer(m_RemoteCursorHideTimer);
+        m_RemoteCursorHideTimer = 0;
+    }
+}
+
+void SdlInputHandler::updateRemoteCursorVisibility(bool visible)
+{
+    if (visible) {
+        // 显示立即生效，同时把还没到期的隐藏作废
+        cancelPendingRemoteCursorHide();
+        m_RemoteCursorVisible = true;
+        return;
+    }
+
+    // 已经藏了，或者已经在等这次隐藏坐实
+    if (!m_RemoteCursorVisible || m_RemoteCursorHideTimer != 0) {
+        return;
+    }
+
+    m_RemoteCursorHideTimer = SDL_AddTimer(REMOTE_CURSOR_HIDE_DEBOUNCE_MS,
+                                           remoteCursorHideTimerCallback,
+                                           this);
+    if (m_RemoteCursorHideTimer == 0) {
+        // 定时器起不来就立即生效。宁可闪，也不能把主机要求藏起来的光标留在屏上。
+        m_RemoteCursorVisible = false;
+    }
+}
+
+void SdlInputHandler::flushPendingRemoteCursorHide()
+{
+    if (m_RemoteCursorHideTimer == 0) {
+        // 事件还在队列里排着的时候主机又说要显示，这次隐藏已经作废了
+        return;
+    }
+
+    m_RemoteCursorHideTimer = 0;
+    m_RemoteCursorVisible = false;
+
+    if (isCaptureActive()) {
+        applyCapturedCursorState();
+    }
+}
+
 void SdlInputHandler::resetRemoteCursor()
 {
+    cancelPendingRemoteCursorHide();
+
     if (m_RemoteCursor == nullptr) {
         return;
     }
@@ -386,6 +497,82 @@ void SdlInputHandler::resetRemoteCursor()
     }
     SDL_FreeCursor(m_RemoteCursor);
     m_RemoteCursor = nullptr;
+}
+
+void SdlInputHandler::installRemoteCursor(SDL_Cursor* cursor)
+{
+    SDL_Cursor* old = m_RemoteCursor;
+    m_RemoteCursor = cursor;
+
+    // 先把新光标装上，再放掉旧的。反过来的话释放的正是当前光标，SDL 会先跳回默认
+    // 光标，于是每次换形状都能看见一帧默认箭头 —— 主机在两个形状之间来回推时（鼠标
+    // 压在文本框边界上就会）这一帧就成了肉眼可见的闪烁。
+    if (old != nullptr && SDL_GetCursor() == old) {
+        SDL_SetCursor(cursor);
+    }
+    SDL_FreeCursor(old);
+}
+
+bool SdlInputHandler::tryUseNativeRemoteCursor(const RemoteCursorUpdate& update)
+{
+    const CursorShapeMetrics metrics =
+        nativeCursorSubstitutionEnabled()
+            ? measureCursorShape(update.width, update.height,
+                                 update.hotspotX, update.hotspotY, update.bgra)
+            : CursorShapeMetrics();
+    const NativeCursorShape shape = classifyCursorShape(metrics);
+
+    if (shape != m_LastCursorClass) {
+        // 认不出来的时候把度量全量打出来，好照着实测数字调阈值——否则只知道"没认
+        // 出来"，看不出被哪条判据挡掉了。走 verbose，默认日志级别下不出现；只在结果
+        // 变化时打，所以游戏里逐帧变的自绘光标也不会刷屏。
+        if (shape == NativeCursorShape::Unknown && metrics.valid) {
+            SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION,
+                           "Unclassified remote cursor %ux%u: "
+                           "box=%dx%d fill=%.3f hotspot=(%.2f,%.2f) "
+                           "symV=%.3f symH=%.3f symRot180=%.3f corr=%.3f "
+                           "centerFill=%.3f firstRow=%.3f widestRow=%.3f "
+                           "topWidth=%.3f violations=%d",
+                           update.width, update.height,
+                           metrics.boxWidth, metrics.boxHeight, metrics.fill,
+                           metrics.hotspotX, metrics.hotspotY,
+                           metrics.symV, metrics.symH, metrics.symRot180,
+                           metrics.diagonalCorrelation,
+                           metrics.centerFill,
+                           metrics.firstRowRatio, metrics.widestRowPosition,
+                           metrics.topWidthRatio, metrics.topMonotoneViolations);
+        }
+
+        m_LastCursorClass = shape;
+    }
+    else if (shape != NativeCursorShape::Unknown && m_RemoteCursor != nullptr) {
+        // 同一种系统光标已经装着了。主机会反复推同一个形状，这里挡掉重建。
+        return true;
+    }
+
+    SDL_SystemCursor systemCursor;
+    if (!toSdlSystemCursor(shape, systemCursor)) {
+        return false;
+    }
+
+    SDL_Cursor* cursor = SDL_CreateSystemCursor(systemCursor);
+    if (cursor == nullptr) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Failed to create system cursor %d: %s",
+                    (int)systemCursor, SDL_GetError());
+        // 别让上面那条"同一形状就短路"的分支把这次失败当成已经装好了
+        m_LastCursorClass = NativeCursorShape::Unknown;
+        return false;
+    }
+
+    // 热点由系统光标自带，主机推来的热点在这条路径上忽略
+    installRemoteCursor(cursor);
+
+    // 系统光标的尺寸由系统自己管，不受窗口 backing 比例影响，所以不必留着形状
+    // 等换屏时重建 —— 顺带让 refreshRemoteCursorScale() 直接短路掉。
+    m_HasLastCursorShape = false;
+    m_RemoteCursorScale = getRemoteCursorScale();
+    return true;
 }
 
 void SdlInputHandler::synchronizeLocalCursorMode()
@@ -409,6 +596,7 @@ void SdlInputHandler::synchronizeLocalCursorMode()
     else {
         // The host will immediately send the authoritative state. Keep the
         // default cursor visible until that update arrives.
+        cancelPendingRemoteCursorHide();
         m_RemoteCursorVisible = true;
     }
 }
@@ -465,7 +653,7 @@ void SdlInputHandler::refreshRemoteCursorScale()
 
 void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
 {
-    m_RemoteCursorVisible = update.visible;
+    updateRemoteCursorVisibility(update.visible);
 
     if (update.hasShape) {
         const qsizetype expectedSize =
@@ -478,7 +666,7 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
                         "Ignoring invalid remote cursor shape %u",
                         update.shapeId);
         }
-        else {
+        else if (!tryUseNativeRemoteCursor(update)) {
             int cursorWidth = update.width;
             int cursorHeight = update.height;
             int hotspotX = update.hotspotX;
@@ -502,11 +690,15 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
                         update.height,
                         update.width * 4,
                         QImage::Format_ARGB32);
-                    scaledCursor = source.scaled(
-                        cursorWidth,
-                        cursorHeight,
-                        Qt::IgnoreAspectRatio,
-                        Qt::SmoothTransformation);
+                    // 先转预乘再缩。直接对直通 alpha 做 SmoothTransformation 的话，
+                    // Qt 会把全透明像素里的黑色一起插值进来，缩完边缘一圈发暗。
+                    scaledCursor = source
+                                       .convertToFormat(QImage::Format_ARGB32_Premultiplied)
+                                       .scaled(cursorWidth,
+                                               cursorHeight,
+                                               Qt::IgnoreAspectRatio,
+                                               Qt::SmoothTransformation)
+                                       .convertToFormat(QImage::Format_ARGB32);
                     cursorPixels = reinterpret_cast<const char*>(scaledCursor.constBits());
                     cursorPitch = scaledCursor.bytesPerLine();
                 }
@@ -535,8 +727,7 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
                                 SDL_GetError());
                 }
                 else {
-                    resetRemoteCursor();
-                    m_RemoteCursor = cursor;
+                    installRemoteCursor(cursor);
 
                     // 记下这一份形状和它用的缩放比例。换显示器时靠它重建 ——
                     // 主机不会因为我们换了屏就重推一次形状。

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -662,8 +662,8 @@ void SdlInputHandler::updateRemoteCursor(const RemoteCursorUpdate& update)
     updateRemoteCursorVisibility(update.visible);
 
     if (update.hasShape) {
-        const qsizetype expectedSize =
-            static_cast<qsizetype>(update.width) * update.height * 4;
+        const qint64 expectedSize =
+            static_cast<qint64>(update.width) * update.height * 4;
         if (update.width == 0 || update.height == 0 ||
             update.hotspotX < 0 || update.hotspotX >= update.width ||
             update.hotspotY < 0 || update.hotspotY >= update.height ||

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -2,6 +2,7 @@
 
 #include "settings/streamingpreferences.h"
 #include "backend/computermanager.h"
+#include "cursorshapeclassifier.h"
 
 #include "SDL_compat.h"
 
@@ -90,6 +91,12 @@ struct DualSenseOutputReport{
 
 #define TOUCHPAD_SCROLL_SUPPRESSION_TIMEOUT_MS 500
 
+// 主机（至少 Sunshine + DXGI 桌面复制）会把"光标可见"这一位翻来翻去：实测每秒五到
+// 十次成对的 hidden → shown，形状和 shapeId 都没变。照做就是肉眼可见的闪烁。所以隐藏
+// 要等它稳定这么久才生效，显示立即生效 —— 真正的隐藏（游戏自己藏光标）会一直保持，
+// 只是晚这么点生效，看不出来；而成对的抖动会被整段吞掉。
+#define REMOTE_CURSOR_HIDE_DEBOUNCE_MS 150
+
 #ifdef HAVE_MACOS_NATIVE_TOUCHPAD
 // macOS reports trackpad contacts and promoted mouse clicks through separate
 // SDL event paths. Keep the click correlation window deliberately short to
@@ -168,6 +175,9 @@ public:
 
     void flushPendingTouchpadFrameEvent();
 
+    // 去抖窗口到期，把主机要求的隐藏落实下去
+    void flushPendingRemoteCursorHide();
+
     int getAttachedGamepadMask();
 
     void raiseAllKeys(bool clearKeys = true);
@@ -234,7 +244,6 @@ public:
 private:
     qreal getRemoteCursorScale() const;
 
-
     GamepadState*
     findStateForGamepad(SDL_JoystickID id);
 
@@ -269,6 +278,18 @@ private:
     void applyCapturedCursorState();
 
     void resetRemoteCursor();
+
+    // 换上新的远端光标并接手它的所有权，顺带放掉旧的那只
+    void installRemoteCursor(SDL_Cursor* cursor);
+
+    // 认位图里的标准形状，认出来就换成本机的系统光标。返回 false 表示没认出来，
+    // 调用方该回退去画主机位图。
+    bool tryUseNativeRemoteCursor(const RemoteCursorUpdate& update);
+
+    // 应用主机推来的显隐状态：显示立即生效，隐藏要等去抖窗口坐实。
+    void updateRemoteCursorVisibility(bool visible);
+
+    void cancelPendingRemoteCursorHide();
 
     struct NativeTouchpadContact {
         uint8_t eventType;
@@ -328,6 +349,9 @@ private:
     static
     Uint32 dragTimerCallback(Uint32 interval, void* param);
 
+    static
+    Uint32 remoteCursorHideTimerCallback(Uint32 interval, void* param);
+
     SDL_Window* m_Window;
     bool m_MultiController;
     bool m_GamepadMouse;
@@ -356,10 +380,16 @@ private:
     std::atomic<int> m_LocalCursorMode;
     bool m_RemoteCursorVisible;
     SDL_Cursor* m_RemoteCursor;
-    // 最后一份成功建出光标的形状，以及当时用的 backing 比例
+    // 上一次的识别结果。用来挡掉"主机重复推同一形状"时的无谓重建，也用来只在结果
+    // 变化时打一次未识别的度量日志。
+    NativeCursorShape m_LastCursorClass;
+    // 最后一份成功建出光标的位图形状，以及当时用的 backing 比例。换成系统光标时会
+    // 清掉 m_HasLastCursorShape —— 系统光标不受 backing 比例影响，不需要重建。
     RemoteCursorUpdate m_LastCursorShape;
     bool m_HasLastCursorShape;
     qreal m_RemoteCursorScale;
+    // 隐藏的去抖定时器。见 updateRemoteCursorVisibility()。
+    SDL_TimerID m_RemoteCursorHideTimer;
 
     struct {
         KeyCombo keyCombo;

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -40,6 +40,7 @@
 #define SDL_CODE_GAMECONTROLLER_SET_ADAPTIVE_TRIGGERS 105
 #define SDL_CODE_FLUSH_TOUCHPAD_FRAME 106
 #define SDL_CODE_CURSOR_UPDATE 107
+#define SDL_CODE_FLUSH_CURSOR_VISIBILITY 108
 
 #include <openssl/rand.h>
 
@@ -409,6 +410,16 @@ bool Session::queueTouchpadFrameFlush()
     SDL_Event flushEvent = {};
     flushEvent.type = SDL_USEREVENT;
     flushEvent.user.code = SDL_CODE_FLUSH_TOUCHPAD_FRAME;
+    return SDL_PushEvent(&flushEvent) > 0;
+}
+
+bool Session::queueCursorVisibilityFlush()
+{
+    // Called from SDL's timer thread. Cursor APIs must run on the main thread on
+    // macOS, so bounce back through the event loop.
+    SDL_Event flushEvent = {};
+    flushEvent.type = SDL_USEREVENT;
+    flushEvent.user.code = SDL_CODE_FLUSH_CURSOR_VISIBILITY;
     return SDL_PushEvent(&flushEvent) > 0;
 }
 
@@ -3845,6 +3856,11 @@ void Session::exec()
                 break;
             case SDL_CODE_FLUSH_TOUCHPAD_FRAME:
                 m_InputHandler->flushPendingTouchpadFrameEvent();
+                break;
+            case SDL_CODE_FLUSH_CURSOR_VISIBILITY:
+                if (m_InputHandler != nullptr) {
+                    m_InputHandler->flushPendingRemoteCursorHide();
+                }
                 break;
             case SDL_CODE_CURSOR_UPDATE:
             {

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -209,6 +209,9 @@ private:
     static
     bool queueTouchpadFrameFlush();
 
+    static
+    bool queueCursorVisibilityFlush();
+
     void updateOptimalWindowDisplayMode();
 
     enum class DecoderAvailability {

--- a/tests/cursor_shape_classification/cursor_shape_classification.pro
+++ b/tests/cursor_shape_classification/cursor_shape_classification.pro
@@ -1,0 +1,16 @@
+QT += core
+CONFIG += c++17 console
+CONFIG -= app_bundle
+
+TARGET = cursor_shape_classification
+TEMPLATE = app
+
+INCLUDEPATH += \
+    $$PWD/../../app
+
+SOURCES += \
+    main.cpp \
+    ../../app/streaming/input/cursorshapeclassifier.cpp
+
+HEADERS += \
+    ../../app/streaming/input/cursorshapeclassifier.h

--- a/tests/cursor_shape_classification/main.cpp
+++ b/tests/cursor_shape_classification/main.cpp
@@ -1,0 +1,478 @@
+#include "streaming/input/cursorshapeclassifier.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QTextStream>
+
+namespace {
+
+// 一张 BGRA8888 画布，只用来搭合成光标。所有不透明像素都画成白色——分类器只看
+// alpha，颜色不参与判断。
+class Canvas
+{
+public:
+    Canvas(int width, int height)
+        : m_width(width),
+          m_height(height),
+          m_data(static_cast<qsizetype>(width) * height * 4, '\0')
+    {
+    }
+
+    void plot(int x, int y)
+    {
+        if (x < 0 || y < 0 || x >= m_width || y >= m_height) {
+            return;
+        }
+        const qsizetype index = (static_cast<qsizetype>(y) * m_width + x) * 4;
+        m_data[index + 0] = static_cast<char>(0xFF); // B
+        m_data[index + 1] = static_cast<char>(0xFF); // G
+        m_data[index + 2] = static_cast<char>(0xFF); // R
+        m_data[index + 3] = static_cast<char>(0xFF); // A
+    }
+
+    void plotRow(int y, int x0, int width)
+    {
+        for (int x = x0; x < x0 + width; x++) {
+            plot(x, y);
+        }
+    }
+
+    int width() const { return m_width; }
+    int height() const { return m_height; }
+    const QByteArray& data() const { return m_data; }
+
+private:
+    int m_width;
+    int m_height;
+    QByteArray m_data;
+};
+
+// Windows 标准箭头的骨架：热点在左上角，三角头部自上而下变宽，接着一条偏右的尾巴
+Canvas makeArrow(int s)
+{
+    Canvas canvas(32 * s, 32 * s);
+
+    const int headRows = 12 * s;
+    const int totalRows = 19 * s;
+    const int maxWidth = 11 * s;
+
+    for (int y = 0; y < totalRows; y++) {
+        if (y < headRows) {
+            const int width = 1 + (maxWidth - 1) * y / (headRows - 1);
+            canvas.plotRow(y, 0, width);
+        }
+        else {
+            const int tailRows = totalRows - headRows;
+            const int width = qMax(1, 6 * s - (y - headRows) * (4 * s) / tailRows);
+            canvas.plotRow(y, 3 * s, width);
+        }
+    }
+
+    return canvas;
+}
+
+// I 型：上下两道齐平的衬线夹一条细竖杆。
+//
+// 比例照实测的真货来：Sunshine 推的 Windows 64×64 I 型，不透明包围盒 21×36、
+// fill≈0.444、topWidthRatio≈4.12。衬线相对整体高度比直觉宽得多（比值只有 1.71），
+// 早先按一个瘦长的 7×20 合成体来定阈值，真货全被挡在外面了。
+Canvas makeIBeam(int s)
+{
+    Canvas canvas(64 * s, 64 * s);
+
+    const int totalRows = 36 * s;
+    const int serifWidth = 21 * s;
+    const int serifRows = 5 * s;
+    const int barWidth = 5 * s;
+    const int barLeft = (serifWidth - barWidth) / 2;
+
+    for (int y = 0; y < totalRows; y++) {
+        if (y < serifRows || y >= totalRows - serifRows) {
+            canvas.plotRow(y, 0, serifWidth);
+        }
+        else {
+            canvas.plotRow(y, barLeft, barWidth);
+        }
+    }
+
+    return canvas;
+}
+
+// 上下双箭头：两端是尖的，最宽处在箭头根部，中间一条细杆
+Canvas makeSizeNS(int s)
+{
+    Canvas canvas(32 * s, 32 * s);
+
+    const int totalRows = 20 * s;
+    const int boxWidth = 9 * s;
+    const int stemWidth = 3 * s;
+    const int arrowRows = 4 * s;
+
+    for (int y = 0; y < totalRows; y++) {
+        const int d = qMin(y, totalRows - 1 - y);
+        int width = stemWidth;
+        if (d < arrowRows) {
+            width = stemWidth +
+                    (boxWidth - stemWidth) * d / (arrowRows - 1);
+            // 保持奇数宽度，才能在 boxWidth 里精确居中
+            if ((width % 2) != (boxWidth % 2)) {
+                width++;
+            }
+        }
+        canvas.plotRow(y, (boxWidth - width) / 2, width);
+    }
+
+    return canvas;
+}
+
+// 左右双箭头 = 上下双箭头转置
+Canvas makeSizeWE(int s)
+{
+    const Canvas source = makeSizeNS(s);
+    Canvas canvas(source.width(), source.height());
+
+    const uchar* pixels = reinterpret_cast<const uchar*>(source.data().constData());
+    for (int y = 0; y < source.height(); y++) {
+        for (int x = 0; x < source.width(); x++) {
+            const qsizetype index =
+                (static_cast<qsizetype>(y) * source.width() + x) * 4 + 3;
+            if (pixels[index] != 0) {
+                canvas.plot(y, x);
+            }
+        }
+    }
+
+    return canvas;
+}
+
+// 沿主对角线（左上-右下）的双箭头。按主对角转置对称地构造，两端各带一个 L 形箭头。
+Canvas makeSizeNWSE(int s, bool mirrored)
+{
+    const int extent = 16 * s;
+    const int headLength = 5 * s;
+    Canvas canvas(32 * s, 32 * s);
+
+    auto plot = [&](int x, int y) {
+        canvas.plot(mirrored ? (extent - 1 - x) : x, y);
+    };
+
+    for (int i = 0; i < extent; i++) {
+        plot(i, i);
+        if (i + 1 < extent) {
+            plot(i + 1, i);
+            plot(i, i + 1);
+        }
+    }
+
+    for (int k = 0; k < headLength; k++) {
+        plot(k, 0);
+        plot(k, 1);
+        plot(0, k);
+        plot(1, k);
+        plot(extent - 1 - k, extent - 1);
+        plot(extent - 1 - k, extent - 2);
+        plot(extent - 1, extent - 1 - k);
+        plot(extent - 2, extent - 1 - k);
+    }
+
+    return canvas;
+}
+
+// 手型：一根食指立在拳头上，指尖偏左于整体中线
+Canvas makeHand(int s)
+{
+    Canvas canvas(32 * s, 32 * s);
+
+    const int boxWidth = 20 * s;
+    const int fingerWidth = 4 * s;
+    const int fingerLeft = 6 * s;
+    const int fingerRows = 8 * s;
+    const int flareRows = 3 * s;
+    const int totalRows = 22 * s;
+
+    for (int y = 0; y < totalRows; y++) {
+        if (y < fingerRows) {
+            canvas.plotRow(y, fingerLeft, fingerWidth);
+        }
+        else if (y < fingerRows + flareRows) {
+            // 手掌张开的过渡段
+            const int step = y - fingerRows + 1;
+            const int width = fingerWidth +
+                              (boxWidth - fingerWidth) * step / (flareRows + 1);
+            canvas.plotRow(y, (boxWidth - width) / 2, width);
+        }
+        else {
+            canvas.plotRow(y, 0, boxWidth);
+        }
+    }
+
+    return canvas;
+}
+
+// 箭头 + 右上角一个转圈（IDC_APPSTARTING）。
+//
+// 比例照实测：Windows 64×64 这只的包围盒是 44×53，热点归一化到 (0.00, 0.29)。热点
+// 的纵向位置不是 0，是因为那个圈比箭头尖还高——包围盒的顶边是圈的顶，箭头尖在它
+// 下面约 15 像素处。corr≈-0.54 也来自这个布局：质量分两坨，箭头在左侧竖着铺，圈在
+// 右上角。
+Canvas makeAppStarting(int s, int& hotspotX, int& hotspotY)
+{
+    Canvas canvas(64 * s, 64 * s);
+
+    // 右上角的圈，顶边就是整体包围盒的顶边
+    const int cx = 30 * s;
+    const int cy = 13 * s;
+    const int outer = 13 * s;
+    const int inner = 5 * s;
+    for (int y = cy - outer; y <= cy + outer; y++) {
+        for (int x = cx - outer; x <= cx + outer; x++) {
+            const int dx = x - cx;
+            const int dy = y - cy;
+            const int d2 = dx * dx + dy * dy;
+            if (d2 <= outer * outer && d2 >= inner * inner) {
+                canvas.plot(x, y);
+            }
+        }
+    }
+
+    // 左边那只箭头，比普通箭头粗一圈（64 像素档的实际观感），尖端压在圈的下方
+    const int arrowTop = 15 * s;
+    const int totalRows = 38 * s;
+    const int headRows = 24 * s;
+    const int maxWidth = 22 * s;
+    for (int y = 0; y < totalRows; y++) {
+        if (y < headRows) {
+            const int width = 1 + (maxWidth - 1) * y / (headRows - 1);
+            canvas.plotRow(arrowTop + y, 0, width);
+        }
+        else {
+            const int tailRows = totalRows - headRows;
+            const int width = qMax(1, 12 * s - (y - headRows) * (8 * s) / tailRows);
+            canvas.plotRow(arrowTop + y, 7 * s, width);
+        }
+    }
+
+    hotspotX = 0;
+    hotspotY = arrowTop;
+    return canvas;
+}
+
+// 等待光标：一个中空的圈。
+//
+// 比例照实测：Windows 64×64 这只的包围盒是 40×40、fill≈0.570，反推内圈半径约为外圈
+// 的 0.52。
+Canvas makeWait(int s)
+{
+    Canvas canvas(64 * s, 64 * s);
+
+    const int size = 40 * s;
+    const qreal center = (size - 1) / 2.0;
+    const qreal outer = size / 2.0;
+    const qreal inner = outer * 0.524;
+
+    for (int y = 0; y < size; y++) {
+        for (int x = 0; x < size; x++) {
+            const qreal dx = x - center;
+            const qreal dy = y - center;
+            const qreal d2 = dx * dx + dy * dy;
+            if (d2 <= outer * outer && d2 >= inner * inner) {
+                canvas.plot(x, y);
+            }
+        }
+    }
+
+    return canvas;
+}
+
+// 四向箭头（IDC_SIZEALL）和十字（IDC_CROSS）：跟等待光标同样是近方形 + 四重对称 +
+// 热点居中，故意不认。它们的臂在中心交汇，中心是实的，正是靠这一点跟圈分开的。
+Canvas makeSizeAll(int s)
+{
+    Canvas canvas(64 * s, 64 * s);
+
+    const int size = 32 * s;
+    const int arm = 5 * s;
+    const int head = 9 * s;
+    const int mid = size / 2;
+
+    for (int y = mid - arm / 2; y < mid - arm / 2 + arm; y++) {
+        canvas.plotRow(y, 0, size);
+    }
+    for (int y = 0; y < size; y++) {
+        canvas.plotRow(y, mid - arm / 2, arm);
+    }
+    // 四个箭头头部
+    for (int k = 0; k < head / 2; k++) {
+        canvas.plotRow(k, mid - k, 2 * k + 1);
+        canvas.plotRow(size - 1 - k, mid - k, 2 * k + 1);
+        for (int y = mid - k; y <= mid + k; y++) {
+            canvas.plot(k, y);
+            canvas.plot(size - 1 - k, y);
+        }
+    }
+
+    return canvas;
+}
+
+Canvas makeCrosshair(int s)
+{
+    Canvas canvas(64 * s, 64 * s);
+
+    const int size = 32 * s;
+    const int thickness = 3 * s;
+    const int mid = size / 2 - thickness / 2;
+
+    for (int y = mid; y < mid + thickness; y++) {
+        canvas.plotRow(y, 0, size);
+    }
+    for (int y = 0; y < size; y++) {
+        canvas.plotRow(y, mid, thickness);
+    }
+
+    return canvas;
+}
+
+// 一块确定性的噪声斑，代表游戏自绘光标：必须落到 Unknown
+Canvas makeNoiseBlob()
+{
+    Canvas canvas(32, 32);
+
+    quint32 state = 0x1234567u;
+    for (int y = 4; y < 26; y++) {
+        for (int x = 5; x < 24; x++) {
+            state = state * 1664525u + 1013904223u;
+            if (((state >> 16) & 0xFF) > 96) {
+                canvas.plot(x, y);
+            }
+        }
+    }
+
+    return canvas;
+}
+
+Canvas makeSolidBlock()
+{
+    Canvas canvas(32, 32);
+    for (int y = 8; y < 24; y++) {
+        canvas.plotRow(y, 8, 16);
+    }
+    return canvas;
+}
+
+void printMetrics(QTextStream& out, const QString& label, const CursorShapeMetrics& m)
+{
+    out << "  " << label << ": box=" << m.boxWidth << 'x' << m.boxHeight
+        << " fill=" << QString::number(m.fill, 'f', 3)
+        << " hotspot=(" << QString::number(m.hotspotX, 'f', 2) << ','
+        << QString::number(m.hotspotY, 'f', 2) << ')'
+        << " symV=" << QString::number(m.symV, 'f', 3)
+        << " symH=" << QString::number(m.symH, 'f', 3)
+        << " symRot180=" << QString::number(m.symRot180, 'f', 3)
+        << " centerFill=" << QString::number(m.centerFill, 'f', 3)
+        << " corr=" << QString::number(m.diagonalCorrelation, 'f', 3)
+        << " firstRow=" << QString::number(m.firstRowRatio, 'f', 3)
+        << " widestRow=" << QString::number(m.widestRowPosition, 'f', 3)
+        << " topWidth=" << QString::number(m.topWidthRatio, 'f', 3)
+        << " violations=" << m.topMonotoneViolations << '\n';
+}
+
+bool expectShape(QTextStream& out,
+                 const QString& label,
+                 const Canvas& canvas,
+                 int hotspotX,
+                 int hotspotY,
+                 NativeCursorShape expected)
+{
+    const CursorShapeMetrics metrics = measureCursorShape(
+        canvas.width(), canvas.height(), hotspotX, hotspotY, canvas.data());
+    const NativeCursorShape actual = classifyCursorShape(metrics);
+
+    printMetrics(out, label, metrics);
+
+    if (actual != expected) {
+        out << "FAIL: " << label << " expected "
+            << nativeCursorShapeName(expected) << ", got "
+            << nativeCursorShapeName(actual) << '\n';
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    QTextStream out(stdout);
+
+    bool ok = true;
+
+    // 同一形状的 1x 与 2x 都要认出来——主机的 DPI 缩放会在这几档之间变
+    for (int s = 1; s <= 2; s++) {
+        const QString suffix = QStringLiteral(" @%1x").arg(s);
+
+        ok &= expectShape(out, QStringLiteral("arrow") + suffix,
+                          makeArrow(s), 0, 0, NativeCursorShape::Arrow);
+
+        int appStartingHx = 0;
+        int appStartingHy = 0;
+        const Canvas appStarting = makeAppStarting(s, appStartingHx, appStartingHy);
+        ok &= expectShape(out, QStringLiteral("app-starting") + suffix,
+                          appStarting, appStartingHx, appStartingHy,
+                          NativeCursorShape::AppStarting);
+        ok &= expectShape(out, QStringLiteral("wait") + suffix,
+                          makeWait(s), 20 * s, 20 * s, NativeCursorShape::Wait);
+
+        ok &= expectShape(out, QStringLiteral("ibeam") + suffix,
+                          makeIBeam(s), 10 * s, 18 * s, NativeCursorShape::IBeam);
+
+        ok &= expectShape(out, QStringLiteral("hand") + suffix,
+                          makeHand(s), 7 * s, 0, NativeCursorShape::Hand);
+
+        ok &= expectShape(out, QStringLiteral("size-ns") + suffix,
+                          makeSizeNS(s), 4 * s, 10 * s, NativeCursorShape::SizeNS);
+
+        ok &= expectShape(out, QStringLiteral("size-we") + suffix,
+                          makeSizeWE(s), 10 * s, 4 * s, NativeCursorShape::SizeWE);
+
+        ok &= expectShape(out, QStringLiteral("size-nwse") + suffix,
+                          makeSizeNWSE(s, false), 8 * s, 8 * s,
+                          NativeCursorShape::SizeNWSE);
+
+        ok &= expectShape(out, QStringLiteral("size-nesw") + suffix,
+                          makeSizeNWSE(s, true), 8 * s, 8 * s,
+                          NativeCursorShape::SizeNESW);
+    }
+
+    // 不认识的一律回退位图
+    // 四向箭头和十字是故意不认的：它们跟等待光标同属"近方形 + 四重对称 + 热点居中"
+    ok &= expectShape(out, QStringLiteral("size-all"),
+                      makeSizeAll(1), 16, 16, NativeCursorShape::Unknown);
+    ok &= expectShape(out, QStringLiteral("crosshair"),
+                      makeCrosshair(1), 16, 16, NativeCursorShape::Unknown);
+    ok &= expectShape(out, QStringLiteral("noise blob"),
+                      makeNoiseBlob(), 12, 8, NativeCursorShape::Unknown);
+    ok &= expectShape(out, QStringLiteral("solid block"),
+                      makeSolidBlock(), 16, 16, NativeCursorShape::Unknown);
+
+    // 全透明（主机用来表示光标不可见）不能被当成任何形状
+    const Canvas blank(32, 32);
+    ok &= expectShape(out, QStringLiteral("fully transparent"),
+                      blank, 0, 0, NativeCursorShape::Unknown);
+
+    // 输入长度不符时必须安全地判为不认识
+    if (classifyCursorShape(32, 32, 0, 0, QByteArray(16, '\0')) !=
+        NativeCursorShape::Unknown) {
+        out << "FAIL: short pixel buffer was not rejected\n";
+        ok = false;
+    }
+    if (classifyCursorShape(0, 0, 0, 0, QByteArray()) !=
+        NativeCursorShape::Unknown) {
+        out << "FAIL: zero-sized shape was not rejected\n";
+        ok = false;
+    }
+
+    out << (ok ? "PASS\n" : "FAILED\n");
+    out.flush();
+    return ok ? 0 : 1;
+}

--- a/tests/cursor_shape_classification/main.cpp
+++ b/tests/cursor_shape_classification/main.cpp
@@ -14,7 +14,7 @@ public:
     Canvas(int width, int height)
         : m_width(width),
           m_height(height),
-          m_data(static_cast<qsizetype>(width) * height * 4, '\0')
+          m_data(width * height * 4, '\0')
     {
     }
 
@@ -23,7 +23,7 @@ public:
         if (x < 0 || y < 0 || x >= m_width || y >= m_height) {
             return;
         }
-        const qsizetype index = (static_cast<qsizetype>(y) * m_width + x) * 4;
+        const int index = (y * m_width + x) * 4;
         m_data[index + 0] = static_cast<char>(0xFF); // B
         m_data[index + 1] = static_cast<char>(0xFF); // G
         m_data[index + 2] = static_cast<char>(0xFF); // R
@@ -134,8 +134,7 @@ Canvas makeSizeWE(int s)
     const uchar* pixels = reinterpret_cast<const uchar*>(source.data().constData());
     for (int y = 0; y < source.height(); y++) {
         for (int x = 0; x < source.width(); x++) {
-            const qsizetype index =
-                (static_cast<qsizetype>(y) * source.width() + x) * 4 + 3;
+            const int index = (y * source.width() + x) * 4 + 3;
             if (pixels[index] != 0) {
                 canvas.plot(y, x);
             }


### PR DESCRIPTION
## 为什么

开着 `showLocalCursor` 时主机的光标不再合进视频，而是客户端本地画。但主机推来的是一整块 Windows BGRA 位图，[input.cpp](app/streaming/input/input.cpp) 原样交给 `SDL_CreateColorCursor()`——macOS 上看到的就是 Windows 那套黑描边箭头，跟系统指针风格不一致，Retina 下还要先降采样，比原生的糊。

协议里没有"这是箭头还是 I 型"的语义，只有一个不透明的 `shapeId`。所以要恢复原生风格，只能在客户端从位图本身把形状**认出来**。

## 怎么做

新增 `app/streaming/input/cursorshapeclassifier.{h,cpp}`——纯函数、只依赖 `QByteArray`、不碰 SDL，便于单测。

不做位图指纹匹配：主机光标随 Windows 主题和 DPI 在 32/48/64 几档之间变，逐像素指纹在这几档之间不成立。改用**尺度无关的几何量**：包围盒长宽比、填充率、热点在盒内的归一化位置、镜像/旋转 180° 对称度、不透明像素坐标的**带符号**皮尔逊相关系数、行宽剖面、中心区填充率。

命中就换 `SDL_CreateSystemCursor()`（Cocoa 后端映射到 `NSCursor`，尺寸/阴影/"辅助功能→指针大小"都跟随系统），`Unknown` 就走原来的位图路径。**宁可回退，不要给错形状。**

认这九种：

| 形状 | 关键判据 |
| --- | --- |
| Arrow | 热点钉左上、顶端尖、上半单调变宽、左右不对称 |
| AppStarting（箭头+转圈） | 热点仍在最左但盒内纵向被圈压到 0.29、corr 为负（质量分两坨） |
| Wait（转圈） | 四重对称 + `fill≈0.57` + `centerFill≈0`（中空） |
| IBeam | 细长、左右对称、第一行就是最宽的衬线 |
| Hand | 顶端窄、上半单调变宽、最宽处在下半 |
| SizeWE / SizeNS | 扁/长 + 双轴对称 + 顶端尖 |
| SizeNWSE / SizeNESW | 近方形 + 旋转对称 + `corr` 的**符号**定方向 |

阈值都照 Sunshine 主机实测的 64×64 位图定，注释里记了实测数字（例如 app-starting `box=44x53 fill=0.446 hotspot=(0.00,0.29) corr=-0.540`）。

**十字（IDC_CROSS）和四向箭头（IDC_SIZEALL）故意不认**：跟转圈同属"近方形 + 四重对称 + 热点居中"，几何上挤在一起分不干净，让它们走位图。`centerFill` 就是为把转圈跟这两个分开才加的——圈 `0.000`、四向箭头 `0.859`、十字 `0.609`。

顺手修了位图回退路径的缩放：原来直接对直通 alpha 的 `ARGB32` 做 `SmoothTransformation`，透明像素的黑会渗进边缘，缩完一圈发暗；改成先转预乘、缩完再转回去。

## 顺带修一个独立的闪烁

排查过程中发现的、跟本特性无关的已有 bug：主机（Sunshine + DXGI 桌面复制）会把"光标可见"这一位翻来翻去，实测每秒五到十次成对的 hidden→shown，形状和 `shapeId` 都没变。客户端照做就是每秒八次 `[NSCursor hide]`/`unhide`，肉眼可见的闪。

改成非对称去抖：**显示立即生效，隐藏等 150ms 坐实**。真正的隐藏（游戏自己藏光标）会一直保持，只是晚这么点生效看不出来；成对的抖动被整段吞掉。定时器跑在 SDL 定时器线程上，而 macOS 要求光标接口只在主线程调，所以经新增的 `SDL_CODE_FLUSH_CURSOR_VISIBILITY` 事件绕回主循环（照 `SDL_CODE_FLUSH_TOUCHPAD_FRAME` 的既有写法）。

## 注意

- **不新增设置项**——`showLocalCursor` 就是总开关。
- `MOONLIGHT_NATIVE_CURSOR=0` 可以不重编退回旧行为，用来确认某个形状是不是被认错了。
- **diff 里零个新增 `#ifdef`**：分类逻辑各平台一致，非 macOS 平台同样受益。
- 已知取舍：SDL 的 Cocoa 后端把 `WAIT` 和 `WAITARROW` 映射到同一只 HIServices `busybutclickable`，所以主机只有一个圈时，本机显示的是"箭头+转圈"。macOS 没有纯转圈的公开光标（沙滩球由 WindowServer 画，设不了），这已经是最接近的原生表达。想撤只需从 `toSdlSystemCursor()` 删掉一个 `case`。
- 未识别时会打一条 `SDL_LogVerbose` 的全量度量（默认日志级别下不出现，且只在结果变化时打）。现场遇到误判时照着日志调阈值比重新猜快得多，所以保留了它而不是删掉。

## 验证

```bash
cd tests/cursor_shape_classification && qmake && make && ./cursor_shape_classification
```

`PASS`。1x/2x 两档各断言九种形状，另外验证噪声斑、实心块、十字、四向箭头、全透明、长度不符的输入都落到 `Unknown`。

主程序 `make -j8` 干净（无新增 warning）。

真机跑过（macOS 客户端 + Sunshine 主机）：桌面空白处、文本框、浏览器链接、窗口边缘、后台忙、纯等待圈都换成了原生指针；`MOONLIGHT_NATIVE_CURSOR=0` 对照确认差异确实来自这条改动；闪烁已消失。最近一轮实测统计：31 arrow / 20 hand / 10 ibeam / 5 size-we / 2 app-starting，0 未识别。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recognizes common remote cursor shapes, including arrows, hands, text cursors, wait indicators, and resize cursors.
  - Replaces recognized remote cursors with native system cursors when enabled.
  - Preserves custom cursor scaling and display quality across supported platforms.

- **Bug Fixes**
  - Improves cursor visibility handling with smoother hiding and reduced flicker.
  - Improves recovery when native cursor creation fails.
  - Prevents stale or incorrectly timed cursor visibility updates.

- **Tests**
  - Added coverage for supported, ambiguous, malformed, transparent, and scaled cursor images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->