### PR TITLE
fix(video): 在 VideoToolbox 上把 AV1 拆帧重打包回 OBU_FRAME

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -321,6 +321,7 @@ ffmpeg {
     DEFINES += HAVE_FFMPEG
     SOURCES += \
         streaming/video/ffmpeg.cpp \
+        streaming/video/av1obu.cpp \
         streaming/video/ffmpeg-renderers/genhwaccel.cpp \
         streaming/video/ffmpeg-renderers/sdlvid.cpp \
         streaming/video/ffmpeg-renderers/swframemapper.cpp \
@@ -328,6 +329,7 @@ ffmpeg {
 
     HEADERS += \
         streaming/video/ffmpeg.h \
+        streaming/video/av1obu.h \
         streaming/video/ffmpeg-renderers/renderer.h \
         streaming/video/ffmpeg-renderers/genhwaccel.h \
         streaming/video/ffmpeg-renderers/sdlvid.h \

--- a/app/streaming/video/av1obu.cpp
+++ b/app/streaming/video/av1obu.cpp
@@ -1,0 +1,225 @@
+#include "av1obu.h"
+
+#include <string.h>
+
+// OBU types we care about (AV1 spec 6.2.2)
+#define OBU_TEMPORAL_DELIMITER 2
+#define OBU_FRAME_HEADER       3
+#define OBU_TILE_GROUP         4
+#define OBU_METADATA           5
+#define OBU_FRAME              6
+
+// A temporal unit from a streaming host is a handful of OBUs. Anything longer is
+// not the layout we rewrite, so we can bail out rather than grow this.
+#define MAX_OBUS 16
+
+// Metadata OBUs that need hoisting are HDR10+ ITU-T T.35, mastering display, and
+// content light level payloads - all well under 100 bytes. They have to be stashed
+// because they move backwards past the frame header while the frame header's own
+// payload moves forwards past them.
+#define MAX_HOISTED_METADATA 512
+
+struct Obu {
+    int type;
+    int headerOffset;   // start of the OBU header
+    int headerLength;   // header + leb128 size field
+    int payloadOffset;
+    int payloadLength;
+};
+
+static int leb128Size(uint64_t value)
+{
+    int size = 0;
+    do {
+        size++;
+        value >>= 7;
+    } while (value != 0);
+    return size;
+}
+
+static int writeLeb128(uint8_t* out, uint64_t value)
+{
+    int size = 0;
+    do {
+        uint8_t byte = value & 0x7F;
+        value >>= 7;
+        if (value != 0) {
+            byte |= 0x80;
+        }
+        out[size++] = byte;
+    } while (value != 0);
+    return size;
+}
+
+// Parses the temporal unit into obus[]. Returns the OBU count, or -1 if the data
+// is malformed or uses a form we can't safely rewrite (missing size fields).
+static int parseObus(const uint8_t* data, int length, Obu* obus)
+{
+    int count = 0;
+    int pos = 0;
+
+    while (pos < length) {
+        if (count == MAX_OBUS) {
+            return -1;
+        }
+
+        uint8_t header = data[pos];
+        if (header & 0x80) {
+            // obu_forbidden_bit must be zero
+            return -1;
+        }
+
+        int headerLength = 1;
+        if (header & 0x04) {
+            // obu_extension_flag: one more byte of temporal_id/spatial_id
+            headerLength++;
+        }
+        if (!(header & 0x02)) {
+            // No obu_size field, so the OBU runs to the end of the buffer and we
+            // can't rewrite anything around it.
+            return -1;
+        }
+        if (pos + headerLength >= length) {
+            return -1;
+        }
+
+        // leb128 obu_size
+        uint64_t size = 0;
+        int sizeBytes = 0;
+        for (;;) {
+            if (sizeBytes == 8 || pos + headerLength + sizeBytes >= length) {
+                return -1;
+            }
+            uint8_t byte = data[pos + headerLength + sizeBytes];
+            size |= (uint64_t)(byte & 0x7F) << (7 * sizeBytes);
+            sizeBytes++;
+            if (!(byte & 0x80)) {
+                break;
+            }
+        }
+        headerLength += sizeBytes;
+
+        if (size > (uint64_t)(length - (pos + headerLength))) {
+            return -1;
+        }
+
+        obus[count].type = (header >> 3) & 0x0F;
+        obus[count].headerOffset = pos;
+        obus[count].headerLength = headerLength;
+        obus[count].payloadOffset = pos + headerLength;
+        obus[count].payloadLength = (int)size;
+        count++;
+
+        pos += headerLength + (int)size;
+    }
+
+    return count;
+}
+
+int repackAv1TemporalUnit(uint8_t* data, int length)
+{
+    Obu obus[MAX_OBUS];
+    int count = parseObus(data, length, obus);
+    if (count <= 0) {
+        return length;
+    }
+
+    // Find the split frame we're here to merge. We only handle the exact layout
+    // NVENC produces: a single frame header, optional metadata, then a single tile
+    // group that ends the temporal unit.
+    int frameHeaderIdx = -1;
+    int tileGroupIdx = -1;
+    for (int i = 0; i < count; i++) {
+        switch (obus[i].type) {
+        case OBU_FRAME:
+            // Already in the merged form the decoder wants
+            return length;
+        case OBU_FRAME_HEADER:
+            if (frameHeaderIdx >= 0) {
+                return length;
+            }
+            frameHeaderIdx = i;
+            break;
+        case OBU_TILE_GROUP:
+            if (tileGroupIdx >= 0) {
+                return length;
+            }
+            tileGroupIdx = i;
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (frameHeaderIdx < 0 || tileGroupIdx != count - 1 || tileGroupIdx < frameHeaderIdx) {
+        return length;
+    }
+
+    // Everything between the frame header and the tile group gets hoisted ahead of
+    // the merged frame. Only metadata belongs there.
+    int metadataLength = 0;
+    for (int i = frameHeaderIdx + 1; i < tileGroupIdx; i++) {
+        if (obus[i].type != OBU_METADATA) {
+            return length;
+        }
+        metadataLength += obus[i].headerLength + obus[i].payloadLength;
+    }
+    if (metadataLength > MAX_HOISTED_METADATA) {
+        return length;
+    }
+
+    const Obu& frameHeader = obus[frameHeaderIdx];
+    const Obu& tileGroup = obus[tileGroupIdx];
+    if (frameHeader.payloadLength == 0) {
+        return length;
+    }
+
+    // An OBU_FRAME_HEADER payload ends with trailing_bits(): a one bit followed by
+    // zeroes out to the byte boundary. Inside an OBU_FRAME the frame header is
+    // followed by byte_alignment() instead, which is zeroes only. So the stop bit -
+    // the lowest set bit of the final byte - has to go.
+    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeader.payloadLength - 1];
+    if (lastByte == 0) {
+        // Malformed: trailing_bits() always writes a stop bit into this byte.
+        return length;
+    }
+    lastByte &= lastByte - 1;
+
+    uint64_t mergedPayloadLength = (uint64_t)frameHeader.payloadLength + tileGroup.payloadLength;
+    int mergedHeaderLength = (frameHeader.headerLength - leb128Size(frameHeader.payloadLength)) +
+                             leb128Size(mergedPayloadLength);
+
+    int preambleLength = frameHeader.headerOffset;
+
+    uint8_t metadata[MAX_HOISTED_METADATA];
+    if (metadataLength > 0) {
+        memcpy(metadata, data + obus[frameHeaderIdx + 1].headerOffset, metadataLength);
+    }
+
+    // Lay out [preamble][metadata][OBU_FRAME header][frame header][tile group].
+    // The preamble doesn't move. Everything else is written back to front so no
+    // move clobbers bytes a later move still needs to read.
+    int mergedHeaderOffset = preambleLength + metadataLength;
+    int frameHeaderDest = mergedHeaderOffset + mergedHeaderLength;
+    int tileGroupDest = frameHeaderDest + frameHeader.payloadLength;
+
+    memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
+    memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeader.payloadLength);
+    data[frameHeaderDest + frameHeader.payloadLength - 1] = lastByte;
+
+    // Reuse the frame header's OBU header so temporal_id/spatial_id survive, but
+    // retype it to OBU_FRAME.
+    data[mergedHeaderOffset] = (data[frameHeader.headerOffset] & ~0x78) | (OBU_FRAME << 3);
+    int written = 1;
+    if (data[mergedHeaderOffset] & 0x04) {
+        data[mergedHeaderOffset + 1] = data[frameHeader.headerOffset + 1];
+        written++;
+    }
+    written += writeLeb128(data + mergedHeaderOffset + written, mergedPayloadLength);
+
+    if (metadataLength > 0) {
+        memcpy(data + preambleLength, metadata, metadataLength);
+    }
+
+    return tileGroupDest + tileGroup.payloadLength;
+}

--- a/app/streaming/video/av1obu.cpp
+++ b/app/streaming/video/av1obu.cpp
@@ -23,6 +23,7 @@ struct Obu {
     int type;
     int headerOffset;   // start of the OBU header
     int headerLength;   // header + leb128 size field
+    int sizeBytes;      // length of the leb128 size field as actually encoded
     int payloadOffset;
     int payloadLength;
 };
@@ -106,6 +107,7 @@ static int parseObus(const uint8_t* data, int length, Obu* obus)
         obus[count].type = (header >> 3) & 0x0F;
         obus[count].headerOffset = pos;
         obus[count].headerLength = headerLength;
+        obus[count].sizeBytes = sizeBytes;
         obus[count].payloadOffset = pos + headerLength;
         obus[count].payloadLength = (int)size;
         count++;
@@ -171,6 +173,19 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
     const Obu& frameHeader = obus[frameHeaderIdx];
     const Obu& tileGroup = obus[tileGroupIdx];
 
+    // The merged OBU_FRAME reuses the frame header's OBU header, so the tile group's
+    // header has to agree with it. If they disagree we'd silently move the tile group
+    // into a different temporal/spatial layer, so leave the whole thing alone.
+    uint8_t fhHeader = data[frameHeader.headerOffset];
+    uint8_t tgHeader = data[tileGroup.headerOffset];
+    if ((fhHeader & 0x04) != (tgHeader & 0x04)) {
+        return length;
+    }
+    if ((fhHeader & 0x04) &&
+        data[frameHeader.headerOffset + 1] != data[tileGroup.headerOffset + 1]) {
+        return length;
+    }
+
     // An OBU_FRAME_HEADER payload ends with trailing_bits(obu_size * 8 - payloadBits):
     // a one bit, then zeroes all the way to the end of obu_size. An encoder that
     // over-declares obu_size therefore leaves whole zero bytes at the end, which is
@@ -192,9 +207,21 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
     }
     uint8_t lastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
     lastByte &= lastByte - 1;
+    if (lastByte == 0) {
+        // The byte held nothing but the stop bit (0x80), i.e. frame_header_obu() ended
+        // exactly on a byte boundary. byte_alignment() contributes nothing there, so
+        // this byte has to disappear rather than become a zero - same reason as above.
+        frameHeaderLength--;
+        if (frameHeaderLength == 0) {
+            return length;
+        }
+    }
 
     uint64_t mergedPayloadLength = (uint64_t)frameHeaderLength + tileGroup.payloadLength;
-    int mergedHeaderLength = (frameHeader.headerLength - leb128Size(frameHeader.payloadLength)) +
+    // Recover the OBU header bytes without its size field. Use the size field's actual
+    // encoded width, not leb128Size(): AV1 permits non-minimal leb128, so an encoder may
+    // have written e.g. 81 00 for a payload of 1.
+    int mergedHeaderLength = (frameHeader.headerLength - frameHeader.sizeBytes) +
                              leb128Size(mergedPayloadLength);
 
     int preambleLength = frameHeader.headerOffset;
@@ -213,7 +240,9 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
 
     memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
     memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeaderLength);
