### PR TITLE
ci: 修好一直红的翻译资源构建

### DIFF
--- a/.github/workflows/build-translate.yml
+++ b/.github/workflows/build-translate.yml
@@ -17,13 +17,17 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    # 跟 build.yml 的 Windows job 保持一致：发布版 aqtinstall 解析不了 Qt 6.11.1 的
+    # 仓库 XML（Failed to locate XML data for Qt version '6.11.1'），必须走 naqt。
     - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jdpurcell/install-qt-action@v5
       with:
+        arch: win64_msvc2022_64
+        host: windows
+        target: desktop
         version: '6.11.1'
-        arch: 'win64_msvc2022_64'
         modules: 'qtmultimedia'
-        cache: true
+        use-naqt: true
 
     - name: Get version
       shell: cmd

--- a/scripts/update_translate.sh
+++ b/scripts/update_translate.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
+set -euo pipefail
+
+# install-qt-action 把 Qt 装在 workspace 下（不是 C:\Qt），并导出 QT_ROOT_DIR，
+# 所以路径不能写死。本地跑时退回 PATH 里的 lrelease。
+if [[ -n "${QT_ROOT_DIR:-}" && -x "$QT_ROOT_DIR/bin/lrelease" ]]; then
+    LRELEASE="$QT_ROOT_DIR/bin/lrelease"
+elif [[ -n "${QT_ROOT_DIR:-}" && -x "$QT_ROOT_DIR/bin/lrelease.exe" ]]; then
+    LRELEASE="$QT_ROOT_DIR/bin/lrelease.exe"
+else
+    LRELEASE="$(command -v lrelease)"
+fi
+echo "Using $LRELEASE"
 
 # 编译所有翻译文件
 for f in app/languages/*.ts; do
     echo "Processing $f..."
-    /c/Qt/6.11.1/msvc2022_64/bin/lrelease "$f"
+    "$LRELEASE" "$f"
 done
 
 echo "Translation compilation completed!"


### PR DESCRIPTION
## 问题

`Build Translate Resources` 最近 **15 次 push 到 master 全部失败**，最早能查到 8-05 就在红。因为它跟 `Build Moonlight Qt` 由同一个 push 事件触发，每次合并后都会看到「一红一绿」。

它带 `permissions: contents: write` 并且会把编译好的翻译文件 push 回 master —— 一直红意味着**翻译资源从 8-05 起就没有自动更新过**。

## 两处都坏了

**1. `Install Qt` 步骤（编译根本没开始跑）**

```
ERROR   : Failed to locate XML data for Qt version '6.11.1'.
##[error]The process 'python.exe' failed with exit code 1
```

用的是原味 `jurplel/install-qt-action@v4` → PyPI 上发布的 `aqtinstall 3.3.0`，解析不了 Qt 6.11.1 的仓库 XML。`build.yml` 的 Windows job 早就绕过去了（`jdpurcell/install-qt-action@v5` + `use-naqt: true`），这里照抄。

**2. `update_translate.sh` 里写死的路径**

```bash
/c/Qt/6.11.1/msvc2022_64/bin/lrelease "$f"
```

而 install-qt-action 装在 workspace 下（日志里是 `--outputdir D:\a\moonlight-qt\Qt`），`C:\Qt` 从来就不存在。所以只修第 1 条的话，这一步照样会失败。改成优先用 action 导出的 `QT_ROOT_DIR`，本地跑时退回 PATH 里的 `lrelease`。

## 验证

- YAML 解析通过。
- `bash -n` 通过；本地 `QT_ROOT_DIR=/opt/homebrew bash scripts/update_translate.sh` 跑通，正常输出 `Generated 254 translation(s)` 等。
- 真正的判据是这条 workflow 合并后第一次跑能绿 —— 它只在 push 到 master 时触发，所以 PR 上看不到。也可以合并前用 workflow_dispatch 在本分支手动跑一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation compilation reliability across supported environments.
  * Translation updates now work with both Windows and non-Windows Qt installations and can use available system tools when needed.

* **Chores**
  * Updated the automated build process to install and configure Qt more consistently.
  * Added stricter error handling to help identify translation build issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->