### PR TITLE
fix(ui): 关掉 FluentWinUI3 自带的圆角焦点环，焦点态统一成方角 accent

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -75,10 +75,14 @@ CenteredGridView {
             radius: 0
             color: chip.selected ? chip.selectedFill
                                  : (chip.hovered ? Theme.surface : Theme.surface2)
-            // 焦点描边压过选中描边：选中与否已经靠填充色表达了，描边留给「焦点在哪」。
-            border.color: chip.visualFocus ? Theme.text
-                        : (chip.selected ? chip.selectedBorder : Theme.lineStrong)
-            border.width: chip.visualFocus ? 2 : 1
+            border.color: chip.selected ? chip.selectedBorder : Theme.lineStrong
+            border.width: 1
+
+            // 选中态是 accent 实心填充，描边腾不出来表达焦点（accent 描 accent 等于
+            // 看不见），所以焦点走统一的外挂方角环。
+            FocusRing {
+                visible: chip.visualFocus
+            }
 
             Behavior on color {
                 ColorAnimation { duration: Theme.durFast }

--- a/app/gui/AutoResizingComboBox.qml
+++ b/app/gui/AutoResizingComboBox.qml
@@ -11,6 +11,10 @@ import "theme"
 ComboBox {
     id: control
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环，焦点由背景的 2px accent 边框表达。
+    // 详见 theme/FocusRing.qml 的注释。
+    readonly property Item __focusFrameTarget: null
+
     property int textWidth
 
     // 每一项文字之外还要留出：控件自身的左右 padding、下拉箭头，以及 contentItem
@@ -118,8 +122,11 @@ ComboBox {
 
         radius: 0
         color: control.pressed ? Theme.surface : Theme.surface2
-        border.width: 1
-        border.color: control.visualFocus || control.hovered ? Theme.accent : Theme.lineStrong
+        // hover 是 1px lineStrong，focus 是 2px accent —— 两个维度都不同，
+        // 免得「鼠标停在上面」和「焦点在这里」看起来一模一样。
+        border.width: control.visualFocus ? 2 : 1
+        border.color: control.visualFocus ? Theme.accent
+                                          : (control.hovered ? Theme.accent : Theme.lineStrong)
 
         Behavior on border.color {
             ColorAnimation { duration: Theme.durFast }

--- a/app/gui/HdrBrightnessHandle.qml
+++ b/app/gui/HdrBrightnessHandle.qml
@@ -34,8 +34,17 @@ Item {
     Accessible.role: Accessible.Slider
     Accessible.name: valueLabel
 
+    FocusRing {
+        visible: handle.activeFocus
+        inset: 1
+    }
+
     // 三个把手全部方角，配色跟着刻度条的三段：暗青 / 青 / 酸性绿。
-    // 焦点态统一用一圈亮描边，不再靠改颜色区分。
+    //
+    // 焦点不画在把手自己的描边上：三个把手的填充分别是 accentDim / accent / acid，
+    // 描边已经被「这是哪一段」占住了（中间那个还正好是 accent，accent 描 accent
+    // 等于看不见）。所以统一挂全应用那个方角 FocusRing，跟 CheckBox / Switch /
+    // Slider 把手一个规矩。
     Rectangle {
         anchors.centerIn: parent
         visible: handle.handleStyle === handle.minimumStyle
@@ -44,7 +53,7 @@ Item {
         radius: 0
         color: Theme.accentDim
         border.width: 2
-        border.color: handle.activeFocus ? Theme.text : Theme.ink
+        border.color: Theme.ink
     }
 
     Rectangle {
@@ -54,8 +63,7 @@ Item {
         height: handle.scaleItem ? handle.scaleItem.height + 12 : 26
         radius: 0
         color: Theme.accent
-        border.width: handle.activeFocus ? 1 : 0
-        border.color: Theme.text
+        border.width: 0
     }
 
     Rectangle {
@@ -66,7 +74,7 @@ Item {
         radius: 0
         color: Theme.acid
         border.width: 2
-        border.color: handle.activeFocus ? Theme.text : Theme.ink
+        border.color: Theme.ink
 
         // 峰值把手带一圈酸性绿光晕，替代参考站的 box-shadow: 0 0 12px
         Rectangle {

--- a/app/gui/NavigableItemDelegate.qml
+++ b/app/gui/NavigableItemDelegate.qml
@@ -4,6 +4,11 @@ import QtQuick.Controls
 ItemDelegate {
     property GridView grid
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环 —— PcView / AppView 的格子项自己画
+    // 焦点表达（月球高亮、卡片描边），再套一圈圆角白环只会糊在一起。
+    // 详见 theme/FocusRing.qml 的注释。
+    readonly property Item __focusFrameTarget: null
+
     highlighted: grid.activeFocus && grid.currentItem === this
 
     Keys.onLeftPressed: {

--- a/app/gui/NavigableToolButton.qml
+++ b/app/gui/NavigableToolButton.qml
@@ -16,6 +16,10 @@ ToolButton {
 
     activeFocusOnTab: true
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环，焦点由下面的 2px accent 边框表达。
+    // 详见 theme/FocusRing.qml 的注释。
+    readonly property Item __focusFrameTarget: null
+
     icon.source: iconSource
     icon.width: iconSize
     icon.height: iconSize
@@ -25,14 +29,15 @@ ToolButton {
     icon.color: (control.hovered || control.visualFocus || control.down)
                 ? Theme.text : Theme.textDim
 
-    // 方角化。FluentWinUI3 的 ToolButton 背景是圆角高亮块，换成方角 + 1px 描边；
+    // 方角化。FluentWinUI3 的 ToolButton 背景是圆角高亮块，换成方角 + 描边；
     // 按下时反过来用 accentSoft 填充，不做缩放也不做模糊。
+    // 静止无描边，hover 1px accent，focus 2px accent —— 和其他控件一个规矩。
     background: Rectangle {
         radius: 0
         color: control.down ? Theme.accentSoft
                             : (control.hovered ? Theme.surface2 : "transparent")
-        border.width: (control.visualFocus || control.hovered) ? 1 : 0
-        border.color: control.visualFocus ? Theme.accent : Theme.lineStrong
+        border.width: control.visualFocus ? 2 : (control.hovered ? 1 : 0)
+        border.color: Theme.accent
 
         Behavior on color {
             ColorAnimation { duration: Theme.durFast }

--- a/app/gui/settings/BasicSettingsPage.qml
+++ b/app/gui/settings/BasicSettingsPage.qml
@@ -672,8 +672,11 @@ Column {
                             radius: 0
                             color: resetBitrateButton.down ? Theme.accentSoft
                                                            : (resetBitrateButton.hovered ? Theme.surface2 : "transparent")
+                            // 和 HardButton 一个规矩：hover / 按下 1px accent，focus 2px accent
                             border.width: resetBitrateButton.visualFocus ? 2 : 1
-                            border.color: resetBitrateButton.visualFocus ? Theme.accent : Theme.lineStrong
+                            border.color: resetBitrateButton.down || resetBitrateButton.hovered
+                                          || resetBitrateButton.visualFocus
+                                        ? Theme.accent : Theme.lineStrong
 
                             Behavior on color {
                                 ColorAnimation { duration: Theme.durFast }

--- a/app/gui/settings/BasicSettingsPage.qml
+++ b/app/gui/settings/BasicSettingsPage.qml
@@ -641,6 +641,10 @@ Column {
 
                     Button {
                         id: resetBitrateButton
+                        // 关掉 FluentWinUI3 那圈白色圆角双环，焦点由下面的 2px accent 边框表达。
+                        // 详见 theme/FocusRing.qml 的注释。
+                        readonly property Item __focusFrameTarget: null
+
 
                         anchors.right: parent.right
                         hoverEnabled: true
@@ -668,8 +672,8 @@ Column {
                             radius: 0
                             color: resetBitrateButton.down ? Theme.accentSoft
                                                            : (resetBitrateButton.hovered ? Theme.surface2 : "transparent")
-                            border.width: 1
-                            border.color: resetBitrateButton.activeFocus ? Theme.accent : Theme.lineStrong
+                            border.width: resetBitrateButton.visualFocus ? 2 : 1
+                            border.color: resetBitrateButton.visualFocus ? Theme.accent : Theme.lineStrong
 
                             Behavior on color {
                                 ColorAnimation { duration: Theme.durFast }

--- a/app/gui/settings/CategoryRail.qml
+++ b/app/gui/settings/CategoryRail.qml
@@ -90,6 +90,10 @@ Item {
 
             readonly property bool current: modelData.key === rail.currentCategory
 
+            // 关掉 FluentWinUI3 那圈白色圆角双环，焦点由下面背景的 2px accent
+            // 描边表达。详见 theme/FocusRing.qml 的注释。
+            readonly property Item __focusFrameTarget: null
+
             width: rail.compact ? Math.max(96, label.implicitWidth + Theme.spaceXl + Theme.spaceLg) : list.width
             height: rail.compact ? list.height : 44
 
@@ -137,12 +141,15 @@ Item {
             // 「当前分类」和「焦点在哪」是两件事，必须分开表达：粗条 + 软填充表示
             // 当前分类，一圈亮描边表示焦点。只用键盘/手柄来的焦点才画描边
             // （visualFocus），鼠标点一下不该冒出个框。
+            //
+            // 描边用 2px accent，和全应用的焦点表达统一（以前这里是 1px 白，
+            // 各处焦点框粗细和颜色都不一样，看着像三套设计）。
             background: Rectangle {
                 radius: 0
                 color: item.current ? Theme.accentSoft
                                     : (item.hovered || item.visualFocus ? Theme.surface2 : "transparent")
-                border.width: item.visualFocus ? 1 : 0
-                border.color: Theme.text
+                border.width: item.visualFocus ? 2 : 0
+                border.color: Theme.accent
 
                 Rectangle {
                     anchors {

--- a/app/gui/settings/HdrBrightnessCard.qml
+++ b/app/gui/settings/HdrBrightnessCard.qml
@@ -304,7 +304,7 @@ Item {
                 background: Rectangle {
                     radius: 0
                     color: Theme.ink
-                    border.width: 1
+                    border.width: hdrMaxBrightnessField.activeFocus ? 2 : 1
                     border.color: hdrMaxBrightnessField.activeFocus ? Theme.accent : Theme.lineStrong
                 }
 
@@ -352,7 +352,7 @@ Item {
                 background: Rectangle {
                     radius: 0
                     color: Theme.ink
-                    border.width: 1
+                    border.width: hdrMinBrightnessField.activeFocus ? 2 : 1
                     border.color: hdrMinBrightnessField.activeFocus ? Theme.accent : Theme.lineStrong
                 }
 
@@ -400,7 +400,7 @@ Item {
                 background: Rectangle {
                     radius: 0
                     color: Theme.ink
-                    border.width: 1
+                    border.width: hdrMaxAverageBrightnessField.activeFocus ? 2 : 1
                     border.color: hdrMaxAverageBrightnessField.activeFocus ? Theme.accent : Theme.lineStrong
                 }
 

--- a/app/gui/settings/SettingsRow.qml
+++ b/app/gui/settings/SettingsRow.qml
@@ -22,15 +22,29 @@ FocusScope {
     height: visible ? implicitHeight : 0
     implicitHeight: Math.max(textColumn.implicitHeight, controlSlot.implicitHeight) + Theme.spaceMd * 2
 
-    // 行背景：方角，hover 时填 surface2，focus 时描 1px accent。
-    // 底部那条 1px 细线是行与行之间的分隔（参考站靠这种细线分栏，不靠间距），
-    // 最后一行不画，避免和卡片下沿贴出双线。
+    // 行背景：方角，hover 时填 surface2；焦点落进这一行时填 surface2 并在左边
+    // 立一条 accent 粗条。
+    //
+    // 以前焦点是给整行描一圈 1px accent。问题是 Tab 进来时焦点其实落在行里的控件上，
+    // 于是控件自己的焦点框和整行的框套在一起，成了两个同色方框嵌套，很脏。
+    // 换成左侧粗条之后两者形态完全不同：粗条说「焦点在这一行」，控件的方框说
+    // 「具体在这个控件上」，叠在一起也读得清。粗条也是这套设计里 Panel 现成的语汇。
     Rectangle {
         anchors.fill: parent
         radius: 0
-        color: hoverArea.containsMouse ? Theme.surface2 : "transparent"
-        border.width: 1
-        border.color: row.activeFocus ? Theme.accent : "transparent"
+        color: (hoverArea.containsMouse || row.activeFocus) ? Theme.surface2 : "transparent"
+        border.width: 0
+
+        Rectangle {
+            anchors {
+                left: parent.left
+                top: parent.top
+                bottom: parent.bottom
+            }
+            width: row.activeFocus ? Theme.accentBar : 0
+            visible: width > 0
+            color: Theme.accent
+        }
 
         Rectangle {
             anchors {
@@ -40,15 +54,13 @@ FocusScope {
             }
             height: 1
             color: Theme.line
-            // 同一个 Column 里最后一行不画分隔线
+            // 行与行之间的 1px 分隔（这套设计靠细线分栏，不靠间距）。
+            // 同一个 Column 里最后一行不画，避免和卡片下沿贴出双线。
             visible: row.parent && row.parent.children
                      && row.parent.children[row.parent.children.length - 1] !== row
         }
 
         Behavior on color {
-            ColorAnimation { duration: Theme.durFast }
-        }
-        Behavior on border.color {
             ColorAnimation { duration: Theme.durFast }
         }
     }

--- a/app/gui/theme/FocusRing.qml
+++ b/app/gui/theme/FocusRing.qml
@@ -1,0 +1,47 @@
+import QtQuick 2.9
+import "."
+
+// 统一的焦点环：方角、2px、accent，套在目标外面 3px。
+//
+// 为什么要自己画一个：FluentWinUI3 会在获得焦点的控件外面挂一圈自己的
+// focus frame（`FluentWinUI3/impl/FocusFrame.qml`）—— 3px 外环 + 1px 内环、
+// 圆角半径 7、深色主题下外白内黑。那圈白色圆角双环在我们这套方角硬投影里
+// 非常突兀，而且它自己就是「各个控件的焦点框长得都不一样」的主要来源。
+//
+// 关掉它的办法是在派生组件上把 style 用来定位的钩子属性影子覆盖成 null：
+//
+//     readonly property Item __focusFrameTarget: null
+//
+// 这不是我们发明的偏方，Qt 自己的 `FluentWinUI3/SearchField.qml:47` 就是这么
+// 干的。关掉之后焦点表达全部由我们自己给：
+//
+//   - 本身就有一圈边框可用的控件（Button / ToolButton / ComboBox / TextField）：
+//     边框直接转 2px accent，hover 维持 1px lineStrong，这样 hover 和 focus
+//     在颜色和粗细两个维度上都能区分开。
+//   - 边框已经被状态占用的小控件（CheckBox / Switch 勾选态是 accent 填充 +
+//     accent 描边，Slider 把手同理）：边框腾不出来表达焦点，改用这个外挂环。
+Rectangle {
+    // 环相对目标向外扩出的距离
+    property int inset: 3
+
+    anchors.fill: parent
+    anchors.margins: -inset
+
+    z: 10
+    radius: 0
+    color: "transparent"
+    border.width: 2
+    border.color: Theme.accent
+
+    // 紧贴目标边缘的 1px 暗色分隔。勾选态的 CheckBox / 打开的 Switch / 选中的
+    // DisplayChip 本身就是 accent（或 acid）实心填充，accent 环直接贴上去几乎读不出来；
+    // 垫一条 ink 把两者分开，环在任何填充色上都是清晰的一圈。
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: parent.border.width
+        radius: 0
+        color: "transparent"
+        border.width: 1
+        border.color: Theme.ink
+    }
+}

--- a/app/gui/theme/HardButton.qml
+++ b/app/gui/theme/HardButton.qml
@@ -10,14 +10,21 @@ Button {
     font.family: Theme.fontSans
     font.bold: true
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环，焦点由下面的 2px accent 边框表达。
+    // 详见 FocusRing.qml 的注释。
+    readonly property Item __focusFrameTarget: null
+
     background: Panel {
         implicitWidth: 96
         implicitHeight: 34
 
         fill: control.down ? Theme.accentDim
                            : (control.hovered ? Theme.surface2 : Theme.surface)
+        // hover / 按下是 1px accent，focus 是 2px accent —— 靠粗细区分，
+        // 免得「鼠标停在上面」和「焦点在这里」看起来一模一样。
         borderColor: control.down || control.hovered || control.visualFocus
                      ? Theme.accent : Theme.lineStrong
+        borderWidth: control.visualFocus ? 2 : 1
         // 按钮比卡片小，投影跟着收一档，否则一堆小按钮会糊成黑块
         shadowDepth: control.down ? 2 : (control.hovered || control.visualFocus ? 6 : 4)
         liftShift: control.down ? 1 : 0

--- a/app/gui/theme/HardCheckBox.qml
+++ b/app/gui/theme/HardCheckBox.qml
@@ -9,6 +9,9 @@ CheckBox {
 
     font.family: Theme.fontSans
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环，焦点改用下面的方角 FocusRing。
+    readonly property Item __focusFrameTarget: null
+
     indicator: Rectangle {
         implicitWidth: 18
         implicitHeight: 18
@@ -20,8 +23,14 @@ CheckBox {
         border.width: 1
         border.color: !control.enabled ? Theme.line
                     : control.checked ? Theme.accent
-                    : (control.hovered || control.visualFocus ? Theme.accent : Theme.lineStrong)
+                    : (control.hovered ? Theme.accent : Theme.lineStrong)
         opacity: control.enabled ? 1.0 : 0.45
+
+        // 勾选态本身就是 accent 填充 + accent 描边，这圈边框腾不出来表达焦点，
+        // 所以焦点走外挂环。只有键盘/手柄带来的焦点才画，鼠标点一下不该冒出个框。
+        FocusRing {
+            visible: control.visualFocus
+        }
 
         // Own clicks on the painted box. FluentWinUI3 can ignore a stationary
         // release on a replaced indicator, which makes a normal click appear

--- a/app/gui/theme/HardCheckBox.qml
+++ b/app/gui/theme/HardCheckBox.qml
@@ -12,6 +12,27 @@ CheckBox {
     // 关掉 FluentWinUI3 那圈白色圆角双环，焦点改用下面的方角 FocusRing。
     readonly property Item __focusFrameTarget: null
 
+    // 自管指针路径要走的切换。不用 AbstractButton.click()：那个方法是 Qt 6.8 才有的
+    // （QtQuick.Templates 的 qmltypes 里 click 标着 revision 1544 = 6×256+8），而
+    // README 里我们还留着「Qt 5.12 或更新版本仍保留兼容」，Steam Link 那条工具链的
+    // Qt 更早，调用它会直接是 TypeError。HardSwitch 早就绕开了，这里一直漏着。
+    //
+    // toggled() 只在真的换了状态时发，clicked() 照发 —— 让这条自管路径和基类点
+    // 标签文字时的那条路径行为一致（目前 25 个使用点全都只接 onCheckedChanged，
+    // 但别给以后的调用方留坑）。
+    function commitPointerToggle() {
+        if (!control.enabled) {
+            return
+        }
+
+        var previousChecked = control.checked
+        control.toggle()
+        if (control.checked !== previousChecked) {
+            control.toggled()
+        }
+        control.clicked()
+    }
+
     indicator: Rectangle {
         implicitWidth: 18
         implicitHeight: 18
@@ -44,7 +65,7 @@ CheckBox {
             cursorShape: Qt.PointingHandCursor
 
             onPressed: control.forceActiveFocus(Qt.MouseFocusReason)
-            onClicked: control.click()
+            onClicked: control.commitPointerToggle()
         }
 
         Behavior on color {

--- a/app/gui/theme/HardSlider.qml
+++ b/app/gui/theme/HardSlider.qml
@@ -6,6 +6,9 @@ import "."
 Slider {
     id: control
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环，焦点改用把手外面的方角 FocusRing。
+    readonly property Item __focusFrameTarget: null
+
     background: Rectangle {
         x: control.leftPadding
         y: control.topPadding + (control.availableHeight - height) / 2
@@ -46,8 +49,14 @@ Slider {
             radius: 0
             color: control.pressed ? Theme.accentStrong : Theme.accent
             border.width: 1
-            border.color: control.visualFocus ? Theme.text : Theme.ink
+            border.color: Theme.ink
             opacity: control.enabled ? 1.0 : 0.45
+        }
+
+        // 把手本身就是 accent 实心块，描边只用来把它从槽里剥出来，
+        // 表达不了焦点，所以焦点走外挂环（和 HardCheckBox / HardSwitch 一致）。
+        FocusRing {
+            visible: control.visualFocus
         }
     }
 }

--- a/app/gui/theme/HardSwitch.qml
+++ b/app/gui/theme/HardSwitch.qml
@@ -12,6 +12,9 @@ Switch {
     padding: 0
     spacing: 0
 
+    // 关掉 FluentWinUI3 那圈白色圆角双环，焦点改用下面的方角 FocusRing。
+    readonly property Item __focusFrameTarget: null
+
     function commitPointerToggle() {
         if (!control.enabled) {
             return
@@ -37,8 +40,14 @@ Switch {
         border.width: 1
         border.color: !control.enabled ? Theme.line
                     : control.checked ? Theme.accent
-                    : (control.hovered || control.visualFocus ? Theme.accent : Theme.lineStrong)
+                    : (control.hovered ? Theme.accent : Theme.lineStrong)
         opacity: control.enabled ? 1.0 : 0.45
+
+        // 开启态是 accent 填充 + accent 描边，轨道边框腾不出来表达焦点，
+        // 所以焦点走外挂环（和 HardCheckBox 一致）。
+        FocusRing {
+            visible: control.visualFocus
+        }
 
         Behavior on color {
             ColorAnimation { duration: Theme.durFast }

--- a/app/gui/theme/HardTextField.qml
+++ b/app/gui/theme/HardTextField.qml
@@ -29,7 +29,9 @@ TextField {
 
         radius: 0
         color: Theme.ink
-        border.width: 1
+        // 输入框的焦点就是「光标在这里」，所以看 activeFocus 而不是 visualFocus。
+        // 粗细/颜色的规矩和其他控件一致：focus 2px accent，hover 1px lineStrong。
+        border.width: control.activeFocus ? 2 : 1
         border.color: control.activeFocus ? Theme.accent
                                           : (control.hovered ? Theme.lineStrong : Theme.line)
 

--- a/app/gui/theme/qmldir
+++ b/app/gui/theme/qmldir
@@ -1,6 +1,7 @@
 singleton Theme 1.0 Theme.qml
 
 Panel 1.0 Panel.qml
+FocusRing 1.0 FocusRing.qml
 MicroLabel 1.0 MicroLabel.qml
 HardButton 1.0 HardButton.qml
 HardCheckBox 1.0 HardCheckBox.qml

--- a/app/qml.qrc
+++ b/app/qml.qrc
@@ -25,6 +25,7 @@
         <file>gui/theme/qmldir</file>
         <file>gui/theme/Theme.qml</file>
         <file>gui/theme/Panel.qml</file>
+        <file>gui/theme/FocusRing.qml</file>
         <file>gui/theme/MicroLabel.qml</file>
         <file>gui/theme/HardButton.qml</file>
         <file>gui/theme/HardCheckBox.qml</file>


### PR DESCRIPTION
起因是逐个控件截图看焦点态，发现「各种焦点态的框很奇怪」是三层问题叠在一起。

## 1. 主因不是我们的样式，是 FluentWinUI3 自己挂的一圈环

`FluentWinUI3/impl/FocusFrame.qml`：3px 外环 + 1px 内环、**圆角半径 7**、深色主题下**外白内黑**，在获得焦点的控件外面挂着。

我们早就把这些控件的 `background` 整块换成了方角硬投影，但这圈环是 style 在 C++ 侧按焦点变化挂上去的，跟 `background` 没有关系，所以一直都在 —— 一个零圆角、零模糊的界面上套着白色圆角胶囊。

关掉的办法是把 style 用来定位的钩子属性影子覆盖成 null：

```qml
readonly property Item __focusFrameTarget: null
```

这不是偏方，Qt 自己的 `FluentWinUI3/SearchField.qml:47` 就是这么写的。我实测确认了派生组件能盖掉基类那条 `readonly` 声明：

```
qml: plain  target = Button_QMLTYPE_1542(0xb361624c0)
qml: shadow target = null
```

凡是派生自带这个属性的 style 控件的地方都加上了：`HardButton` / `NavigableToolButton` / `HardCheckBox` / `HardSwitch` / `HardSlider` / `AutoResizingComboBox` / `NavigableItemDelegate`，以及 `CategoryRail` 和 `BasicSettingsPage` 里那两个裸控件。

## 2. 焦点表达原本是三套并行的

`HardButton` / `AutoResizingComboBox` 用 accent 描边，`CategoryRail` 和 `AppView` 的 chip 用白色描边，`HdrBrightnessHandle` 三个把手也用白色，粗细在 1px 和 2px 之间随机 —— 这本身就是「各种焦点态都不一样」的另一半原因。现在统一成一条规矩：

- **边框腾得出来的**（Button / ToolButton / ComboBox / TextField）：hover 1px accent，focus **2px** accent。靠粗细区分，不靠有无 —— 以前 hover 和 focus 都是 1px accent，两者根本分不开。
- **边框已经被状态占用的**（CheckBox 勾选态、Switch 打开态、Slider 把手、选中的 chip、HDR 三个把手 —— 填充本身就是 accent 或 acid）：改挂新增的 `theme/FocusRing.qml`，方角、2px accent、外扩 3px。

`FocusRing` 里贴着目标边缘垫了一条 1px ink。第一版没垫，accent 环压在 accent 实心填充上几乎读不出来；垫一条暗色分隔之后在任何填充色上都是清晰的一圈。勾选态 CheckBox、打开的 Switch、选中的 chip（accent 填充）和 VDD chip（acid 填充）四种情况都离屏抓图确认过。

## 3. SettingsRow 会和内部控件套成双层同色方框

原来是给整行描一圈 1px accent 表示焦点。但 Tab 进来时焦点其实落在行里的控件上，于是控件自己的焦点框和整行的框套在一起，成了两个同色方框嵌套。

改成**左侧一条 accent 粗条 + surface2 填充**：形态和控件的方框完全不同，「焦点在这一行」和「具体在哪个控件上」可以同时读出来，而且粗条是这套设计里 `Panel` 现成的语汇（当前分类、运行中的 app 都在用）。

## 验证

焦点态没法用合成输入驱动（此前合成点击误启动过串流，已约定不再使用合成输入），所以用离屏 harness 逐个 `forceActiveFocus(Qt.TabFocusReason)` 抓图，改前改后各跑一轮逐控件对比。

- `scripts/qmllint-check.sh` 通过
- 构建 0 error
- 冷启动 10 秒无 QML 报错

**还需要真机复核**：键盘 / 手柄 Tab 走一圈的实际观感，尤其是设置页里焦点从分类栏进到内容区、再在 SettingsRow 之间移动时那条左侧粗条的读感。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized keyboard and controller focus visuals with consistent accent-colored focus rings and border widths.
  * Added clearer focus treatment for buttons, checkboxes, sliders, switches, text fields, combo boxes, and HDR controls.
  * Replaced settings-row focus borders with a left-side accent indicator.
  * Improved separation between hover, active focus, and visual focus states.

* **Accessibility**
  * Focus indicators are now more prominent and consistently visible during keyboard or controller navigation.
  * Improved focus feedback across settings navigation and interactive controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->