### PR TITLE
feat(video): 性能覆盖层显示 HDR10+ 是否真的生效

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/plvk.cpp
+++ b/app/streaming/video/ffmpeg-renderers/plvk.cpp
@@ -1124,7 +1124,7 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
                                   std::memory_order_relaxed);
     }
     else {
-        m_ToneMappingSource.store(ToneMappingSource::None, std::memory_order_relaxed);
+        m_ToneMappingSource.store(ToneMappingSource::Sdr, std::memory_order_relaxed);
     }
 
     // Render the video image and overlays into the swapchain buffer

--- a/app/streaming/video/ffmpeg-renderers/plvk.cpp
+++ b/app/streaming/video/ffmpeg-renderers/plvk.cpp
@@ -1112,12 +1112,19 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
         // HDR10PLUS there would tone map against nothing at all.
         colorMapParams.metadata = PL_HDR_METADATA_HDR10PLUS;
         renderParams.color_map_params = &colorMapParams;
+        m_ToneMappingSource.store(ToneMappingSource::Hdr10Plus, std::memory_order_relaxed);
     }
     else if (pl_color_transfer_is_hdr(mappedFrame.color.transfer)) {
         // No usable dynamic metadata. Measure the frame ourselves instead. libplacebo
         // needs compute shaders for this and silently skips it where they are
         // unavailable, which just leaves us at the previous behavior.
         renderParams.peak_detect_params = &pl_peak_detect_default_params;
+        m_ToneMappingSource.store(m_Vulkan->gpu->glsl.compute ? ToneMappingSource::PeakDetect
+                                                              : ToneMappingSource::Static,
+                                  std::memory_order_relaxed);
+    }
+    else {
+        m_ToneMappingSource.store(ToneMappingSource::None, std::memory_order_relaxed);
     }
 
     // Render the video image and overlays into the swapchain buffer
@@ -1414,4 +1421,9 @@ AVPixelFormat PlVkRenderer::getPreferredPixelFormat(int videoFormat)
     else {
         return AV_PIX_FMT_VULKAN;
     }
+}
+
+IFFmpegRenderer::ToneMappingSource PlVkRenderer::getActiveToneMappingSource()
+{
+    return m_ToneMappingSource.load(std::memory_order_relaxed);
 }

--- a/app/streaming/video/ffmpeg-renderers/plvk.h
+++ b/app/streaming/video/ffmpeg-renderers/plvk.h
@@ -113,9 +113,9 @@ private:
     // thread in renderFrame(), read on the receive thread by the stats overlay and the
     // HDR10+ log, so it has to be atomic. Purely diagnostic, hence relaxed ordering.
     //
-    // Starts at None rather than Unsupported: once plvk is the frontend renderer it is
+    // Starts at Sdr rather than Unsupported: once plvk is the frontend renderer it is
     // a renderer that tone maps, even before the first frame goes through.
-    std::atomic<ToneMappingSource> m_ToneMappingSource { ToneMappingSource::None };
+    std::atomic<ToneMappingSource> m_ToneMappingSource { ToneMappingSource::Sdr };
 
 #ifdef PLVK_USE_EARLY_RENDER_TO_WAIT
     pl_overlay m_EmptyOverlay = {};

--- a/app/streaming/video/ffmpeg-renderers/plvk.h
+++ b/app/streaming/video/ffmpeg-renderers/plvk.h
@@ -2,6 +2,8 @@
 
 #include "renderer.h"
 
+#include <atomic>
+
 #ifdef Q_OS_WIN32
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
@@ -53,6 +55,7 @@ public:
     virtual int getDecoderCapabilities() override;
     virtual bool isPixelFormatSupported(int videoFormat, enum AVPixelFormat pixelFormat) override;
     virtual AVPixelFormat getPreferredPixelFormat(int videoFormat) override;
+    virtual ToneMappingSource getActiveToneMappingSource() override;
 
 private:
     static void lockQueue(AVHWDeviceContext *dev_ctx, uint32_t queue_family, uint32_t index);