-    data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
+    if (lastByte != 0) {
+        data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
+    }
 
     // Reuse the frame header's OBU header so temporal_id/spatial_id survive, but
     // retype it to OBU_FRAME.

--- a/app/streaming/video/av1obu.cpp
+++ b/app/streaming/video/av1obu.cpp
@@ -170,22 +170,30 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
 
     const Obu& frameHeader = obus[frameHeaderIdx];
     const Obu& tileGroup = obus[tileGroupIdx];
-    if (frameHeader.payloadLength == 0) {
-        return length;
-    }
 
-    // An OBU_FRAME_HEADER payload ends with trailing_bits(): a one bit followed by
-    // zeroes out to the byte boundary. Inside an OBU_FRAME the frame header is
-    // followed by byte_alignment() instead, which is zeroes only. So the stop bit -
-    // the lowest set bit of the final byte - has to go.
-    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeader.payloadLength - 1];
-    if (lastByte == 0) {
-        // Malformed: trailing_bits() always writes a stop bit into this byte.
+    // An OBU_FRAME_HEADER payload ends with trailing_bits(obu_size * 8 - payloadBits):
+    // a one bit, then zeroes all the way to the end of obu_size. An encoder that
+    // over-declares obu_size therefore leaves whole zero bytes at the end, which is
+    // legal.
+    //
+    // Inside an OBU_FRAME the frame header is followed by byte_alignment() instead,
+    // and that only pads to the next byte boundary - it can never span a whole byte.
+    // So two things have to happen here: the stop bit (the lowest set bit of the last
+    // non-zero byte) goes away, and any whole zero bytes after it get dropped.
+    // Keeping them would shift them into tile_group_obu()'s payload and corrupt the
+    // frame.
+    int frameHeaderLength = frameHeader.payloadLength;
+    while (frameHeaderLength > 0 && data[frameHeader.payloadOffset + frameHeaderLength - 1] == 0) {
+        frameHeaderLength--;
+    }
+    if (frameHeaderLength == 0) {
+        // Malformed: trailing_bits() always writes a stop bit somewhere.
         return length;
     }
+    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
     lastByte &= lastByte - 1;
 
-    uint64_t mergedPayloadLength = (uint64_t)frameHeader.payloadLength + tileGroup.payloadLength;
+    uint64_t mergedPayloadLength = (uint64_t)frameHeaderLength + tileGroup.payloadLength;
     int mergedHeaderLength = (frameHeader.headerLength - leb128Size(frameHeader.payloadLength)) +
                              leb128Size(mergedPayloadLength);
 
@@ -201,11 +209,11 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
     // move clobbers bytes a later move still needs to read.
     int mergedHeaderOffset = preambleLength + metadataLength;
     int frameHeaderDest = mergedHeaderOffset + mergedHeaderLength;
-    int tileGroupDest = frameHeaderDest + frameHeader.payloadLength;
+    int tileGroupDest = frameHeaderDest + frameHeaderLength;
 
     memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
-    memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeader.payloadLength);
-    data[frameHeaderDest + frameHeader.payloadLength - 1] = lastByte;
+    memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeaderLength);
+    data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
 
     // Reuse the frame header's OBU header so temporal_id/spatial_id survive, but
     // retype it to OBU_FRAME.

--- a/app/streaming/video/av1obu.cpp
+++ b/app/streaming/video/av1obu.cpp
@@ -205,12 +205,16 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
         // Malformed: trailing_bits() always writes a stop bit somewhere.
         return length;
     }
