### PR TITLE
feat(video): 让 FFmpeg 解码路保留 HEVC 前缀 SEI

### DIFF
--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -152,6 +152,15 @@ int FFmpegVideoDecoder::getDecoderCapabilities()
     // our operation.
     capabilities |= CAPABILITY_PULL_RENDERER;
 
+    // moonlight-common-c strips HEVC prefix SEI by default, because renderers that
+    // hand raw NALUs to a platform decoder have historically choked on NALUs
+    // arriving ahead of VPS/SPS/PPS. Every decoder this class can select consumes
+    // an FFmpeg AVPacket instead, and FFmpeg's HEVC parser is happy to skip SEI it
+    // does not understand, so we can opt back in. Keeping the SEI is what lets
+    // FFmpeg surface registered ITU-T T.35 payloads (HDR10+ among them) as frame
+    // side data.
+    capabilities |= CAPABILITY_PRESERVE_HEVC_SEI;
+
     return capabilities;
 }
 


### PR DESCRIPTION
从 #164 里拆出来的前置改动，单独评审，因为它的影响面比 HDR10+ 本身大得多。

## 改了什么

`FFmpegVideoDecoder::getDecoderCapabilities()` 加一行 `CAPABILITY_PRESERVE_HEVC_SEI`。

## 为什么可以这么干

moonlight-common-c 默认把 HEVC 前缀 SEI 剥掉，这条后路是给「直接把 NALU 丢给平台解码器」的渲染器留的——那类解码器碰到 VPS/SPS/PPS 之前冒出来的 NALU 会炸。而 `FFmpegVideoDecoder` 能选到的解码器一律走 `AVPacket`，FFmpeg 的 HEVC 解析器遇到不认识的 SEI 直接跳过。

留住 SEI 之后 FFmpeg 才能把注册的 ITU-T T.35 载荷解析成 per-frame side data，HDR10+ (SMPTE ST 2094-40) 就在里面。本 PR 只开开关，怎么用见 #164。

## 影响面

**所有 HEVC 流、所有平台**：解码单元里会多出以前被丢掉的前缀 SEI。这是需要单独评审的原因。

- 不需要动子模块。当前 pin 的 `moonlight-common-c` (`7bfa0c1e`, `mic`) 已经有这个能力位，`validateDecodeUnitForPlayback()` 也已经为它放宽了 IDR 的结构校验（`VideoDepacketizer.c:205`）。
- 只对 H.265 生效（`shouldPreserveHevcSei()` 里 `VIDEO_FORMAT_MASK_H265` 硬门）。H.264 和 AV1 不受影响。

## 验证

macOS 本地 qmake 全量构建 + 链接通过。Windows / Linux 交给 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HEVC video decoding to preserve supplemental enhancement information (SEI), including HDR10+ metadata, in decoded frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->