### PR TITLE
feat(video): add HDR10+ metadata support

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/plvk.cpp
+++ b/app/streaming/video/ffmpeg-renderers/plvk.cpp
@@ -974,22 +974,35 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
         return;
     }
 
-    // Adjust the swapchain if the colorspace of incoming frames has changed
-    if (!pl_color_space_equal(&mappedFrame.color, &m_LastColorspace)) {
-        m_LastColorspace = mappedFrame.color;
-        SDL_assert(pl_color_space_equal(&mappedFrame.color, &m_LastColorspace));
+    // Adjust the swapchain if the colorspace of incoming frames has changed.
+    //
+    // Only the primaries, transfer function, and static mastering luminance matter to
+    // the swapchain. pl_color_space_equal() also compares the dynamic sections of the
+    // HDR metadata, and HDR10+ moves scene_max/scene_avg on nearly every frame, so
+    // comparing the frame colorspace verbatim would re-hint the swapchain continuously
+    // once dynamic metadata starts arriving. Strip the dynamic sections first.
+    pl_color_space hintColorspace = mappedFrame.color;
+    hintColorspace.hdr = {};
+    hintColorspace.hdr.prim = mappedFrame.color.hdr.prim;
+    hintColorspace.hdr.min_luma = mappedFrame.color.hdr.min_luma;
+    hintColorspace.hdr.max_luma = mappedFrame.color.hdr.max_luma;
+    hintColorspace.hdr.max_cll = mappedFrame.color.hdr.max_cll;
+    hintColorspace.hdr.max_fall = mappedFrame.color.hdr.max_fall;
+
+    if (!pl_color_space_equal(&hintColorspace, &m_LastColorspace)) {
+        m_LastColorspace = hintColorspace;
 
 #ifdef Q_OS_DARWIN
         // There is a gamma mismatch on macOS between what libplacebo thinks BT.709
         // should use and what the Metal layer actually displays. Use sRGB for the
         // swapchain when the incoming frames are BT.709 as a workaround.
-        if (pl_color_space_equal(&mappedFrame.color, &pl_color_space_bt709)) {
+        if (pl_color_space_equal(&hintColorspace, &pl_color_space_bt709)) {
             pl_swapchain_colorspace_hint(m_Swapchain, &pl_color_space_srgb);
         }
         else
 #endif
         {
-            pl_swapchain_colorspace_hint(m_Swapchain, &mappedFrame.color);
+            pl_swapchain_colorspace_hint(m_Swapchain, &hintColorspace);
         }
     }
 
@@ -1080,10 +1093,37 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
     beginRenderTiming();
 #endif
 
+    // Pick the tone mapping data source for this frame.
+    //
+    // pl_render_fast_params leaves peak_detect_params NULL, so out of the box an HDR
+    // stream is tone mapped purely against the static mastering metadata — numbers that
+    // describe the mastering display, not the picture. ST 2094-40 replaces that with
+    // real per-frame content statistics when the host sends them, and frame-by-frame
+    // peak detection approximates the same thing when it doesn't.
+    pl_render_params renderParams = pl_render_fast_params;
+    pl_color_map_params colorMapParams = *renderParams.color_map_params;
+
+    if (pl_hdr_metadata_contains(&mappedFrame.color.hdr, PL_HDR_METADATA_HDR10PLUS)) {
+        // Ask for ST 2094-40 by name. PL_HDR_METADATA_ANY would normally prefer it as
+        // well, but being explicit keeps static mastering data from winning when the
+        // bitstream carries both. Note the gate is on what libplacebo actually mapped,
+        // not on the mere presence of side data: an incomplete or unmappable payload
+        // (application_version >= 2, say) leaves the fields zeroed, and forcing
+        // HDR10PLUS there would tone map against nothing at all.
+        colorMapParams.metadata = PL_HDR_METADATA_HDR10PLUS;
+        renderParams.color_map_params = &colorMapParams;
+    }
+    else if (pl_color_transfer_is_hdr(mappedFrame.color.transfer)) {
+        // No usable dynamic metadata. Measure the frame ourselves instead. libplacebo
+        // needs compute shaders for this and silently skips it where they are
+        // unavailable, which just leaves us at the previous behavior.
+        renderParams.peak_detect_params = &pl_peak_detect_default_params;
+    }
+
     // Render the video image and overlays into the swapchain buffer
     targetFrame.num_overlays = (int)overlays.size();
     targetFrame.overlays = overlays.data();
-    if (!pl_render_image(m_Renderer, &mappedFrame, &targetFrame, &pl_render_fast_params)) {
+    if (!pl_render_image(m_Renderer, &mappedFrame, &targetFrame, &renderParams)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "pl_render_image() failed");
         // NB: We must fallthrough to call pl_swapchain_submit_frame()

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -1922,6 +1922,7 @@ void FFmpegVideoDecoder::decoderThreadProc()
                     // Log the first frame that carries ST 2094-40, so a user reporting
                     // "HDR10+ does nothing" can be told apart from a host that never sent
                     // any. Once per session is enough; this is the decoder hot path.
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 25, 100)
                     if (!m_LoggedHdr10PlusMetadata &&
                             av_frame_get_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS) != nullptr) {
                         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
@@ -1929,6 +1930,7 @@ void FFmpegVideoDecoder::decoderThreadProc()
                                     (m_VideoFormat & VIDEO_FORMAT_MASK_AV1) ? "AV1" : "HEVC");
                         m_LoggedHdr10PlusMetadata = true;
                     }
