### PR TITLE
fix(settings): 开关拨过去了但设置没保存

### DIFF
--- a/app/gui/theme/HardSwitch.qml
+++ b/app/gui/theme/HardSwitch.qml
@@ -51,6 +51,11 @@ Switch {
         // Own the pointer gesture on the painted track. This avoids the
         // FluentWinUI3 Switch regression where a stationary release is ignored,
         // while retaining both tap-to-toggle and drag-to-select behavior.
+        //
+        // 提交状态一律走 click()，不能用 toggle()：toggle() 只是 setChecked(!checked)，
+        // 发的仅有 checkedChanged，不发 toggled()。而 ToggleRow 正是靠 toggled() 把值
+        // 写回偏好设置的（checked 是绑定，初始化阶段也会变，所以不能用 checkedChanged）。
+        // 用 toggle() 的结果就是：开关看着拨过去了，设置根本没保存。
         MouseArea {
             id: pointerArea
             anchors.fill: parent
@@ -84,14 +89,16 @@ Switch {
                         (mouse.x - dragOffset - 3 - handle.width / 2) / travel))
                 }
             }
-            onReleased: function(mouse) {
+            onReleased: function() {
                 if (dragging) {
+                    // 拖到哪一侧就是哪一侧：只有真的换了边才提交，
+                    // 拖回原位松手等于什么都没做。
                     var targetChecked = dragPosition >= 0.5
                     if (targetChecked !== control.checked) {
-                        control.toggle()
+                        control.click()
                     }
                 } else {
-                    control.toggle()
+                    control.click()
                 }
                 dragging = false
             }

--- a/app/gui/theme/HardSwitch.qml
+++ b/app/gui/theme/HardSwitch.qml
@@ -12,6 +12,18 @@ Switch {
     padding: 0
     spacing: 0
 
+    function commitPointerToggle() {
+        if (!control.enabled) {
+            return
+        }
+
+        var previousChecked = control.checked
+        control.toggle()
+        if (control.checked !== previousChecked) {
+            control.toggled()
+        }
+    }
+
     indicator: Rectangle {
         id: track
         implicitWidth: 44
@@ -52,10 +64,10 @@ Switch {
         // FluentWinUI3 Switch regression where a stationary release is ignored,
         // while retaining both tap-to-toggle and drag-to-select behavior.
         //
-        // 提交状态一律走 click()，不能用 toggle()：toggle() 只是 setChecked(!checked)，
-        // 发的仅有 checkedChanged，不发 toggled()。而 ToggleRow 正是靠 toggled() 把值
-        // 写回偏好设置的（checked 是绑定，初始化阶段也会变，所以不能用 checkedChanged）。
-        // 用 toggle() 的结果就是：开关看着拨过去了，设置根本没保存。
+        // 这条自管的指针路径必须同时切换状态并发出 toggled()：ToggleRow 靠它把值
+        // 写回偏好设置，而 checkedChanged 在初始化恢复绑定值时也会触发，不能代替。
+        // 不使用 AbstractButton.click()，因为它从 Qt 6.8 才有；Steam Link 和部分
+        // Linux 构建仍使用更早的 Qt。
         MouseArea {
             id: pointerArea
             anchors.fill: parent
@@ -95,10 +107,10 @@ Switch {
                     // 拖回原位松手等于什么都没做。
                     var targetChecked = dragPosition >= 0.5
                     if (targetChecked !== control.checked) {
-                        control.click()
+                        control.commitPointerToggle()
                     }
                 } else {
-                    control.click()
+                    control.commitPointerToggle()
                 }
                 dragging = false
             }


### PR DESCRIPTION
## 改了啥呀

设置页里的 `HardSwitch` 会自己接管鼠标点击和拖拽，用来绕开 FluentWinUI3 静止松手被吞掉的问题。原实现只调用 `control.toggle()`：开关外观会变化，但不会发出 `toggled()`，于是 [ToggleRow.qml](app/gui/settings/ToggleRow.qml) 根本没有机会把新值写回偏好设置。这个杂鱼 bug 最会装正常——看着切过去了，重进设置页却还是原样。

这次把指针提交统一收进 `commitPointerToggle()`：

- 禁用状态直接忽略；
- 用所有受支持 Qt 版本都有的 `toggle()` 改变状态；
- 仅当 `checked` 真的发生变化时显式发出 `toggled()`，触发设置写回；
- 拖过半程会提交，拖回原位仍然不做任何事。

`checkedChanged` 不能代替这里的 `toggled()`：`checked` 从偏好设置恢复初值时也会变化，用它写回会在初始化阶段误提交。

## 为啥不用 `click()`

PR 最初用 `AbstractButton.click()` 补齐信号，但这个 API [从 Qt 6.8 才提供](https://doc.qt.io/qt-6.8/qml-qtquick-controls-abstractbutton.html#click-method)。仓库仍支持 Steam Link 的 Qt 5.14.1 和其他旧 Qt Linux 构建，只升级 standalone AppImage workflow 会漏掉这些目标。

现在的 `toggle()` + 条件式 `toggled()` 与 Qt 内部交互切换的关键语义一致，也不会让新旧 Qt 分别发出不同的 `pressed` / `released` / `clicked` 信号序列。保存问题修掉了，旧 Qt 的回归口也一起堵上啦。

## 怎么验证

- QML TestCase 在 Qt 6.8.2、6.9.2、6.11.1 各运行 7 项，全部通过：点击并写回、初始化恢复不写回、禁用、拖过半程、拖回原位；
- `scripts/qmllint-check.sh` 通过（41 个 QML 文件）；
- `HardSwitch.qml` 在 Qt 6.8.2、6.9.2、6.11.1 的 `qmllint` 均通过；
- `git diff --check` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switch interaction handling so clicks and qualifying drags consistently update the displayed state.
  * Prevented disabled switches from responding to pointer actions.
  * Avoided unnecessary toggle updates when a drag ends without changing the switch position.
  * Ensured toggle notifications are emitted only when the switch state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->