-    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
-    lastByte &= lastByte - 1;
-    if (lastByte == 0) {
-        // The byte held nothing but the stop bit (0x80), i.e. frame_header_obu() ended
-        // exactly on a byte boundary. byte_alignment() contributes nothing there, so
-        // this byte has to disappear rather than become a zero - same reason as above.
+    uint8_t origLastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
+    uint8_t lastByte = origLastByte & (origLastByte - 1);
+    // Exactly 0x80 means the stop bit was the first bit of the byte, i.e.
+    // frame_header_obu() ended on the previous byte boundary and this byte carries no
+    // payload bits at all. byte_alignment() contributes nothing there, so the byte has
+    // to disappear rather than become a zero - same reason as the zero bytes above.
+    // Any other single-bit value (0x20, 0x40, ...) still holds real payload bits ahead
+    // of the stop bit, so it stays as 0x00 and byte_alignment() pads out the rest.
+    bool dropLastByte = (origLastByte == 0x80);
+    if (dropLastByte) {
         frameHeaderLength--;
         if (frameHeaderLength == 0) {
             return length;
@@ -240,7 +244,7 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
 
     memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
     memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeaderLength);
-    if (lastByte != 0) {
+    if (!dropLastByte) {
         data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
     }
 

--- a/app/streaming/video/av1obu.h
+++ b/app/streaming/video/av1obu.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdint.h>
+
+// Repacks an AV1 temporal unit in place, merging an OBU_FRAME_HEADER and its
+// OBU_TILE_GROUP into a single OBU_FRAME and hoisting any OBU_METADATA that sat
+// between them ahead of the merged frame.
+//
+// macOS VideoToolbox rejects the split frame header + tile group layout that
+// NVENC emits for AV1 HDR, failing every frame with kVTVideoDecoderMalfunctionErr
+// (-12911). The same encoder uses the merged OBU_FRAME form for SDR, which decodes
+// fine, so rewriting to that form is enough to make HDR decode too.
+//
+// Hoisting the metadata is a free side effect of the merge, and it happens to be
+// what the HDR10+ AV1 Metadata Handling Specification requires: the metadata OBU
+// must precede the frame header.
+//
+// Returns the new length, which is never larger than the original. If the temporal
+// unit doesn't match the layout we rewrite, the buffer is left untouched and the
+// original length is returned.
+int repackAv1TemporalUnit(uint8_t* data, int length);

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -1,5 +1,6 @@
 #include <Limelight.h>
 #include "ffmpeg.h"
+#include "av1obu.h"
 #include "utils.h"
 #include "streaming/session.h"
 #include "streaming/network/bandwidth.h"
@@ -243,6 +244,7 @@ FFmpegVideoDecoder::FFmpegVideoDecoder(bool testOnly)
       m_StreamFps(0),
       m_VideoFormat(0),
       m_NeedsSpsFixup(false),
+      m_NeedsAv1ObuRepack(false),
       m_LoggedHdr10PlusMetadata(false),
       m_TestOnly(testOnly),
       m_CurrentTestMode(TestMode::TestFrameOnly),
@@ -732,6 +734,20 @@ bool FFmpegVideoDecoder::completeInitialization(const AVCodec* decoder, enum AVP
         }
         else {
             m_NeedsSpsFixup = false;
+        }
+
+        // macOS VideoToolbox fails every frame with kVTVideoDecoderMalfunctionErr
+        // when NVENC splits an AV1 frame into OBU_FRAME_HEADER + OBU_TILE_GROUP,
+        // which it does for HDR (but not SDR). Merge them back into an OBU_FRAME
+        // before handing the packet to the decoder.
+        if ((params->videoFormat & VIDEO_FORMAT_MASK_AV1) && m_HwDecodeCfg != nullptr &&
+                m_HwDecodeCfg->device_type == AV_HWDEVICE_TYPE_VIDEOTOOLBOX) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Using AV1 OBU repack for VideoToolbox");
+            m_NeedsAv1ObuRepack = true;
+        }
+        else {
+            m_NeedsAv1ObuRepack = false;
         }
 
         // Tell overlay manager to use this frontend renderer
@@ -2220,6 +2236,10 @@ int FFmpegVideoDecoder::submitDecodeUnit(PDECODE_UNIT du)
     while (entry != nullptr) {
         writeBuffer(entry, offset);
         entry = entry->next;
+    }
+
+    if (m_NeedsAv1ObuRepack) {
+        offset = repackAv1TemporalUnit(reinterpret_cast<uint8_t*>(m_DecodeBuffer.data()), offset);
     }
 
     m_Pkt->data = reinterpret_cast<uint8_t*>(m_DecodeBuffer.data());

--- a/app/streaming/video/ffmpeg.h
+++ b/app/streaming/video/ffmpeg.h
@@ -130,6 +130,7 @@ private:
     int m_OriginalVideoHeight;
     int m_VideoFormat;
     bool m_NeedsSpsFixup;
+    bool m_NeedsAv1ObuRepack;
     bool m_LoggedHdr10PlusMetadata;
     bool m_TestOnly;
     TestMode m_CurrentTestMode;

--- a/docs/av1-videotoolbox-obu-repack.md
+++ b/docs/av1-videotoolbox-obu-repack.md
@@ -103,13 +103,19 @@ byte_alignment() {
 }
 ```
 
-它**只补到下一个字节边界，永远跨不过一整个字节**。所以合并时要做两件事：
+它**只补到下一个字节边界，永远跨不过一整个字节**。所以合并时要做三件事：
 
 1. 清掉停止位 —— 即**最后一个非零字节**的最低置位位（`lastByte &= lastByte - 1`，例 `0x88` → `0x80`）；
 2. **丢掉它后面所有的整零字节**。留着的话，它们会被挪进 `tile_group_obu()` 的载荷里，把帧解坏。
+3. 如果清完停止位之后这个字节本身变成了 `0x00`（原值是 `0x80`），**把它也整个丢掉**，
+   而不是留一个零字节在那里。
 
-只做第 1 件事、把零字节留下是**错的**，这是个很容易踩的坑。若整个载荷全是零，说明码流非法
-（`trailing_bits()` 必然在某处写入停止位），放弃重写。
+第 3 条特别容易漏：`frame_header_obu()` 正好在字节边界结束时，`trailing_bits()` 补出来的就是
+整个 `0x80` 字节，概率大约 1/8，不是边角情况。而合并后 `byte_alignment()` 在这里一位都不补，
+所以那个字节必须消失。留成 `0x00` 跟第 2 条留着补零字节是**同一个 bug**，一样会解坏帧。
+
+只做第 1 件事是**错的**，这是个很容易踩的坑。若整个载荷全是零（或只有一个停止位），
+说明码流非法，放弃重写。
 
 **2. 输出恒不变长，可以就地覆写**
 
@@ -119,6 +125,11 @@ byte_alignment() {
 因为 `leb128(a+b) <= leb128(a) + leb128(b)`，新开销恒小于旧开销，所以**输出永远不比输入长**，
 不需要额外分配缓冲区。搬运顺序从后往前（先 tile group 再 frame header），
 保证没有一次 `memmove` 会踩到后面还要读的字节。
+
+这里有个坑：算「原 OBU 头去掉长度字段之后还剩几字节」时，必须用**长度字段实际占的字节数**，
+不能拿 `leb128Size(payloadLength)` 反推。AV1 的 leb128 **允许非最短编码**（载荷长度 1
+可以写成 `81 00`），拿规范长度去减会少减一个字节，结果在合并头和载荷之间留下游离字节，
+整个 TU 的 OBU 边界就错位了。所以解析时要把实际读到的字节数存下来。
 
 metadata 是唯一需要临时暂存的部分 —— 它要往前挪，而 frame header 的载荷要往后挪，
 两者会交叉。栈上 512 字节足够（HDR10+ T.35 / mastering display / MaxCLL 都远小于 100 字节）。
@@ -134,8 +145,11 @@ metadata 是唯一需要临时暂存的部分 —— 它要往前挪，而 frame
 - 多个 tile group（多 tile 分片传输）
 - 多帧 TU
 - 任何 OBU 的 `obu_has_size_field == 0`（长度不可解，动不得）
-- frame header 载荷全是 `0x00`（码流非法，找不到停止位）
+- frame header 载荷全是 `0x00`，或者除了停止位什么都没有（码流非法）
 - 待前移的 metadata 合计超过 512 字节
+- frame header 和 tile group 的 `obu_extension_flag` 不一致，或扩展字节
+  （`temporal_id` / `spatial_id`）不同 —— 合并会沿用 frame header 的 OBU 头，
+  两者不一致就等于把 tile group 挪进了别的时域/空域层
 
 反过来说，命中重写的条件只跟**布局**有关，跟是哪个编码器无关：任何编码器只要发出
 「frame header + metadata + tile group」这种拆开的形式，都会被合并。上面列出的情况
@@ -212,6 +226,7 @@ typedef struct {
     int type;
     int headerOffset;   // start of the OBU header
     int headerLength;   // header + leb128 size field
+    int sizeBytes;      // length of the leb128 size field as actually encoded
     int payloadOffset;
     int payloadLength;
 } Obu;
@@ -295,6 +310,7 @@ static int parseObus(const uint8_t* data, int length, Obu* obus)
         obus[count].type = (header >> 3) & 0x0F;
         obus[count].headerOffset = pos;
         obus[count].headerLength = headerLength;
+        obus[count].sizeBytes = sizeBytes;
         obus[count].payloadOffset = pos + headerLength;
         obus[count].payloadLength = (int)size;
         count++;
@@ -360,6 +376,19 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
     Obu frameHeader = obus[frameHeaderIdx];
     Obu tileGroup = obus[tileGroupIdx];
 
+    // The merged OBU_FRAME reuses the frame header's OBU header, so the tile group's
+    // header has to agree with it. If they disagree we'd silently move the tile group
+    // into a different temporal/spatial layer, so leave the whole thing alone.
+    uint8_t fhHeader = data[frameHeader.headerOffset];
+    uint8_t tgHeader = data[tileGroup.headerOffset];
+    if ((fhHeader & 0x04) != (tgHeader & 0x04)) {
+        return length;
+    }
+    if ((fhHeader & 0x04) &&
+        data[frameHeader.headerOffset + 1] != data[tileGroup.headerOffset + 1]) {
+        return length;
+    }
+
     // An OBU_FRAME_HEADER payload ends with trailing_bits(obu_size * 8 - payloadBits):
     // a one bit, then zeroes all the way to the end of obu_size. An encoder that
     // over-declares obu_size therefore leaves whole zero bytes at the end, which is
@@ -381,9 +410,21 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
     }
     uint8_t lastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
     lastByte &= lastByte - 1;
+    if (lastByte == 0) {
+        // The byte held nothing but the stop bit (0x80), i.e. frame_header_obu() ended
+        // exactly on a byte boundary. byte_alignment() contributes nothing there, so
+        // this byte has to disappear rather than become a zero - same reason as above.
+        frameHeaderLength--;
+        if (frameHeaderLength == 0) {
+            return length;
+        }
+    }
 
     uint64_t mergedPayloadLength = (uint64_t)frameHeaderLength + tileGroup.payloadLength;
-    int mergedHeaderLength = (frameHeader.headerLength - leb128Size(frameHeader.payloadLength)) +
+    // Recover the OBU header bytes without its size field. Use the size field's actual
+    // encoded width, not leb128Size(): AV1 permits non-minimal leb128, so an encoder may
+    // have written e.g. 81 00 for a payload of 1.
+    int mergedHeaderLength = (frameHeader.headerLength - frameHeader.sizeBytes) +
                              leb128Size(mergedPayloadLength);
 
     int preambleLength = frameHeader.headerOffset;
@@ -402,7 +443,9 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
 
     memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
     memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeaderLength);
-    data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
+    if (lastByte != 0) {
+        data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
+    }
 
     // Reuse the frame header's OBU header so temporal_id/spatial_id survive, but
     // retype it to OBU_FRAME.
@@ -484,6 +527,9 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
 | frame header 载荷全为 `0x00` | 原样返回，字节全等 |
 | metadata 合计 512 字节 | 正常重写（边界内） |
 | metadata 合计 513 字节 | 原样返回，字节全等（拷贝前就退出） |
+| frame header 末字节正好是 `0x80` | 该字节被整个丢掉，不是写成 `0x00` |
+| 长度字段用非最短 leb128（如 `81 00`） | 输出与最短编码的同一帧**逐字节相同** |
+| fh / tg 扩展头不一致 | 原样返回，字节全等 |
 | 合并后长度跨 leb128 边界（如 203） | 长度字段写成 `cb 01`，总长 208→206 |
 | `obu_extension_flag` 置位 | 合并头 `0x36`，ext 字节原样保留，长度正确 |
 

--- a/docs/av1-videotoolbox-obu-repack.md
+++ b/docs/av1-videotoolbox-obu-repack.md
@@ -122,6 +122,8 @@ byte_alignment() {
 
 metadata 是唯一需要临时暂存的部分 —— 它要往前挪，而 frame header 的载荷要往后挪，
 两者会交叉。栈上 512 字节足够（HDR10+ T.35 / mastering display / MaxCLL 都远小于 100 字节）。
+这 512 字节算的是**所有待前移 metadata OBU 的头 + 载荷之和**：合计 **≤ 512 接受，≥ 513
+在任何拷贝发生之前就原样返回**，所以 `memcpy` 到栈缓冲永远不会越界。
 
 **3. 保守匹配，不认识就别动**
 
@@ -133,8 +135,12 @@ metadata 是唯一需要临时暂存的部分 —— 它要往前挪，而 frame
 - 多帧 TU
 - 任何 OBU 的 `obu_has_size_field == 0`（长度不可解，动不得）
 - frame header 载荷全是 `0x00`（码流非法，找不到停止位）
+- 待前移的 metadata 合计超过 512 字节
 
-这样这段代码对所有非 NVENC-AV1-HDR 的场景都是零影响的空操作，爆炸半径最小。
+反过来说，命中重写的条件只跟**布局**有关，跟是哪个编码器无关：任何编码器只要发出
+「frame header + metadata + tile group」这种拆开的形式，都会被合并。上面列出的情况
+则一律一个字节都不碰。所以对已经发 `OBU_FRAME` 的码流（AMF、NVENC 的 SDR 路径）
+以及所有非 AV1 / 非 VideoToolbox 的路径，这段代码是零影响的空操作。
 
 ### 完整实现（纯 C，可直接拖进 Xcode 工程）
 
@@ -476,6 +482,8 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
 | 只有 tile group、没有 frame header | 原样返回，字节全等 |
 | frame header 尾部有整零字节填充 | 零字节被截掉，输出与「没有填充」的同一帧**逐字节相同** |
 | frame header 载荷全为 `0x00` | 原样返回，字节全等 |
+| metadata 合计 512 字节 | 正常重写（边界内） |
+| metadata 合计 513 字节 | 原样返回，字节全等（拷贝前就退出） |
 | 合并后长度跨 leb128 边界（如 203） | 长度字段写成 `cb 01`，总长 208→206 |
 | `obu_extension_flag` 置位 | 合并头 `0x36`，ext 字节原样保留，长度正确 |
 
@@ -491,7 +499,10 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
    HDR10+ AV1 Metadata Handling Specification「metadata 须先于 frame header」的要求，
    AV1 的动态元数据理应也能被取出来用上。
 
-moonlight-qt 上的实测结果（4K120、AV1 10-bit HDR、NVENC）：
+moonlight-qt 上的实测结果（4K120、AV1 10-bit HDR、NVENC）。
+**注意：这份日志抓自 `fd6821b8`，也就是后来那个「截掉尾部整零填充」的修正（`66b7ef2e`）之前。**
+两者只在「编码器把 `obu_size` 报大、留下整字节补零」时输出才有差别，那次抓到的流里
+是否存在这种补零并没有单独确认，所以**当前 commit 的实机复测还没做**：
 
 ```text
 Video stream is 3840x2160x120 (format 0x2000)

--- a/docs/av1-videotoolbox-obu-repack.md
+++ b/docs/av1-videotoolbox-obu-repack.md
@@ -13,8 +13,9 @@ NVENC 在 **AV1 HDR** 路径下会把一帧拆成 `OBU_FRAME_HEADER(3)` + `OBU_T
 修法：**在送进 VideoToolbox 之前，把这两个 OBU 合并回单个 `OBU_FRAME`**。纯字节搬运，
 不需要解析熵编码内容，唯一的位级操作是清掉一个停止位。本文附完整可直接使用的 C 实现。
 
-这跟 HDR10+ 没关系 —— 是 AV1 HDR 通杀。只要你的客户端支持 AV1 且用 VideoToolbox 解码，
-连 NVENC 主机开 HDR 就会中招。
+这跟 HDR10+ 没关系。触发条件是**编码器选了拆开的 OBU 打包**，目前已知 NVENC 在 AV1 HDR
+路径下会这么发（AMF 不会，NVENC 的 AV1 SDR 也不会）。只要你的客户端支持 AV1 且用
+VideoToolbox 解码，连 NVENC 主机开 HDR 就会中招；换个别的编码器如果也这么打包，同样会中。
 
 ---
 
@@ -22,7 +23,7 @@ NVENC 在 **AV1 HDR** 路径下会把一帧拆成 `OBU_FRAME_HEADER(3)` + `OBU_T
 
 macOS 上表现为（iOS 上的日志文本会不同，但错误码一样）：
 
-```
+```text
 vt decoder cb: output image buffer is null: -12911
 HW accel end frame fail.
 avcodec_send_packet() failed
@@ -89,16 +90,26 @@ VideoToolbox 显然只实现了 `OBU_FRAME` 这条路。
 
 **1. `trailing_bits()` 必须处理**（唯一的位级操作，漏掉会解出花屏或直接失败）
 
-`OBU_FRAME_HEADER` 的载荷末尾是 `trailing_bits()`：一个 `1` 停止位 + 补零到字节边界。
-而在 `OBU_FRAME` 内部，`frame_header_obu()` 后面跟的是 `byte_alignment()` —— **纯补零，没有停止位**。
-所以合并时要**清掉 frame header 载荷最后一个字节的最低置位位**：
+`OBU_FRAME_HEADER` 的载荷末尾是 `trailing_bits(obu_size * 8 - payloadBits)`：一个 `1` 停止位，
+然后**一路补零到 `obu_size` 声明的末尾**。注意 `nbBits` 是按 `obu_size` 算的，所以编码器如果把
+`obu_size` 报大了，补零可以跨越整字节 —— **载荷最后一个字节合法地是 `0x00`**。
+
+而在 `OBU_FRAME` 内部，`frame_header_obu()` 后面跟的是 `byte_alignment()`：
 
 ```c
-lastByte &= lastByte - 1;   // 清掉最低的那个 1
+byte_alignment() {
+    while ( get_position( ) & 7 )
+        zero_bit
+}
 ```
 
-例：`0x88` → `0x80`。若最后一个字节是 `0x00`，说明码流非法（`trailing_bits()` 必然写入停止位），
-放弃重写。
+它**只补到下一个字节边界，永远跨不过一整个字节**。所以合并时要做两件事：
+
+1. 清掉停止位 —— 即**最后一个非零字节**的最低置位位（`lastByte &= lastByte - 1`，例 `0x88` → `0x80`）；
+2. **丢掉它后面所有的整零字节**。留着的话，它们会被挪进 `tile_group_obu()` 的载荷里，把帧解坏。
+
+只做第 1 件事、把零字节留下是**错的**，这是个很容易踩的坑。若整个载荷全是零，说明码流非法
+（`trailing_bits()` 必然在某处写入停止位），放弃重写。
 
 **2. 输出恒不变长，可以就地覆写**
 
@@ -121,7 +132,7 @@ metadata 是唯一需要临时暂存的部分 —— 它要往前挪，而 frame
 - 多个 tile group（多 tile 分片传输）
 - 多帧 TU
 - 任何 OBU 的 `obu_has_size_field == 0`（长度不可解，动不得）
-- frame header 载荷为空或末字节为 `0x00`
+- frame header 载荷全是 `0x00`（码流非法，找不到停止位）
 
 这样这段代码对所有非 NVENC-AV1-HDR 的场景都是零影响的空操作，爆炸半径最小。
 
@@ -342,22 +353,30 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
 
     Obu frameHeader = obus[frameHeaderIdx];
     Obu tileGroup = obus[tileGroupIdx];
-    if (frameHeader.payloadLength == 0) {
-        return length;
-    }
 
-    // An OBU_FRAME_HEADER payload ends with trailing_bits(): a one bit followed by
-    // zeroes out to the byte boundary. Inside an OBU_FRAME the frame header is
-    // followed by byte_alignment() instead, which is zeroes only. So the stop bit -
-    // the lowest set bit of the final byte - has to go.
-    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeader.payloadLength - 1];
-    if (lastByte == 0) {
-        // Malformed: trailing_bits() always writes a stop bit into this byte.
+    // An OBU_FRAME_HEADER payload ends with trailing_bits(obu_size * 8 - payloadBits):
+    // a one bit, then zeroes all the way to the end of obu_size. An encoder that
+    // over-declares obu_size therefore leaves whole zero bytes at the end, which is
+    // legal.
+    //
+    // Inside an OBU_FRAME the frame header is followed by byte_alignment() instead,
+    // and that only pads to the next byte boundary - it can never span a whole byte.
+    // So two things have to happen here: the stop bit (the lowest set bit of the last
+    // non-zero byte) goes away, and any whole zero bytes after it get dropped.
+    // Keeping them would shift them into tile_group_obu()'s payload and corrupt the
+    // frame.
+    int frameHeaderLength = frameHeader.payloadLength;
+    while (frameHeaderLength > 0 && data[frameHeader.payloadOffset + frameHeaderLength - 1] == 0) {
+        frameHeaderLength--;
+    }
+    if (frameHeaderLength == 0) {
+        // Malformed: trailing_bits() always writes a stop bit somewhere.
         return length;
     }
+    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
     lastByte &= lastByte - 1;
 
-    uint64_t mergedPayloadLength = (uint64_t)frameHeader.payloadLength + tileGroup.payloadLength;
+    uint64_t mergedPayloadLength = (uint64_t)frameHeaderLength + tileGroup.payloadLength;
     int mergedHeaderLength = (frameHeader.headerLength - leb128Size(frameHeader.payloadLength)) +
                              leb128Size(mergedPayloadLength);
 
@@ -373,11 +392,11 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
     // move clobbers bytes a later move still needs to read.
     int mergedHeaderOffset = preambleLength + metadataLength;
     int frameHeaderDest = mergedHeaderOffset + mergedHeaderLength;
-    int tileGroupDest = frameHeaderDest + frameHeader.payloadLength;
+    int tileGroupDest = frameHeaderDest + frameHeaderLength;
 
     memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
-    memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeader.payloadLength);
-    data[frameHeaderDest + frameHeader.payloadLength - 1] = lastByte;
+    memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeaderLength);
+    data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
 
     // Reuse the frame header's OBU header so temporal_id/spatial_id survive, but
     // retype it to OBU_FRAME.