+#endif
 
                     // Attach HDR metadata to the frame if it's not already present. We will defer to
                     // any metadata contained in the bitstream itself since that is guaranteed to be

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -243,6 +243,7 @@ FFmpegVideoDecoder::FFmpegVideoDecoder(bool testOnly)
       m_StreamFps(0),
       m_VideoFormat(0),
       m_NeedsSpsFixup(false),
+      m_LoggedHdr10PlusMetadata(false),
       m_TestOnly(testOnly),
       m_CurrentTestMode(TestMode::TestFrameOnly),
       m_DecoderThread(nullptr),
@@ -1917,6 +1918,17 @@ void FFmpegVideoDecoder::decoderThreadProc()
                 if (err == 0) {
                     SDL_assert(m_FrameInfoQueue.size() == m_FramesIn - m_FramesOut);
                     m_FramesOut++;
+
+                    // Log the first frame that carries ST 2094-40, so a user reporting
+                    // "HDR10+ does nothing" can be told apart from a host that never sent
+                    // any. Once per session is enough; this is the decoder hot path.
+                    if (!m_LoggedHdr10PlusMetadata &&
+                            av_frame_get_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS) != nullptr) {
+                        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                    "Received HDR10+ dynamic metadata from the %s bitstream",
+                                    (m_VideoFormat & VIDEO_FORMAT_MASK_AV1) ? "AV1" : "HEVC");
+                        m_LoggedHdr10PlusMetadata = true;
+                    }
 
                     // Attach HDR metadata to the frame if it's not already present. We will defer to
                     // any metadata contained in the bitstream itself since that is guaranteed to be

--- a/app/streaming/video/ffmpeg.h
+++ b/app/streaming/video/ffmpeg.h
@@ -129,6 +129,7 @@ private:
     int m_OriginalVideoHeight;
     int m_VideoFormat;
     bool m_NeedsSpsFixup;
+    bool m_LoggedHdr10PlusMetadata;
     bool m_TestOnly;
     TestMode m_CurrentTestMode;
     SDL_Thread* m_DecoderThread;


### PR DESCRIPTION
基于 #165（保留 HEVC 前缀 SEI）。**先合 #165。**

主机侧还有前置修复：AlkaidLab/foundation-sunshine#935。在那个合进去之前，本 PR 接上真实主机是**负收益**——见下。

---

## 这个 PR 做什么

把主机随码流发来的 HDR10+（SMPTE ST 2094-40）动态元数据接到 libplacebo 的 tone mapping 上。

FFmpeg 已经会把 T.35 SEI / AV1 OBU 里的 ST 2094-40 解析成 `AV_FRAME_DATA_DYNAMIC_HDR_PLUS`，`pl_map_hdr_metadata()` 也已经把它填进 `pl_color_space::hdr` 的 `scene_max`/`scene_avg`。缺的只是告诉 color mapper 用它。

### 1. plvk：HDR10+ 优先，没有就退回逐帧峰值检测

`pl_render_fast_params` 的 `peak_detect_params` 是 `NULL`，所以现状是 HDR 流只能拿静态 mastering 元数据做 tone mapping——那描述的是母版显示器，不是画面本身。补两条腿：