@@ -105,6 +108,14 @@ private:
     pl_renderer m_Renderer = nullptr;
     pl_tex m_Textures[PL_MAX_PLANES] = {};
     pl_color_space m_LastColorspace = {};
+
+    // What the last rendered frame actually tone mapped against. Written on the render
+    // thread in renderFrame(), read on the receive thread by the stats overlay and the
+    // HDR10+ log, so it has to be atomic. Purely diagnostic, hence relaxed ordering.
+    //
+    // Starts at None rather than Unsupported: once plvk is the frontend renderer it is
+    // a renderer that tone maps, even before the first frame goes through.
+    std::atomic<ToneMappingSource> m_ToneMappingSource { ToneMappingSource::None };
 
 #ifdef PLVK_USE_EARLY_RENDER_TO_WAIT
     pl_overlay m_EmptyOverlay = {};

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -155,6 +155,19 @@ public:
         VTMetal,
     };
 
+    // What the renderer is currently deriving its HDR tone mapping from.
+    //
+    // Purely diagnostic: it drives the performance overlay and the HDR10+ log
+    // message, so a user can tell "the host never sent dynamic metadata" apart
+    // from "it arrived and nothing used it".
+    enum class ToneMappingSource {
+        Unsupported,  // this renderer never tone maps HDR itself
+        None,         // it does, but the current frame isn't HDR
+        Static,       // HDR10 static mastering metadata only
+        PeakDetect,   // per-frame peak detection
+        Hdr10Plus,    // ST 2094-40 dynamic metadata
+    };
+
     IFFmpegRenderer(RendererType type) : m_Type(type) {}
 
     virtual bool initialize(PDECODER_PARAMETERS params) = 0;
@@ -184,6 +197,11 @@ public:
 
     virtual InitFailureReason getInitFailureReason() {
         return m_InitFailureReason;
+    }
+
+    virtual ToneMappingSource getActiveToneMappingSource() {
+        // Renderers that don't tone map HDR themselves don't have an answer here
+        return ToneMappingSource::Unsupported;
     }
 
     // Called for threaded renderers to allow them to wait prior to us latching

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -160,9 +160,13 @@ public:
     // Purely diagnostic: it drives the performance overlay and the HDR10+ log
     // message, so a user can tell "the host never sent dynamic metadata" apart
     // from "it arrived and nothing used it".
+    //
+    // NB: Don't name an enumerator None here. X11's X.h defines None as a macro,
+    // and ffmpeg.cpp reaches it through vaapi.h -> va_x11.h -> Xlib.h before this
+    // header, so the qualified name expands to ToneMappingSource::0L on Linux.
     enum class ToneMappingSource {
         Unsupported,  // this renderer never tone maps HDR itself
-        None,         // it does, but the current frame isn't HDR
+        Sdr,          // it does, but the current frame isn't HDR
         Static,       // HDR10 static mastering metadata only
         PeakDetect,   // per-frame peak detection
         Hdr10Plus,    // ST 2094-40 dynamic metadata

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -813,10 +813,32 @@ void FFmpegVideoDecoder::addVideoStats(VIDEO_STATS& src, VIDEO_STATS& dst)
     dst.renderedFps     = (double)dst.renderedFrames / timeDiffSecs;
 }
 