@@ -455,7 +474,8 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
 | AMF 布局 `2,5,6` | 原样返回，字节全等 |
 | 两个 tile group | 原样返回，字节全等 |
 | 只有 tile group、没有 frame header | 原样返回，字节全等 |
-| frame header 末字节 `0x00` | 原样返回，字节全等 |
+| frame header 尾部有整零字节填充 | 零字节被截掉，输出与「没有填充」的同一帧**逐字节相同** |
+| frame header 载荷全为 `0x00` | 原样返回，字节全等 |
 | 合并后长度跨 leb128 边界（如 203） | 长度字段写成 `cb 01`，总长 208→206 |
 | `obu_extension_flag` 置位 | 合并头 `0x36`，ext 字节原样保留，长度正确 |
 
@@ -473,7 +493,7 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
 
 moonlight-qt 上的实测结果（4K120、AV1 10-bit HDR、NVENC）：
 
-```
+```text
 Video stream is 3840x2160x120 (format 0x2000)
 Using AV1 OBU repack for VideoToolbox
 [av1] Total OBUs on this packet: 3.   OBU idx:0 type:2 / idx:1 type:1 / idx:2 type:6

--- a/docs/av1-videotoolbox-obu-repack.md
+++ b/docs/av1-videotoolbox-obu-repack.md
@@ -107,12 +107,17 @@ byte_alignment() {
 
 1. 清掉停止位 —— 即**最后一个非零字节**的最低置位位（`lastByte &= lastByte - 1`，例 `0x88` → `0x80`）；
 2. **丢掉它后面所有的整零字节**。留着的话，它们会被挪进 `tile_group_obu()` 的载荷里，把帧解坏。
-3. 如果清完停止位之后这个字节本身变成了 `0x00`（原值是 `0x80`），**把它也整个丢掉**，
-   而不是留一个零字节在那里。
+3. 如果这个字节的**原值恰好是 `0x80`**，**把它也整个丢掉**，而不是留一个零字节在那里。
 
 第 3 条特别容易漏：`frame_header_obu()` 正好在字节边界结束时，`trailing_bits()` 补出来的就是
 整个 `0x80` 字节，概率大约 1/8，不是边角情况。而合并后 `byte_alignment()` 在这里一位都不补，
 所以那个字节必须消失。留成 `0x00` 跟第 2 条留着补零字节是**同一个 bug**，一样会解坏帧。
+
+但判据必须是**原值等于 `0x80`**，不能是「清完停止位之后等于 `0x00`」—— 后者太宽。
+比如 `0x20`（`0010 0000`）清完也是 `0x00`，可它的高 2 位是**真实的载荷位**（值恰好为零），
+只是 `frame_header_obu()` 在这个字节里只用掉了 2 位。这时 `byte_alignment()` 会补满剩下的
+6 位，字节仍然存在，必须原样留成 `0x00`。丢掉它就会把 `tile_group_obu()` 整体前移一个字节。
+只有原值 `0x80` 时停止位落在字节的第一位，整个字节不含任何载荷位，才该消失。
 
 只做第 1 件事是**错的**，这是个很容易踩的坑。若整个载荷全是零（或只有一个停止位），
 说明码流非法，放弃重写。
@@ -408,12 +413,16 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
         // Malformed: trailing_bits() always writes a stop bit somewhere.
         return length;
     }