- 主机真发了 ST 2094-40 → 显式选 `PL_HDR_METADATA_HDR10PLUS`。判据是 `pl_hdr_metadata_contains()`，即 **libplacebo 到底映射出没有**，而不是 side data 在不在。载荷不完整或 `application_version >= 2` 时字段是全零，这时候强行指定 HDR10PLUS 等于拿空数据做 tone mapping，比不做还糟。
- 没有可用动态元数据的 HDR 流 → 打开 `pl_peak_detect_default_params` 自己量。libplacebo 需要 compute shader，不支持的平台上它自己跳过，退回原行为。

### 2. 顺带修掉 swapchain colorspace hint 的抖动

`pl_color_space_equal()` 连 HDR 元数据的动态段一起比，而 HDR10+ 几乎每帧都在动 `scene_max`/`scene_avg`——照原样比下去，会变成**每帧都调一次** `pl_swapchain_colorspace_hint()`。hint 只关心基色、传递函数和静态 mastering 亮度，比较前先把动态段剥掉。

这个坑不修的话，本 PR 就是拿 tone mapping 的收益换 swapchain 的抖动。

### 3. 一条一次性日志

收到第一帧带 ST 2094-40 的画面时打一行 info。「HDR10+ 没效果」的报告里，得能把「主机没发」和「客户端没用」分开。

## 相比初版改了什么

- **去掉了 DXGI 那条腿。** 初版往 `d3d11va.cpp` 加了 `updateHdr10PlusMetadata()`，走 `IDXGISwapChain4::SetHDRMetaData` + `DXGI_HDR_METADATA_TYPE_HDR10PLUS`。这东西没有公开文档，微软明确说过 Windows 不支持 HDR10+，72 字节 `Data[]` 的布局也没有规范——而 `av_dynamic_hdr_plus_to_t35()` 的输出是从 application mode 开始的，两边对不上。Windows 用户走 plvk 一样能吃到 tone mapping 收益。
- **`CAPABILITY_PRESERVE_HEVC_SEI` 拆到 #165。** 它影响所有平台的所有 HEVC 流，值得单独评审。
- **HDR10+ 从「无条件强制」改成「优先 + 兜底」**（理由见上）。

## 平台覆盖

只有 **PlVkRenderer** 这条路能吃到。macOS 上选 AVSampleBufferDisplayLayer / Metal（VideoToolbox）渲染器的用户没有收益：Apple 没有 HDR10+ 透传 API，那两条路也不做客户端 tone mapping。Windows / Linux 同理，只要没走 plvk 就没有。

## 依赖主机侧修复

AlkaidLab/foundation-sunshine#935 修了两个会让本 PR 变成负收益的 bug：

1. `hdr10plus_from_luminance()` 按**目标显示器峰值**归一化内容统计，而不是 ST 2084 的 10000 尼特基准。libplacebo 的还原方式是 `scene_max[i] = 10000 * av_q2d(maxscl[i])`，所以整幅画面会被按比例缩放。400 尼特显示器上 maxSCL 直接饱和到 1.0，峰值细节全被压平——发这种动态元数据不如不发。
2. ST 2094-40 §8.5.4 规定 `application_version = 1` 时 5% / 10% 两个槽位不属于 CDF，必须固定为 V1=0.00000、V2=0.00255。主机往里写了真实百分位数，于是 libplacebo 把 **5% 分位**（画面最暗的部分）当成 `max_pq_y` 拿去做 tone mapping——而 `pl_color_space_nominal_luma_ex()` 是**优先**用 CIE-Y 而不是 maxSCL 的。

## 验证

macOS 本地 qmake 全量构建 + 链接通过，只剩 `plvk.cpp` 里原有的两条 `lock_queue`/`unlock_queue` deprecation 警告。Windows / Linux 交给 CI。

端到端的画质验证还没做，得等 #935 合进主机之后。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved HDR and HDR10+ video rendering for compatible content.
  - Automatically selects available HDR10+ metadata or peak-detection processing for HDR frames.
  - Added a one-time diagnostic log when HDR10+ metadata is detected in supported AV1 or HEVC video.

- **Bug Fixes**
  - Reduced unnecessary display updates when dynamic HDR metadata changes without affecting static color information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->