+// The dynamic range slot of the codec string in the performance overlay.
+//
+// "HDR10+" means the frontend renderer is actually tone mapping against ST 2094-40
+// this frame, not merely that the bitstream carried it: a renderer that ignores the
+// metadata, or a payload libplacebo couldn't map, both stay at "HDR".
+const char* FFmpegVideoDecoder::dynamicRangeLabel()
+{
+    if (!LiGetCurrentHostDisplayHdrMode()) {
+        return "SDR";
+    }
+
+    // NB: logVideoStats() runs during cleanup, after the renderers have been deleted
+    // and nulled, so this can legitimately be called with no renderer at all.
+    if (m_FrontendRenderer != nullptr &&
+            m_FrontendRenderer->getActiveToneMappingSource() == IFFmpegRenderer::ToneMappingSource::Hdr10Plus) {
+        return "HDR10+";
+    }
+
+    return "HDR";
+}
+
 void FFmpegVideoDecoder::stringifyVideoStats(VIDEO_STATS &stats, char *output, int length)
 {
     int offset = 0;
     const char *codecString;
+    char codecStringBuffer[32];
     int ret;
 
     // Start with an empty string
@@ -841,25 +863,13 @@ void FFmpegVideoDecoder::stringifyVideoStats(VIDEO_STATS &stats, char *output, i
         break;
 
     case VIDEO_FORMAT_H265_MAIN10:
-        if (LiGetCurrentHostDisplayHdrMode())
-        {
-            codecString = "HEVC 10-bit HDR";
-        }
-        else
-        {
-            codecString = "HEVC 10-bit SDR";
-        }
+        snprintf(codecStringBuffer, sizeof(codecStringBuffer), "HEVC 10-bit %s", dynamicRangeLabel());
+        codecString = codecStringBuffer;
         break;
 
     case VIDEO_FORMAT_H265_REXT10_444:
-        if (LiGetCurrentHostDisplayHdrMode())
-        {
-            codecString = "HEVC 10-bit HDR 4:4:4";
-        }
-        else
-        {
-            codecString = "HEVC 10-bit SDR 4:4:4";
-        }
+        snprintf(codecStringBuffer, sizeof(codecStringBuffer), "HEVC 10-bit %s 4:4:4", dynamicRangeLabel());
+        codecString = codecStringBuffer;
         break;
 
     case VIDEO_FORMAT_AV1_MAIN8:
@@ -871,25 +881,13 @@ void FFmpegVideoDecoder::stringifyVideoStats(VIDEO_STATS &stats, char *output, i
         break;
 
     case VIDEO_FORMAT_AV1_MAIN10:
-        if (LiGetCurrentHostDisplayHdrMode())
-        {
-            codecString = "AV1 10-bit HDR";
-        }
-        else
-        {
-            codecString = "AV1 10-bit SDR";
-        }
+        snprintf(codecStringBuffer, sizeof(codecStringBuffer), "AV1 10-bit %s", dynamicRangeLabel());
+        codecString = codecStringBuffer;
         break;
 
     case VIDEO_FORMAT_AV1_HIGH10_444:
-        if (LiGetCurrentHostDisplayHdrMode())
-        {
-            codecString = "AV1 10-bit HDR 4:4:4";
-        }
-        else
-        {
-            codecString = "AV1 10-bit SDR 4:4:4";
-        }
+        snprintf(codecStringBuffer, sizeof(codecStringBuffer), "AV1 10-bit %s 4:4:4", dynamicRangeLabel());
+        codecString = codecStringBuffer;
         break;
 
     default:
@@ -1922,12 +1920,19 @@ void FFmpegVideoDecoder::decoderThreadProc()
                     // Log the first frame that carries ST 2094-40, so a user reporting
                     // "HDR10+ does nothing" can be told apart from a host that never sent
                     // any. Once per session is enough; this is the decoder hot path.
+                    //
+                    // Also say whether anything downstream will use it: a renderer that
+                    // reports Unsupported never tone maps HDR itself, so the metadata
+                    // arriving is not the same as the metadata mattering.
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 25, 100)
                     if (!m_LoggedHdr10PlusMetadata &&
                             av_frame_get_side_data(frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS) != nullptr) {
+                        bool rendererUsesIt = m_FrontendRenderer != nullptr &&
+                                m_FrontendRenderer->getActiveToneMappingSource() != IFFmpegRenderer::ToneMappingSource::Unsupported;
                         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                                    "Received HDR10+ dynamic metadata from the %s bitstream",
-                                    (m_VideoFormat & VIDEO_FORMAT_MASK_AV1) ? "AV1" : "HEVC");
+                                    "Received HDR10+ dynamic metadata from the %s bitstream%s",
+                                    (m_VideoFormat & VIDEO_FORMAT_MASK_AV1) ? "AV1" : "HEVC",
+                                    rendererUsesIt ? "" : " (ignored: the current renderer does not tone map HDR)");
                         m_LoggedHdr10PlusMetadata = true;
                     }
 #endif