-    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
-    lastByte &= lastByte - 1;
-    if (lastByte == 0) {
-        // The byte held nothing but the stop bit (0x80), i.e. frame_header_obu() ended
-        // exactly on a byte boundary. byte_alignment() contributes nothing there, so
-        // this byte has to disappear rather than become a zero - same reason as above.
+    uint8_t origLastByte = data[frameHeader.payloadOffset + frameHeaderLength - 1];
+    uint8_t lastByte = origLastByte & (origLastByte - 1);
+    // Exactly 0x80 means the stop bit was the first bit of the byte, i.e.
+    // frame_header_obu() ended on the previous byte boundary and this byte carries no
+    // payload bits at all. byte_alignment() contributes nothing there, so the byte has
+    // to disappear rather than become a zero - same reason as the zero bytes above.
+    // Any other single-bit value (0x20, 0x40, ...) still holds real payload bits ahead
+    // of the stop bit, so it stays as 0x00 and byte_alignment() pads out the rest.
+    int dropLastByte = (origLastByte == 0x80);
+    if (dropLastByte) {
         frameHeaderLength--;
         if (frameHeaderLength == 0) {
             return length;
@@ -443,7 +452,7 @@ int repackAv1TemporalUnit(uint8_t* data, int length)
 
     memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
     memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeaderLength);
-    if (lastByte != 0) {
+    if (!dropLastByte) {
         data[frameHeaderDest + frameHeaderLength - 1] = lastByte;
     }
 
@@ -528,6 +537,7 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
 | metadata 合计 512 字节 | 正常重写（边界内） |
 | metadata 合计 513 字节 | 原样返回，字节全等（拷贝前就退出） |
 | frame header 末字节正好是 `0x80` | 该字节被整个丢掉，不是写成 `0x00` |
+| frame header 末字节是 `0x20` 等其他单比特值 | 该字节**保留**并写成 `0x00`（高位是真实载荷位） |
 | 长度字段用非最短 leb128（如 `81 00`） | 输出与最短编码的同一帧**逐字节相同** |
 | fh / tg 扩展头不一致 | 原样返回，字节全等 |
 | 合并后长度跨 leb128 边界（如 203） | 长度字段写成 `cb 01`，总长 208→206 |

--- a/docs/av1-videotoolbox-obu-repack.md
+++ b/docs/av1-videotoolbox-obu-repack.md
@@ -1,0 +1,500 @@
+# AV1 + HDR 在 VideoToolbox 上黑屏：起因与移植到 iOS 的做法
+
+> 这份文档是给 **moonlight-ios**（以及任何直接用 VideoToolbox 解码的 Apple 平台客户端）看的。
+> moonlight-qt 侧的修复见 [#168](https://github.com/qiin2333/moonlight-qt/pull/168)，
+> 实现文件是 `app/streaming/video/av1obu.{h,cpp}`。
+
+## TL;DR
+
+NVENC 在 **AV1 HDR** 路径下会把一帧拆成 `OBU_FRAME_HEADER(3)` + `OBU_TILE_GROUP(4)` 两个 OBU，
+而 SDR 路径下发的是合并的 `OBU_FRAME(6)`。**VideoToolbox 吞不下拆开的那种**，每一帧都返回
+`kVTVideoDecoderMalfunctionErr (-12911)`，一帧都解不出来 → 黑屏。
+
+修法：**在送进 VideoToolbox 之前，把这两个 OBU 合并回单个 `OBU_FRAME`**。纯字节搬运，
+不需要解析熵编码内容，唯一的位级操作是清掉一个停止位。本文附完整可直接使用的 C 实现。
+
+这跟 HDR10+ 没关系 —— 是 AV1 HDR 通杀。只要你的客户端支持 AV1 且用 VideoToolbox 解码，
+连 NVENC 主机开 HDR 就会中招。
+
+---
+
+## 症状
+
+macOS 上表现为（iOS 上的日志文本会不同，但错误码一样）：
+
+```
+vt decoder cb: output image buffer is null: -12911
+HW accel end frame fail.
+avcodec_send_packet() failed
+```
+
+`-12911` = `kVTVideoDecoderMalfunctionErr`。特征是**每一帧都失败，成功率为零**，
+不是偶发花屏或丢帧。客户端如果有「解码失败 → 重启解码器 → 请求 IDR」的逻辑，
+就会陷入死循环，用户看到的就是纯黑屏 + 偶尔闪一下。
+
+HEVC（包括 HEVC HDR / HDR10+）在同一台主机上完全正常，所以很容易被误判成
+「HDR 元数据的问题」或「主机的问题」。都不是。
+
+## 根因
+
+同一台 M4、同一台 NVENC 主机 `212333.monster`，对比首帧的 OBU 序列：
+
+| 场景 | 首帧 OBU 序列 | 结果 |
+|---|---|---|
+| AV1 8-bit **SDR**（NVENC） | `TD(2), SeqHdr(1), FRAME(6)` | 正常，连跑数小时 |
+| AV1 10-bit **HDR**（NVENC） | `TD(2), SeqHdr(1), FRAME_HEADER(3), TILE_GROUP(4)` | **每帧 -12911** |
+| AV1 10-bit HDR（**AMF** 主机） | `TD(2), SeqHdr(1), METADATA(5), FRAME(6)` | 正常 |
+| HEVC HDR10+（NVENC） | — | 正常 |
+
+唯一的变量就是 **frame header 和 tile group 有没有合并成一个 `OBU_FRAME`**。
+分辨率、tile 数、码率、丢包都排除了：4K 和 1080p 都复现，0% 丢包也复现。
+
+按 AV1 spec，`OBU_FRAME` 只是 `OBU_FRAME_HEADER` + `OBU_TILE_GROUP` 的等价打包形式
+（spec 5.10 `frame_obu()`），两者语义完全相同，合法解码器**应该**都支持。
+VideoToolbox 显然只实现了 `OBU_FRAME` 这条路。
+
+### 排除掉的几个嫌疑
+
+**HDR10+ 元数据不是元凶。** 最初我以为是 metadata OBU 夹在 frame header 和 tile group
+中间违反了 HDR10+ AV1 Metadata Handling Specification 的顺序要求。但 1080p 那次会话的
+**第一个 IDR 完全没有 metadata OBU**（序列就是 `2,1,3,4`），照样 -12911。
+元数据的存在与位置都不是触发条件。
+
+**FFmpeg 无辜**（如果你的客户端也走 FFmpeg 的 VT hwaccel）。
+`videotoolbox_av1.c` 的 `end_frame` 按 `start_unit..nb_unit` 把整段 OBU 原样拼给 VT，
+`av1dec.c` 里 `s->nb_unit = i + 1`（`i` 为 tile group 下标）把 tile group 算进了范围，
+一个 OBU 都没漏。iOS 如果是自己构造 `CMBlockBuffer` 直接喂 `VTDecompressionSession`，
+那更是原样透传，同样中招。
+
+**主机端拧不动。** `nvEncodeAPI.h` 的 `NV_ENC_CONFIG_AV1` / `NV_ENC_PIC_PARAMS_AV1` 里
+**没有任何字段控制 OBU 打包方式**（没有 `enableFrameOBU` 之类），由驱动自己决定。
+所以只能修在客户端 —— 好处是对**任何**主机都生效：上游 Sunshine、老驱动、GFN 都不用改。
+
+### 时间线
+
+主机端 AV1 的静态 HDR 元数据（`pMasteringDisplay` / `pMaxCll`）是 foundation-sunshine
+`a3bd8799`（2025-12-26，#389）加进去的。**macOS/iOS 上的 AV1 HDR 很可能从 2025 年 12 月起
+就一直是黑的**，不是最近哪个 PR 弄坏的。如果 iOS 那边有「AV1 开 HDR 就黑屏」的老 issue，
+八成就是这个。
+
+---
+
+## 修法
+
+在**把 temporal unit 交给 VideoToolbox 之前**，就地把
+`FRAME_HEADER + TILE_GROUP` 合并成单个 `OBU_FRAME`，顺带把夹在中间的 metadata OBU
+提到合并帧之前。
+
+### 三个关键点
+
+**1. `trailing_bits()` 必须处理**（唯一的位级操作，漏掉会解出花屏或直接失败）
+
+`OBU_FRAME_HEADER` 的载荷末尾是 `trailing_bits()`：一个 `1` 停止位 + 补零到字节边界。
+而在 `OBU_FRAME` 内部，`frame_header_obu()` 后面跟的是 `byte_alignment()` —— **纯补零，没有停止位**。
+所以合并时要**清掉 frame header 载荷最后一个字节的最低置位位**：
+
+```c
+lastByte &= lastByte - 1;   // 清掉最低的那个 1
+```
+
+例：`0x88` → `0x80`。若最后一个字节是 `0x00`，说明码流非法（`trailing_bits()` 必然写入停止位），
+放弃重写。
+
+**2. 输出恒不变长，可以就地覆写**
+
+- 旧开销：`2` 个 OBU 头 + `leb128(fh) + leb128(tg)`
+- 新开销：`1` 个 OBU 头 + `leb128(fh + tg)`
+
+因为 `leb128(a+b) <= leb128(a) + leb128(b)`，新开销恒小于旧开销，所以**输出永远不比输入长**，
+不需要额外分配缓冲区。搬运顺序从后往前（先 tile group 再 frame header），
+保证没有一次 `memmove` 会踩到后面还要读的字节。
+
+metadata 是唯一需要临时暂存的部分 —— 它要往前挪，而 frame header 的载荷要往后挪，
+两者会交叉。栈上 512 字节足够（HDR10+ T.35 / mastering display / MaxCLL 都远小于 100 字节）。
+
+**3. 保守匹配，不认识就别动**
+
+只处理「恰好一个 frame header，其后恰好一个 tile group 且位于 TU 末尾，两者之间只有 metadata」
+这一种布局。以下情况一律**原样返回、一个字节都不碰**：
+
+- 已经是 `OBU_FRAME`（AMF 主机、NVENC 的 SDR 路径）
+- 多个 tile group（多 tile 分片传输）
+- 多帧 TU
+- 任何 OBU 的 `obu_has_size_field == 0`（长度不可解，动不得）
+- frame header 载荷为空或末字节为 `0x00`
+
+这样这段代码对所有非 NVENC-AV1-HDR 的场景都是零影响的空操作，爆炸半径最小。
+
+### 完整实现（纯 C，可直接拖进 Xcode 工程）
+
+不依赖 FFmpeg、不依赖任何库，只用 `<stdint.h>` 和 `<string.h>`。
+头文件带 `extern "C"` 守卫，`.m` / `.mm` / `.cpp` 都能用。
+
+**`av1obu.h`**
+
+```c
+#ifndef AV1OBU_H
+#define AV1OBU_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Repacks an AV1 temporal unit in place, merging an OBU_FRAME_HEADER and its
+// OBU_TILE_GROUP into a single OBU_FRAME and hoisting any OBU_METADATA that sat
+// between them ahead of the merged frame.
+//
+// macOS VideoToolbox rejects the split frame header + tile group layout that
+// NVENC emits for AV1 HDR, failing every frame with kVTVideoDecoderMalfunctionErr
+// (-12911). The same encoder uses the merged OBU_FRAME form for SDR, which decodes
+// fine, so rewriting to that form is enough to make HDR decode too.
+//
+// Hoisting the metadata is a free side effect of the merge, and it happens to be
+// what the HDR10+ AV1 Metadata Handling Specification requires: the metadata OBU
+// must precede the frame header.
+//
+// Returns the new length, which is never larger than the original. If the temporal
+// unit doesn't match the layout we rewrite, the buffer is left untouched and the
+// original length is returned.
+int repackAv1TemporalUnit(uint8_t* data, int length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+```
+
+**`av1obu.c`**
+
+```c
+#include "av1obu.h"
+
+#include <string.h>
+
+// OBU types we care about (AV1 spec 6.2.2)
+#define OBU_TEMPORAL_DELIMITER 2
+#define OBU_FRAME_HEADER       3
+#define OBU_TILE_GROUP         4
+#define OBU_METADATA           5
+#define OBU_FRAME              6
+
+// A temporal unit from a streaming host is a handful of OBUs. Anything longer is
+// not the layout we rewrite, so we can bail out rather than grow this.
+#define MAX_OBUS 16
+
+// Metadata OBUs that need hoisting are HDR10+ ITU-T T.35, mastering display, and
+// content light level payloads - all well under 100 bytes. They have to be stashed
+// because they move backwards past the frame header while the frame header's own
+// payload moves forwards past them.
+#define MAX_HOISTED_METADATA 512
+
+typedef struct {
+    int type;
+    int headerOffset;   // start of the OBU header
+    int headerLength;   // header + leb128 size field
+    int payloadOffset;
+    int payloadLength;
+} Obu;
+
+static int leb128Size(uint64_t value)
+{
+    int size = 0;
+    do {
+        size++;
+        value >>= 7;
+    } while (value != 0);
+    return size;
+}
+
+static int writeLeb128(uint8_t* out, uint64_t value)
+{
+    int size = 0;
+    do {
+        uint8_t byte = value & 0x7F;
+        value >>= 7;
+        if (value != 0) {
+            byte |= 0x80;
+        }
+        out[size++] = byte;
+    } while (value != 0);
+    return size;
+}
+
+// Parses the temporal unit into obus[]. Returns the OBU count, or -1 if the data
+// is malformed or uses a form we can't safely rewrite (missing size fields).
+static int parseObus(const uint8_t* data, int length, Obu* obus)
+{
+    int count = 0;
+    int pos = 0;
+
+    while (pos < length) {
+        if (count == MAX_OBUS) {
+            return -1;
+        }
+
+        uint8_t header = data[pos];
+        if (header & 0x80) {
+            // obu_forbidden_bit must be zero
+            return -1;
+        }
+
+        int headerLength = 1;
+        if (header & 0x04) {
+            // obu_extension_flag: one more byte of temporal_id/spatial_id
+            headerLength++;
+        }
+        if (!(header & 0x02)) {
+            // No obu_size field, so the OBU runs to the end of the buffer and we
+            // can't rewrite anything around it.
+            return -1;
+        }
+        if (pos + headerLength >= length) {
+            return -1;
+        }
+
+        // leb128 obu_size
+        uint64_t size = 0;
+        int sizeBytes = 0;
+        for (;;) {
+            if (sizeBytes == 8 || pos + headerLength + sizeBytes >= length) {
+                return -1;
+            }
+            uint8_t byte = data[pos + headerLength + sizeBytes];
+            size |= (uint64_t)(byte & 0x7F) << (7 * sizeBytes);
+            sizeBytes++;
+            if (!(byte & 0x80)) {
+                break;
+            }
+        }
+        headerLength += sizeBytes;
+
+        if (size > (uint64_t)(length - (pos + headerLength))) {
+            return -1;
+        }
+
+        obus[count].type = (header >> 3) & 0x0F;
+        obus[count].headerOffset = pos;
+        obus[count].headerLength = headerLength;
+        obus[count].payloadOffset = pos + headerLength;
+        obus[count].payloadLength = (int)size;
+        count++;
+
+        pos += headerLength + (int)size;
+    }
+
+    return count;
+}
+
+int repackAv1TemporalUnit(uint8_t* data, int length)
+{
+    Obu obus[MAX_OBUS];
+    int count = parseObus(data, length, obus);
+    if (count <= 0) {
+        return length;
+    }
+
+    // Find the split frame we're here to merge. We only handle the exact layout
+    // NVENC produces: a single frame header, optional metadata, then a single tile
+    // group that ends the temporal unit.
+    int frameHeaderIdx = -1;
+    int tileGroupIdx = -1;
+    for (int i = 0; i < count; i++) {
+        switch (obus[i].type) {
+        case OBU_FRAME:
+            // Already in the merged form the decoder wants
+            return length;
+        case OBU_FRAME_HEADER:
+            if (frameHeaderIdx >= 0) {
+                return length;
+            }
+            frameHeaderIdx = i;
+            break;
+        case OBU_TILE_GROUP:
+            if (tileGroupIdx >= 0) {
+                return length;
+            }
+            tileGroupIdx = i;
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (frameHeaderIdx < 0 || tileGroupIdx != count - 1 || tileGroupIdx < frameHeaderIdx) {
+        return length;
+    }
+
+    // Everything between the frame header and the tile group gets hoisted ahead of
+    // the merged frame. Only metadata belongs there.
+    int metadataLength = 0;
+    for (int i = frameHeaderIdx + 1; i < tileGroupIdx; i++) {
+        if (obus[i].type != OBU_METADATA) {
+            return length;
+        }
+        metadataLength += obus[i].headerLength + obus[i].payloadLength;
+    }
+    if (metadataLength > MAX_HOISTED_METADATA) {
+        return length;
+    }
+
+    Obu frameHeader = obus[frameHeaderIdx];
+    Obu tileGroup = obus[tileGroupIdx];
+    if (frameHeader.payloadLength == 0) {
+        return length;
+    }
+
+    // An OBU_FRAME_HEADER payload ends with trailing_bits(): a one bit followed by
+    // zeroes out to the byte boundary. Inside an OBU_FRAME the frame header is
+    // followed by byte_alignment() instead, which is zeroes only. So the stop bit -
+    // the lowest set bit of the final byte - has to go.
+    uint8_t lastByte = data[frameHeader.payloadOffset + frameHeader.payloadLength - 1];
+    if (lastByte == 0) {
+        // Malformed: trailing_bits() always writes a stop bit into this byte.
+        return length;
+    }
+    lastByte &= lastByte - 1;
+
+    uint64_t mergedPayloadLength = (uint64_t)frameHeader.payloadLength + tileGroup.payloadLength;
+    int mergedHeaderLength = (frameHeader.headerLength - leb128Size(frameHeader.payloadLength)) +
+                             leb128Size(mergedPayloadLength);
+
+    int preambleLength = frameHeader.headerOffset;
+
+    uint8_t metadata[MAX_HOISTED_METADATA];
+    if (metadataLength > 0) {
+        memcpy(metadata, data + obus[frameHeaderIdx + 1].headerOffset, metadataLength);
+    }
+
+    // Lay out [preamble][metadata][OBU_FRAME header][frame header][tile group].
+    // The preamble doesn't move. Everything else is written back to front so no
+    // move clobbers bytes a later move still needs to read.
+    int mergedHeaderOffset = preambleLength + metadataLength;
+    int frameHeaderDest = mergedHeaderOffset + mergedHeaderLength;
+    int tileGroupDest = frameHeaderDest + frameHeader.payloadLength;
+
+    memmove(data + tileGroupDest, data + tileGroup.payloadOffset, tileGroup.payloadLength);
+    memmove(data + frameHeaderDest, data + frameHeader.payloadOffset, frameHeader.payloadLength);
+    data[frameHeaderDest + frameHeader.payloadLength - 1] = lastByte;
+
+    // Reuse the frame header's OBU header so temporal_id/spatial_id survive, but
+    // retype it to OBU_FRAME.
+    data[mergedHeaderOffset] = (data[frameHeader.headerOffset] & ~0x78) | (OBU_FRAME << 3);
+    int written = 1;
+    if (data[mergedHeaderOffset] & 0x04) {
+        data[mergedHeaderOffset + 1] = data[frameHeader.headerOffset + 1];
+        written++;
+    }
+    written += writeLeb128(data + mergedHeaderOffset + written, mergedPayloadLength);
+
+    if (metadataLength > 0) {
+        memcpy(data + preambleLength, metadata, metadataLength);
+    }
+
+    return tileGroupDest + tileGroup.payloadLength;
+}
+```
+
+> 上面这份 C 版本我用 `clang -std=c99 -Wall -Wextra` 编过，零警告，
+> 并且用同一套 harness 跑出来跟 moonlight-qt 里的 C++ 版**逐字节一致**。
+
+### 接在哪里
+
+调用点要满足两个条件：**整个 temporal unit 已经拼成一段连续内存**，且**还没交给 VideoToolbox**。
+
+对 moonlight-common-c 的客户端来说这很好定位：AV1 的 DU **所有 buffer 都是
+`BUFFER_TYPE_PICDATA`**（见 `Limelight.h`，只有 H.264/HEVC 才会拆出 VPS/SPS/PPS 类型），
+所以在 `DecoderRendererSubmitDecodeUnit` 回调里把 `du->bufferList` 顺着 `next` 拼完之后，
+缓冲区里就是完整的一个 temporal unit。在这之后、构造 `CMBlockBuffer` 之前插一行：
+
+```c
+if (needsAv1ObuRepack) {
+    offset = repackAv1TemporalUnit(buffer, offset);
+}
+// 然后拿 offset 当长度去建 CMBlockBuffer / CMSampleBuffer
+```
+
+moonlight-qt 里就是这么接的（`ffmpeg.cpp` 的 `submitDecodeUnit()`，紧跟在
+`writeBuffer()` 循环之后、`m_Pkt->size = offset` 之前）。
+
+**开关建议**：只在「AV1 + VideoToolbox」时置位，别无条件开。
+
+```c
+needsAv1ObuRepack = (videoFormat & VIDEO_FORMAT_MASK_AV1) != 0;
+```
+
+iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
+不建议再按「是否 HDR」收窄 —— 触发条件是编码器的打包选择，不是 HDR 本身，
+而且函数对已经是 `OBU_FRAME` 的码流是零成本空操作（解析几个 OBU 头就返回了）。
+
+### 注意事项
+
+- **不要动 sequence header。** 重写只碰 frame header / tile group / metadata。
+  如果你从 sequence header 构造 `av1C` / `CMFormatDescription`，那条路完全不受影响。
+- **函数会就地修改缓冲区。** 确保传进去的是你自己的可写拼接缓冲，不是 moonlight-common-c
+  的 DU 内存。
+- **返回值是新长度，必须用它**，别继续用原来的 `offset`，否则尾部会多出 2 字节垃圾。
+- **性能可忽略。** 只解析 OBU 头 + 两次 `memmove`，4K 帧上是微秒级，
+  而且不匹配时连 `memmove` 都不会发生。
+
+---
+
+## 验证
+
+### 单元层面
+
+我用的 harness 覆盖了这些用例，移植后建议照着跑一遍：
+
+| 用例 | 期望 |
+|---|---|
+| 拆帧、无 metadata | `2,1,3,4` → `2,1,6`；长度 63→61；停止位 `0x88`→`0x80` |
+| 拆帧、带 metadata | `2,1,3,5,4` → `2,1,5,6`；metadata 前移，内容不变 |
+| 已是 `OBU_FRAME` | 原样返回，字节全等 |
+| AMF 布局 `2,5,6` | 原样返回，字节全等 |
+| 两个 tile group | 原样返回，字节全等 |
+| 只有 tile group、没有 frame header | 原样返回，字节全等 |
+| frame header 末字节 `0x00` | 原样返回，字节全等 |
+| 合并后长度跨 leb128 边界（如 203） | 长度字段写成 `cb 01`，总长 208→206 |
+| `obu_extension_flag` 置位 | 合并头 `0x36`，ext 字节原样保留，长度正确 |
+
+一个通用的自检：重写后从头把 OBU 走一遍，**消耗的字节数必须正好等于返回的新长度**。
+
+### 实机
+
+连一台 NVENC 主机开 AV1 + HDR，主判据：
+
+1. **出画、不黑**，且 `-12911` 出现 0 次。
+2. 如果你能打出 OBU 序列，应该从 `2,1,3,5,4` 变成 `2,1,5,6`。
+3. 顺带看一眼 HDR10+ 有没有被识别 —— metadata 前移之后正好满足
+   HDR10+ AV1 Metadata Handling Specification「metadata 须先于 frame header」的要求，
+   AV1 的动态元数据理应也能被取出来用上。
+
+moonlight-qt 上的实测结果（4K120、AV1 10-bit HDR、NVENC）：
+
+```
+Video stream is 3840x2160x120 (format 0x2000)
+Using AV1 OBU repack for VideoToolbox
+[av1] Total OBUs on this packet: 3.   OBU idx:0 type:2 / idx:1 type:1 / idx:2 type:6
+Received HDR10+ dynamic metadata from the AV1 bitstream
+```
+
+`-12911` / `HW accel end frame fail` / `avcodec_send_packet() failed` 各 0 次，
+0.00% 丢包，解码 6.52ms。
+
+### 回归
+
+这三条路重写函数都会原样返回、一个字节都不碰，但还是各连一次更稳：
+
+- AMF 主机的 AV1 HDR（本来就发 `OBU_FRAME`）
+- NVENC 的 AV1 SDR（同上）
+- HEVC（`needsAv1ObuRepack` 为 false，一行都走不到）
+
+---
+
+## 附：一个顺带发现（不影响本问题）
+
+foundation-sunshine 的 `src/nvenc/common_impl/nvenc_base.cpp` 里，
+AV1 的 `outputMaxCll` / `outputMasteringDisplay` 是**无条件**设的 —— SDR 也设。
+看着像个独立的小 bug，但跟这次的黑屏无关，也不在本次修复范围内。

--- a/docs/av1-videotoolbox-obu-repack.md
+++ b/docs/av1-videotoolbox-obu-repack.md
@@ -499,20 +499,31 @@ iOS 上解码器只有 VideoToolbox 一条路，所以判 AV1 就够了。
    HDR10+ AV1 Metadata Handling Specification「metadata 须先于 frame header」的要求，
    AV1 的动态元数据理应也能被取出来用上。
 
-moonlight-qt 上的实测结果（4K120、AV1 10-bit HDR、NVENC）。
-**注意：这份日志抓自 `fd6821b8`，也就是后来那个「截掉尾部整零填充」的修正（`66b7ef2e`）之前。**
-两者只在「编码器把 `obu_size` 报大、留下整字节补零」时输出才有差别，那次抓到的流里
-是否存在这种补零并没有单独确认，所以**当前 commit 的实机复测还没做**：
+moonlight-qt 上的实测结果（M4、4K120、AV1 10-bit HDR、NVENC 主机）：
 
 ```text
-Video stream is 3840x2160x120 (format 0x2000)
+Video stream is 3840x2160x120 (format 0x2000)   # AV1 MAIN10，请求里 hdrMode=1
 Using AV1 OBU repack for VideoToolbox
+[av1] Format videotoolbox_vld chosen by get_format().
 [av1] Total OBUs on this packet: 3.   OBU idx:0 type:2 / idx:1 type:1 / idx:2 type:6
 Received HDR10+ dynamic metadata from the AV1 bitstream
 ```
 
-`-12911` / `HW accel end frame fail` / `avcodec_send_packet() failed` 各 0 次，
-0.00% 丢包，解码 6.52ms。
+- `-12911` / `output image buffer is null` / `HW accel end frame fail` /
+  `avcodec_send_packet() failed` **各 0 次**。
+- 整场会话里**没有出现过一个 `type:3` 或 `type:4`** —— 拆帧全部被合并掉了。
+- HDR10+ 那行**没有 `(ignored: ...)` 后缀**，说明渲染器真的取用了动态元数据。
+- 55.0 Rx / 55.0 De / 54.1 Rd，丢包 0.00%，解码 4.16ms。
+
+注意这里渲染器是 Vulkan(libplacebo)，但硬解走的仍然是 `videotoolbox_vld`
+（日志里的 `AV1 decode get format: videotoolbox_vld`），所以命中的正是原来黑屏的那条路。
+判断开关时要看的是 **hwaccel 是不是 VideoToolbox**，不是渲染器是什么。
+
+**这份实测能证明什么、不能证明什么：** 它证明了合并逻辑在真实码流上有效、且没有引入回归。
+但日志里只看得到重写**之后**的结果，看不出这台编码器有没有把 `obu_size` 报大、
+在 frame header 尾部留下整字节补零 —— 也就是「截掉尾部整零填充」那条分支
+**是否被实机走到过，无法从日志判定**。那条分支目前由单元测试覆盖
+（有补零和无补零的同一帧输出逐字节相同）。它是纯收紧的改动：没有补零时行为与不做截断完全一致。
 
 ### 回归
 


### PR DESCRIPTION
## 问题

macOS 上用 **AV1 + HDR** 连 NVENC 主机全程黑屏：每一帧都是

```
vt decoder cb: output image buffer is null: -12911   (kVTVideoDecoderMalfunctionErr)
HW accel end frame fail.
avcodec_send_packet() failed
```

一帧都解不出来，客户端陷入「重启解码器 → 请求 IDR」死循环。HEVC HDR（含 HDR10+）在同一台主机上完全正常。

## 定位

同一台 M4、同一台 NVENC 主机，对比日志里的首帧 OBU 序列：

| 场景 | 首帧 OBU 序列 | 结果 |
|---|---|---|
| AV1 8-bit SDR（NVENC） | `TD(2), SeqHdr(1), FRAME(6)` | 正常，连跑数小时 |
| AV1 10-bit HDR（NVENC） | `TD, SeqHdr, FRAME_HEADER(3), TILE_GROUP(4)` | 每帧 -12911 |
| AV1 10-bit HDR（AMF） | `TD, SeqHdr, METADATA(5), FRAME(6)` | 正常 |
| HEVC HDR10+（NVENC） | — | 正常 |

**NVENC 在 AV1 HDR 路径下把一帧拆成 `FRAME_HEADER` + `TILE_GROUP`，SDR 路径下发的却是合并的 `OBU_FRAME`** —— VideoToolbox 吞不下拆开的那种。

排除项：

- **HDR10+ 元数据不是元凶**。1080p 那次的第一个 IDR 完全没有 metadata OBU，照样 -12911。
- **FFmpeg 无辜**。`videotoolbox_av1.c` 的 `end_frame` 按 `start_unit..nb_unit` 把整段 OBU 原样拼给 VT，`av1dec.c` 里 `s->nb_unit = i + 1`（i 为 tile group 下标）把 tile group 算进了范围，一个 OBU 都没漏。
- **主机端拧不动**。`nvEncodeAPI.h` 的 `NV_ENC_CONFIG_AV1` / `NV_ENC_PIC_PARAMS_AV1` 里没有任何字段控制 OBU 打包方式，由驱动决定。

所以修在客户端，对**任何**主机（上游 Sunshine、旧驱动、GFN）都生效。

顺带一提，主机端 AV1 的静态 HDR 元数据是 2025-12 加的，macOS 上的 AV1 HDR 很可能从那时起就一直黑屏，不是最近几个 PR 弄坏的。

## 改动

新增 `app/streaming/video/av1obu.{h,cpp}`，自包含、不依赖 FFmpeg，只做字节层面的搬运：

```cpp
int repackAv1TemporalUnit(uint8_t* data, int length);
```

送进解码器之前把 `FRAME_HEADER` + `TILE_GROUP` 合并回单个 `OBU_FRAME`，顺带把夹在中间的 metadata OBU 提到帧之前 —— 后者正好是 HDR10+ AV1 Metadata Handling Specification 要求的顺序（metadata 须先于 frame header）。

几个要点：

- **trailing_bits 修正**（唯一的位级操作）：`OBU_FRAME_HEADER` 载荷末尾是 `trailing_bits()`（一个停止位 + 补零到字节边界），而 `OBU_FRAME` 里 `frame_header_obu()` 后面跟的是 `byte_alignment()`（纯补零），所以要清掉载荷最后一个字节的**最低置位位**。
- **输出恒不变长**：新开销 `1 + ext + leb128(fh+tg)` 恒小于旧开销 `2 + ext + leb128(fh) + leb128(tg)`，所以可以就地覆写，不需要额外缓冲。搬运顺序从后往前，不会踩到还没读的字节。
- **保守匹配**：恰好一个 frame header、其后恰好一个 tile group 且位于 TU 末尾，两者之间只允许 metadata。已经是 `OBU_FRAME`、多个 tile group、缺 `obu_size` 字段、frame header 末字节为 `0x00` 等一律原样返回，不碰缓冲区。
- 合并后的 OBU 沿用 frame header 的 extension 字节，保留 `temporal_id` / `spatial_id`。

接进解码路径的位置沿用 `m_NeedsSpsFixup` 那套「客户端改码流」的既有先例。AV1 的 DU 全部是 `BUFFER_TYPE_PICDATA`，整个 temporal unit 在 `writeBuffer()` 循环跑完后是连续的，所以调用点放在循环之后、`m_Pkt->size = offset` 之前。`m_NeedsAv1ObuRepack` 只在 **VideoToolbox + AV1** 时置位，其他平台一行都走不到。

## 验证

- 本地 release 编译通过，`av1obu.cpp` 零警告。
- 写了个临时 harness 覆盖重写函数的各条分支，均符合预期：
  - 拆帧无 metadata → `2,1,6`，长度 63→61，停止位 `0x88`→`0x80`
  - 拆帧带 metadata → `2,1,5,6`，metadata 正确前移
  - 已是 `OBU_FRAME` / AMF 布局 / 多个 tile group / 只有 tile group / frame header 末字节 `0x00` → 全部原样返回，字节不变
  - 合并后长度跨 leb128 边界（203 字节）→ 长度字段正确写成 `cb 01`
  - extension flag 路径 → 头部 `0x36`、ext 字节 `0x60` 保留，长度正确
- 待实机验证：AV1 HDR 连 NVENC（主判据：出画、无 -12911，FFmpeg debug 的 OBU 序列从 `2,1,3,5,4` 变成 `2,1,5,6`）、AV1 HDR 连 AMF 回归、AV1 SDR 回归、HEVC 回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware AV1 playback on macOS by repacking compatible video units for VideoToolbox.
  * Fixed black-screen issues with certain AV1 HDR streams.
  * Preserved metadata and safely leaves unsupported or malformed streams unchanged.
  * Improved HDR10+ performance reporting to indicate when tone mapping is actively used.

* **Documentation**
  * Added guidance for AV1 VideoToolbox compatibility, integration, testing, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->