--- a/app/streaming/video/ffmpeg.h
+++ b/app/streaming/video/ffmpeg.h
@@ -52,6 +52,7 @@ private:
                                 bool useAlternateFrontend);
 
     void stringifyVideoStats(VIDEO_STATS& stats, char* output, int length);
+    const char* dynamicRangeLabel();
 
     void logVideoStats(VIDEO_STATS& stats, const char* title);
 


### PR DESCRIPTION
接 #164 / AlkaidLab/foundation-sunshine#935。HDR10+ 两端都合入了，但客户端**没有任何界面能告诉用户它到底有没有生效**：

- 覆盖层里的 `HDR`/`SDR` 只来自 `LiGetCurrentHostDisplayHdrMode()`，跟色调映射走哪一路无关。
- 唯一的线索是那条一次性日志 `Received HDR10+ dynamic metadata`，而它**只看解码器拿没拿到侧数据，不看渲染器用不用**。用户手动选了 AVSBDL 或 Metal 渲染器时这条日志照打，实际却完全没进色调映射 —— 是误导。

两件事根子相同：没人能问渲染器「你这一帧的色调映射是拿什么算的」。加一个接口，两处一起解决。

## 改动

**`renderer.h`** —— `IFFmpegRenderer` 新增 `ToneMappingSource` 枚举和 `getActiveToneMappingSource()`，基类默认返回 `Unsupported`。这个默认值是关键：它让「渲染器压根不参与」和「参与了但这帧没有动态元数据」变成两个可区分的状态。VTRenderer / D3D11VA / DRM 等一概不动，默认值对它们就是正确答案。

**`plvk.h` / `plvk.cpp`** —— 在 `renderFrame()` 现成的三分支里如实上报，不新增判断逻辑：走 HDR10+ 的报 `Hdr10Plus`；走峰值检测的再看 `gpu->glsl.compute`，为假时 libplacebo 会静默跳过峰值检测退回静态元数据，如实报 `Static`；SDR 报 `None`。写在渲染线程、读在接收线程，所以是 `std::atomic`；纯诊断用途，`memory_order_relaxed` 足够。初值取 `None` 而非 `Unsupported`，这样日志在第一帧就能判断，不用等渲染线程跑起来。

**`ffmpeg.cpp`** —— 动态范围那一格从两态变三态：`SDR` / `HDR` / `HDR10+`，占用原来 `HDR` 的位置，四个 10-bit 分支收敛到一个 `dynamicRangeLabel()` 辅助函数。`Static` 和 `PeakDetect` 不在覆盖层区分 —— 那一格只放得下一个词，这个粒度的信息留给日志。一次性日志则在渲染器不参与时补一句 `(ignored: the current renderer does not tone map HDR)`。

## 顺带修一个现成的空指针

`logVideoStats()` 在 `m_FrontendRenderer` 被置空**之后**才调用，也就是流结束时 `stringifyVideoStats()` 拿到的是 nullptr。现在没炸是因为它压根不碰渲染器；这次一碰就是解空指针，所以 `dynamicRangeLabel()` 里判空，判空时退回原来的 `HDR`/`SDR`。

## 验证

- macOS release 构建通过，除既有的 Qt/libplacebo 弃用警告外无新增警告。
- 待实测的三种情形：Vulkan + 主机发 HDR10+ → `HEVC 10-bit HDR10+`；Vulkan + HDR 无动态元数据 → `HEVC 10-bit HDR`；手选 AVSBDL/Metal → `HEVC 10-bit HDR` 且日志明说这份元数据不会被用；SDR 回归。
- 空指针那条路径：正常结束串流（不是 kill），确认 `Global video stats` 正常打出。
- `renderer.h` 是所有渲染器都包的，Windows/Linux 交给 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer HDR tone-mapping status reporting, including HDR10+, peak detection, static mapping, SDR, and unsupported states.
  - Performance overlays now distinguish SDR, HDR, and actively tone-mapped HDR10+ video.
  - HDR10+ diagnostics indicate whether metadata is being applied or ignored.

- **Bug Fixes**
  - Improved accuracy of displayed dynamic-range information for supported 10-bit video formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->