### PR TITLE
feat(branding): rename desktop client to Moonlight V+ for PC

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,14 +14,14 @@
 **支持平台：**
 - Windows (x64/ARM64) - 使用 Qt 6.11.1
 - macOS - 使用 Qt 6.11.1
-- Linux (x86_64) - 使用 Qt 6.11.1
+- Linux (x86_64 / aarch64) - 使用 Qt 6.11.1
 - SteamLink - 交叉编译
 
 **构建产物：**
-- Windows: `MoonlightPortable-{arch}-r{build_number}.zip`
-- macOS: `Moonlight-r{build_number}.dmg`
-- Linux: `Moonlight-r{build_number}-x86_64.AppImage`
-- SteamLink: `Moonlight-SteamLink-r{build_number}.zip`
+- Windows: `Moonlight-VPlus-Portable-{arch}-r{build_number}.zip`
+- macOS: `Moonlight-VPlus-r{build_number}.dmg`
+- Linux: `Moonlight-VPlus-r{build_number}-{arch}.AppImage`
+- SteamLink: `Moonlight-VPlus-SteamLink-r{build_number}.zip`
 
 ## 平台特定配置
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,6 +23,9 @@
 - Linux: `Moonlight-VPlus-r{build_number}-{arch}.AppImage`
 - SteamLink: `Moonlight-VPlus-SteamLink-r{build_number}.zip`
 
+首个 V+ 品牌版本还会同时发布 `MoonlightPortable-*` 和 `MoonlightSetup-*`
+兼容别名，保证旧版 Windows 客户端能完成跨品牌升级。
+
 ## 平台特定配置
 
 ### Windows 构建

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Upload Binaries
         uses: actions/upload-artifact@v6
         with:
-          name: Moonlight-LinuxAppImage-${{ env.CI_VERSION }}
-          path: build/installer-release/Moonlight-${{ env.CI_VERSION }}-x86_64.AppImage
+          name: Moonlight-VPlus-LinuxAppImage-${{ env.CI_VERSION }}
+          path: build/installer-release/Moonlight-VPlus-${{ env.CI_VERSION }}-x86_64.AppImage
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -40,8 +40,10 @@ jobs:
 
       - name: Resolve artifact version
         shell: bash
+        env:
+          INPUT_CI_VERSION: ${{ inputs.ci_version }}
         run: |
-          version='${{ inputs.ci_version }}'
+          version="$INPUT_CI_VERSION"
           if [[ -z "$version" ]]; then
             version=$(python3 scripts/derive-version.py --field artifact)
           fi

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       ci_version:
         required: false
-        default: manual
+        default: ''
         type: string
   workflow_call:
     inputs:
@@ -38,6 +38,19 @@ jobs:
           path: steamlink-sdk
           fetch-depth: 1
 
+      - name: Resolve artifact version
+        shell: bash
+        run: |
+          version='${{ inputs.ci_version }}'
+          if [[ -z "$version" ]]; then
+            version=$(python3 scripts/derive-version.py --field artifact)
+          fi
+          if [[ ! "$version" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::ci_version contains characters that are unsafe in an artifact name"
+            exit 1
+          fi
+          echo "CI_VERSION=$version" >> "$GITHUB_ENV"
+
       - name: Build binaries
         run: STEAMLINK_SDK_PATH=$PWD/steamlink-sdk scripts/build-steamlink-app.sh
 
@@ -45,5 +58,5 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: Moonlight-VPlus-SteamLink-${{ env.CI_VERSION }}
-          path: build/deploy-release/*
+          path: build/installer-release/Moonlight-VPlus-SteamLink-*.zip
           if-no-files-found: error

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Upload Binaries
         uses: actions/upload-artifact@v6
         with:
-          name: Moonlight-SteamLink-${{ env.CI_VERSION }}
+          name: Moonlight-VPlus-SteamLink-${{ env.CI_VERSION }}
           path: build/deploy-release/*
           if-no-files-found: error

--- a/.github/workflows/build-win-mac.yml
+++ b/.github/workflows/build-win-mac.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: runner.os == 'Windows'
         with:
-          name: Moonlight-${{ runner.os }}-x64-${{ env.CI_VERSION }}
+          name: Moonlight-VPlus-${{ runner.os }}-x64-${{ env.CI_VERSION }}
           path: build/deploy-x64-release/*
           if-no-files-found: error
 
@@ -112,7 +112,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: runner.os == 'Windows'
         with:
-          name: Moonlight-${{ runner.os }}-arm64-${{ env.CI_VERSION }}
+          name: Moonlight-VPlus-${{ runner.os }}-arm64-${{ env.CI_VERSION }}
           path: build/deploy-arm64-release/*
           if-no-files-found: error
 
@@ -120,7 +120,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: runner.os == 'macOS'
         with:
-          name: Moonlight-${{ runner.os }}-${{ env.CI_VERSION }}
+          name: Moonlight-VPlus-${{ runner.os }}-${{ env.CI_VERSION }}
           path: build/installer-Release/*.dmg
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Moonlight Qt
+name: Build Moonlight V+ for PC
 
 on:
   push:
@@ -159,7 +159,7 @@ jobs:
         set "PATH=%Qt6_DIR%\bin;%PATH%"
         call scripts\build-arch.bat release arm64
         if errorlevel 1 exit /b %ERRORLEVEL%
-        for %%f in (build\installer-arm64-release\MoonlightPortable-arm64-*.zip) do powershell -NoProfile -ExecutionPolicy Bypass -File scripts\verify-pe-machine.ps1 -Path "%%f" -ExpectedMachine 0xAA64
+        for %%f in (build\installer-arm64-release\Moonlight-VPlus-Portable-arm64-*.zip) do powershell -NoProfile -ExecutionPolicy Bypass -File scripts\verify-pe-machine.ps1 -Path "%%f" -ExpectedMachine 0xAA64
         if errorlevel 1 exit /b %ERRORLEVEL%
 
     - name: Generate universal installer
@@ -171,20 +171,20 @@ jobs:
     - name: Upload portable artifact
       uses: actions/upload-artifact@v4
       with:
-        name: MoonlightPortable-x64-r${{ env.BUILD_NUMBER }}
-        path: build/installer-x64-release/MoonlightPortable-x64-*.zip
+        name: Moonlight-VPlus-Portable-x64-r${{ env.BUILD_NUMBER }}
+        path: build/installer-x64-release/Moonlight-VPlus-Portable-x64-*.zip
 
     - name: Upload portable artifact arm64
       uses: actions/upload-artifact@v4
       with:
-        name: MoonlightPortable-arm64-r${{ env.BUILD_NUMBER }}
-        path: build/installer-arm64-release/MoonlightPortable-arm64-*.zip
+        name: Moonlight-VPlus-Portable-arm64-r${{ env.BUILD_NUMBER }}
+        path: build/installer-arm64-release/Moonlight-VPlus-Portable-arm64-*.zip
 
     - name: Upload executable artifact
       uses: actions/upload-artifact@v4
       with:
-        name: moonlight-universal-setup-r${{ env.BUILD_NUMBER }}.exe
-        path: build/installer-Release/MoonlightSetup-*.exe
+        name: Moonlight-VPlus-Setup-r${{ env.BUILD_NUMBER }}.exe
+        path: build/installer-Release/Moonlight-VPlus-Setup-*.exe
 
   build-macos:
     runs-on: macos-15
@@ -222,8 +222,8 @@ jobs:
     - name: Upload DMG artifact
       uses: actions/upload-artifact@v4
       with:
-        name: Moonlight-r${{ env.BUILD_NUMBER }}.dmg
-        path: build/installer-Release/Moonlight-*.dmg
+        name: Moonlight-VPlus-r${{ env.BUILD_NUMBER }}.dmg
+        path: build/installer-Release/Moonlight-VPlus-*.dmg
 
   build-linux:
     # x86_64 用标准 runner，aarch64 用 GitHub 的免费 ARM runner（公共仓库可用）。
@@ -520,8 +520,8 @@ jobs:
     - name: Upload AppImage artifact
       uses: actions/upload-artifact@v4
       with:
-        name: Moonlight-r${{ env.BUILD_NUMBER }}-${{ matrix.arch }}.AppImage
-        path: build/installer-release/Moonlight-*-${{ matrix.arch }}.AppImage
+        name: Moonlight-VPlus-r${{ env.BUILD_NUMBER }}-${{ matrix.arch }}.AppImage
+        path: build/installer-release/Moonlight-VPlus-*-${{ matrix.arch }}.AppImage
 
   build-steamlink:
     runs-on: ubuntu-22.04
@@ -556,8 +556,8 @@ jobs:
     - name: Upload SteamLink artifact
       uses: actions/upload-artifact@v4
       with:
-        name: Moonlight-SteamLink-r${{ env.BUILD_NUMBER }}
-        path: build/installer-release/Moonlight-SteamLink-*.zip
+        name: Moonlight-VPlus-SteamLink-r${{ env.BUILD_NUMBER }}
+        path: build/installer-release/Moonlight-VPlus-SteamLink-*.zip
 
   release:
     if: github.event_name == 'release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,7 @@ jobs:
       with:
         name: Moonlight-VPlus-r${{ env.BUILD_NUMBER }}.dmg
         path: build/installer-Release/Moonlight-VPlus-*.dmg
+        if-no-files-found: error
 
   build-linux:
     # x86_64 用标准 runner，aarch64 用 GitHub 的免费 ARM runner（公共仓库可用）。

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,19 +172,25 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Moonlight-VPlus-Portable-x64-r${{ env.BUILD_NUMBER }}
-        path: build/installer-x64-release/Moonlight-VPlus-Portable-x64-*.zip
+        path: |
+          build/installer-x64-release/Moonlight-VPlus-Portable-x64-*.zip
+          build/installer-x64-release/MoonlightPortable-x64-*.zip
 
     - name: Upload portable artifact arm64
       uses: actions/upload-artifact@v4
       with:
         name: Moonlight-VPlus-Portable-arm64-r${{ env.BUILD_NUMBER }}
-        path: build/installer-arm64-release/Moonlight-VPlus-Portable-arm64-*.zip
+        path: |
+          build/installer-arm64-release/Moonlight-VPlus-Portable-arm64-*.zip
+          build/installer-arm64-release/MoonlightPortable-arm64-*.zip
 
     - name: Upload executable artifact
       uses: actions/upload-artifact@v4
       with:
         name: Moonlight-VPlus-Setup-r${{ env.BUILD_NUMBER }}.exe
-        path: build/installer-Release/Moonlight-VPlus-Setup-*.exe
+        path: |
+          build/installer-Release/Moonlight-VPlus-Setup-*.exe
+          build/installer-Release/MoonlightSetup-*.exe
 
   build-macos:
     runs-on: macos-15

--- a/README.en.md
+++ b/README.en.md
@@ -1,23 +1,27 @@
-# Moonlight PC - Foundation Client Fork
+# Moonlight V+ for PC
 
 [中文](README.md)
 
 [![Build](https://img.shields.io/github/actions/workflow/status/qiin2333/moonlight-qt/build.yml?branch=master)](https://github.com/qiin2333/moonlight-qt/actions/workflows/build.yml?query=branch%3Amaster)
 [![Downloads](https://img.shields.io/github/downloads/qiin2333/moonlight-qt/total)](https://github.com/qiin2333/moonlight-qt/releases)
 
-This is a downstream desktop client fork based on [moonlight-stream/moonlight-qt](https://github.com/moonlight-stream/moonlight-qt), designed to work closely with [Foundation Sunshine](https://github.com/qiin2333/Sunshine).
+Moonlight V+ for PC is an enhanced desktop client based on [moonlight-stream/moonlight-qt](https://github.com/moonlight-stream/moonlight-qt), designed to work closely with [Foundation Sunshine](https://github.com/qiin2333/Sunshine).
 
-The fork remains compatible with upstream Moonlight and standard Sunshine hosts, while improving the Foundation Sunshine desktop experience with clearer capability negotiation, finer quality/performance controls, and more efficient in-stream actions.
+It remains compatible with upstream Moonlight and standard Sunshine hosts, while improving the Foundation Sunshine desktop experience with clearer capability negotiation, finer quality/performance controls, and more efficient in-stream actions.
 
 ## Downloads
 
-Download Windows, macOS, Linux AppImage, and Steam Link builds from this fork's [GitHub Releases](https://github.com/qiin2333/moonlight-qt/releases).
+Download Windows, macOS, Linux AppImage, and Steam Link builds from [GitHub Releases](https://github.com/qiin2333/moonlight-qt/releases).
 
-For upstream Moonlight distribution channels, mobile clients, Flatpak, Snap, or distro packages, see the [Moonlight website](https://moonlight-stream.org) and the [upstream repository](https://github.com/moonlight-stream/moonlight-qt). Those builds may not include the Foundation Sunshine extensions maintained in this fork.
+> **macOS currently ships Apple Silicon (arm64) builds only**, named like `Moonlight-VPlus-<version>-arm64.dmg`.
+>
+> **Linux AppImages are available for x86_64 and aarch64**, named like `Moonlight-VPlus-<version>-x86_64.AppImage` and `Moonlight-VPlus-<version>-aarch64.AppImage`.
+
+For upstream Moonlight distribution channels, mobile clients, Flatpak, Snap, or distro packages, see the [Moonlight website](https://moonlight-stream.org) and the [upstream repository](https://github.com/moonlight-stream/moonlight-qt). Those builds may not include the Foundation Sunshine extensions maintained in Moonlight V+ for PC.
 
 ## Foundation Sunshine Integration
 
-Foundation Sunshine is the primary server counterpart for this client fork. The client probes host capabilities during connection setup; enhanced protocols are enabled only when the server advertises support, and standard Moonlight / Sunshine behavior is used otherwise.
+Foundation Sunshine is the primary server counterpart for Moonlight V+ for PC. The client probes host capabilities during connection setup; enhanced protocols are enabled only when the server advertises support, and standard Moonlight / Sunshine behavior is used otherwise.
 
 You can use it like a regular Moonlight client, or pair it with a Foundation Sunshine host for richer clipboard, audio input, display control, bitrate control, and folder-mapping behavior. When an extension is unavailable, the client falls back to standard compatible behavior.
 
@@ -59,7 +63,7 @@ You can use it like a regular Moonlight client, or pair it with a Foundation Sun
 
 - The standard Moonlight / Sunshine protocol remains compatible, so regular hosts do not need extra setup.
 - When connected to standard Sunshine or another upstream-compatible host, Foundation extensions such as image clipboard, HQ Mic, ABR, and folder mapping gracefully downgrade or stay disabled.
-- NVIDIA GameStream compatibility is inherited from upstream Moonlight, but new development in this fork is primarily focused on the Sunshine ecosystem.
+- NVIDIA GameStream compatibility is inherited from upstream Moonlight, but new development in Moonlight V+ for PC is primarily focused on the Sunshine ecosystem.
 
 ## Building
 
@@ -157,13 +161,13 @@ Original Steam Link hardware limits:
 
 ## Contributing
 
-This fork prioritizes Foundation Sunshine integration, desktop client experience, Chinese localization, and cross-platform build stability.
+Moonlight V+ for PC prioritizes Foundation Sunshine integration, desktop client experience, Chinese localization, and cross-platform build stability.
 
 When opening an issue or pull request, please include:
 
 - Client operating system and version.
 - Foundation Sunshine or standard Sunshine version.
-- Whether you are using a release build from this fork.
+- Whether you are using a Moonlight V+ for PC release build.
 - Whether the report involves an extension such as clipboard sync, HQ Mic, ABR, folder mapping, or remote resolution handling.
 
 ## Upstream And License

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# Moonlight PC - Foundation 客户端 fork
+# Moonlight V+ for PC
 
 [English](README.en.md)
 
 [![Build](https://img.shields.io/github/actions/workflow/status/qiin2333/moonlight-qt/build.yml?branch=master)](https://github.com/qiin2333/moonlight-qt/actions/workflows/build.yml?query=branch%3Amaster)
 [![Downloads](https://img.shields.io/github/downloads/qiin2333/moonlight-qt/total)](https://github.com/qiin2333/moonlight-qt/releases)
 
-这是基于 [moonlight-stream/moonlight-qt](https://github.com/moonlight-stream/moonlight-qt) 维护的下游客户端 fork，面向搭配 [Foundation Sunshine](https://github.com/qiin2333/Sunshine) 使用的桌面串流场景。
+Moonlight V+ for PC 是基于 [moonlight-stream/moonlight-qt](https://github.com/moonlight-stream/moonlight-qt) 维护的增强版桌面客户端，面向搭配 [Foundation Sunshine](https://github.com/qiin2333/Sunshine) 使用的桌面串流场景。
 
-本项目继续兼容上游 Moonlight / 标准 Sunshine，同时进一步完善 Foundation Sunshine 的客户端体验：能力协商更明确，画质与性能控制更细，串流中的常用操作效率更高。
+它继续兼容上游 Moonlight / 标准 Sunshine，同时进一步完善 Foundation Sunshine 的客户端体验：能力协商更明确，画质与性能控制更细，串流中的常用操作效率更高。
 
 ## 下载
 
-推荐从本 fork 的 [GitHub Releases](https://github.com/qiin2333/moonlight-qt/releases) 下载 Windows、macOS、Linux AppImage 和 Steam Link 构建产物。
+推荐从 [GitHub Releases](https://github.com/qiin2333/moonlight-qt/releases) 下载 Windows、macOS、Linux AppImage 和 Steam Link 构建产物。
 
-> **macOS 目前只提供 Apple Silicon（arm64）构建**，资产名形如 `Moonlight-<版本>-arm64.dmg`。Intel Mac 需要自行按下面「从源码构建」的步骤编译。
+> **macOS 目前只提供 Apple Silicon（arm64）构建**，资产名形如 `Moonlight-VPlus-<版本>-arm64.dmg`。Intel Mac 需要自行按下面「从源码构建」的步骤编译。
 >
-> **Linux AppImage 提供 x86_64 和 aarch64 两份**，资产名形如 `Moonlight-<版本>-x86_64.AppImage` / `Moonlight-<版本>-aarch64.AppImage`。x86_64 在 Ubuntu 22.04 上构建（glibc >= 2.35），aarch64 在 Ubuntu 24.04 上构建（glibc >= 2.39，因此 Debian 12 / Raspberry Pi OS bookworm 用不了，需要 trixie 或更新）。
+> **Linux AppImage 提供 x86_64 和 aarch64 两份**，资产名形如 `Moonlight-VPlus-<版本>-x86_64.AppImage` / `Moonlight-VPlus-<版本>-aarch64.AppImage`。x86_64 在 Ubuntu 22.04 上构建（glibc >= 2.35），aarch64 在 Ubuntu 24.04 上构建（glibc >= 2.39，因此 Debian 12 / Raspberry Pi OS bookworm 用不了，需要 trixie 或更新）。
 
-如果你需要上游 Moonlight 的官方发行渠道、移动端客户端、Flatpak、Snap 或发行版软件源，请参考 [Moonlight 官方网站](https://moonlight-stream.org) 和 [上游仓库](https://github.com/moonlight-stream/moonlight-qt)。这些渠道不一定包含本 fork 与 Foundation Sunshine 配套的扩展能力。
+如果你需要上游 Moonlight 的官方发行渠道、移动端客户端、Flatpak、Snap 或发行版软件源，请参考 [Moonlight 官方网站](https://moonlight-stream.org) 和 [上游仓库](https://github.com/moonlight-stream/moonlight-qt)。这些渠道不一定包含 Moonlight V+ for PC 与 Foundation Sunshine 配套的扩展能力。
 
 ## Foundation Sunshine 协同
 
-Foundation Sunshine 是本 fork 的主要服务端配套项目。客户端会在连接时探测服务端能力；当服务端支持对应扩展时启用增强协议，不支持时回退到标准 Moonlight / Sunshine 行为。
+Foundation Sunshine 是 Moonlight V+ for PC 的主要服务端配套项目。客户端会在连接时探测服务端能力；当服务端支持对应扩展时启用增强协议，不支持时回退到标准 Moonlight / Sunshine 行为。
 
 这意味着你可以把它当作普通 Moonlight 客户端使用，也可以在 Foundation Sunshine 主机上获得更完整的剪贴板、音频输入、显示控制、码率控制和文件夹映射体验。扩展能力不可用时，客户端会回退到标准兼容行为。
 
@@ -54,7 +54,7 @@ Foundation Sunshine 是本 fork 的主要服务端配套项目。客户端会在
 
 ### 自动化与发布
 
-- **本 fork 更新检查**：客户端更新检查指向 `qiin2333/moonlight-qt` 的 GitHub Releases。
+- **Moonlight V+ 更新检查**：客户端更新检查指向 `qiin2333/moonlight-qt` 的 GitHub Releases。
 - **基于 Git tag 的版本号**：`scripts/derive-version.py` 支持 CI 与本地构建产物使用一致的版本命名。
 - **自动翻译构建**：`.github/workflows/build-translate.yml` 用于周期性更新 `.ts` / `.qm` 翻译资源。
 - **CI 构建矩阵**：Windows、macOS、Linux AppImage 和 Steam Link 均有独立工作流维护。
@@ -161,13 +161,13 @@ Steam Link 原始硬件限制：
 
 ## 贡献
 
-这个 fork 的改动优先围绕 Foundation Sunshine 协同能力、桌面客户端体验、中文本地化和跨平台构建稳定性展开。
+Moonlight V+ for PC 的改动优先围绕 Foundation Sunshine 协同能力、桌面客户端体验、中文本地化和跨平台构建稳定性展开。
 
 提交 issue 或 PR 时，请尽量说明：
 
 - 客户端系统和版本。
 - Foundation Sunshine 或标准 Sunshine 的版本。
-- 是否使用本 fork 的 release 构建。
+- 是否使用 Moonlight V+ for PC 的 release 构建。
 - 是否涉及扩展能力，例如剪贴板、HQ Mic、ABR、文件夹映射或远程分辨率。
 
 ## 上游与许可

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -41,9 +41,9 @@
 		<true/>
 	</dict>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Moonlight uses the local network to connect to your gaming PC for streaming.</string>
+	<string>Moonlight V+ for PC uses the local network to connect to your gaming PC for streaming.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Moonlight needs access to the microphone to support microphone redirection to the host.</string>
+	<string>Moonlight V+ for PC needs access to the microphone to support microphone redirection to the host.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_nvstream._tcp</string>
@@ -53,7 +53,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>VERSION</string>
 	<key>CFBundleDisplayName</key>
-	<string>Moonlight</string>
+	<string>Moonlight V+ for PC</string>
     <key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 </dict>

--- a/app/Moonlight.exe.manifest
+++ b/app/Moonlight.exe.manifest
@@ -7,7 +7,7 @@
             </requestedPrivileges>
         </security>
     </trustInfo>
-    <description>Moonlight Game Streaming</description>
+    <description>Moonlight V+ for PC Game Streaming</description>
     <asmv3:application>
         <asmv3:windowsSettings>
             <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>

--- a/app/app.pro
+++ b/app/app.pro
@@ -632,9 +632,9 @@ unix:!macx: {
 }
 win32 {
     RC_ICONS = moonlight.ico
-    QMAKE_TARGET_COMPANY = Moonlight Game Streaming Project
-    QMAKE_TARGET_DESCRIPTION = Moonlight Game Streaming Client
-    QMAKE_TARGET_PRODUCT = Moonlight
+    QMAKE_TARGET_COMPANY = Moonlight V+ Project
+    QMAKE_TARGET_DESCRIPTION = Moonlight V+ for PC Game Streaming Client
+    QMAKE_TARGET_PRODUCT = Moonlight V+ for PC
 
     CONFIG -= embed_manifest_exe
     QMAKE_LFLAGS += /MANIFEST:embed /MANIFESTINPUT:$${PWD}/Moonlight.exe.manifest

--- a/app/backend/autoupdatechecker.cpp
+++ b/app/backend/autoupdatechecker.cpp
@@ -166,10 +166,10 @@ QString AutoUpdateChecker::getExpectedAssetPrefix() const
 {
 #if defined(Q_OS_WIN32)
     if (isPortableInstall()) {
-        return QStringLiteral("MoonlightPortable-%1-").arg(getCurrentBuildArch());
+        return QStringLiteral("Moonlight-VPlus-Portable-%1-").arg(getCurrentBuildArch());
     }
 
-    return QStringLiteral("MoonlightSetup-");
+    return QStringLiteral("Moonlight-VPlus-Setup-");
 #else
     return QString();
 #endif
@@ -311,6 +311,15 @@ void AutoUpdateChecker::handleUpdateCheckRequestFinished(QNetworkReply* reply)
                         QString assetName = assetObj["name"].toString();
                         bool prefixMatches = expectedPrefix.isEmpty() ||
                                              assetName.startsWith(expectedPrefix, Qt::CaseInsensitive);
+#if defined(Q_OS_WIN32)
+                        // Accept pre-rebrand assets while users transition from Moonlight PC.
+                        if (!prefixMatches) {
+                            const QString legacyPrefix = isPortableInstall()
+                                    ? QStringLiteral("MoonlightPortable-%1-").arg(getCurrentBuildArch())
+                                    : QStringLiteral("MoonlightSetup-");
+                            prefixMatches = assetName.startsWith(legacyPrefix, Qt::CaseInsensitive);
+                        }
+#endif
                         bool suffixMatches = assetName.endsWith(expectedSuffix, Qt::CaseInsensitive);
 
                         if (!prefixMatches || !suffixMatches) {

--- a/app/backend/autoupdatechecker.cpp
+++ b/app/backend/autoupdatechecker.cpp
@@ -135,6 +135,12 @@ QString AutoUpdateChecker::getPreferredAssetSuffix() const
     // Moonlight-<版本>.dmg。匹配不到就退回任意 .dmg，否则老版本的用户会看到
     // 「找不到更新包」。
     return QStringLiteral("-") + QSysInfo::buildCpuArchitecture() + QStringLiteral(".dmg");
+#elif defined(APP_IMAGE)
+    QString architecture = QSysInfo::buildCpuArchitecture().toLower();
+    if (architecture == QStringLiteral("arm64")) {
+        architecture = QStringLiteral("aarch64");
+    }
+    return QStringLiteral("-") + architecture + QStringLiteral(".AppImage");
 #else
     return QString();
 #endif
@@ -340,7 +346,10 @@ void AutoUpdateChecker::handleUpdateCheckRequestFinished(QNetworkReply* reply)
                         // 退回打开 release 页面让用户自己看。
                         bool isOtherArchAsset =
                                 assetName.endsWith(QStringLiteral("-arm64.dmg"), Qt::CaseInsensitive) ||
-                                assetName.endsWith(QStringLiteral("-x86_64.dmg"), Qt::CaseInsensitive);
+                                assetName.endsWith(QStringLiteral("-x86_64.dmg"), Qt::CaseInsensitive) ||
+                                (!preferredSuffix.isEmpty() &&
+                                 (assetName.endsWith(QStringLiteral("-aarch64.AppImage"), Qt::CaseInsensitive) ||
+                                  assetName.endsWith(QStringLiteral("-x86_64.AppImage"), Qt::CaseInsensitive)));
 
                         if (fallbackUrl.isEmpty() && !isOtherArchAsset) {
                             fallbackUrl = assetObj["browser_download_url"].toString();

--- a/app/backend/autoupdatechecker.h
+++ b/app/backend/autoupdatechecker.h
@@ -33,7 +33,7 @@ private:
     bool isPortableInstall() const;
     QString getExpectedAssetPrefix() const;
     QString getExpectedAssetSuffix() const;
-    // 同一个后缀里再优先挑本机架构的那个资产（macOS 的 DMG 带 -arm64 / -x86_64）
+    // 同一个后缀里再优先挑本机架构的资产（macOS DMG 和 Linux AppImage）。
     QString getPreferredAssetSuffix() const;
     QString getCurrentBuildArch() const;
 

--- a/app/deploy/linux/com.moonlight_stream.Moonlight.appdata.xml
+++ b/app/deploy/linux/com.moonlight_stream.Moonlight.appdata.xml
@@ -3,11 +3,11 @@
 	<id>com.moonlight_stream.Moonlight</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0+</project_license>
-	<name>Moonlight</name>
+	<name>Moonlight V+ for PC</name>
 	<summary>Stream games and other applications from another PC running Sunshine or GeForce Experience</summary>
 
 	<description>
-		<p>Moonlight can stream games and other applications from another PC with Sunshine or GeForce Experience software installed.</p>
+		<p>Moonlight V+ for PC can stream games and other applications from another PC with Sunshine or GeForce Experience software installed.</p>
 		<p>Features include:</p>
 		<ul>
 			<li>Hardware accelerated video decoding with VAAPI, VDPAU, and Vulkan Video support</li>
@@ -20,14 +20,13 @@
 		</ul>
 	</description>
 
-	<url type="homepage">https://moonlight-stream.org</url>
-	<url type="bugtracker">https://github.com/moonlight-stream/moonlight-qt/issues</url>
+	<url type="homepage">https://github.com/qiin2333/moonlight-qt</url>
+	<url type="bugtracker">https://github.com/qiin2333/moonlight-qt/issues</url>
 	<url type="help">https://github.com/moonlight-stream/moonlight-docs/wiki/Setup-Guide</url>
-	<url type="vcs-browser">https://github.com/moonlight-stream/moonlight-qt</url>
-	<developer id="org.moonlight-stream">
-		<name>Moonlight Game Streaming Team</name>
+	<url type="vcs-browser">https://github.com/qiin2333/moonlight-qt</url>
+	<developer id="io.github.qiin2333">
+		<name>Moonlight V+ Project</name>
 	</developer>
-	<update_contact>cameron@moonlight-stream.org</update_contact>
 	<launchable type="desktop-id">com.moonlight_stream.Moonlight.desktop</launchable>
 	<provides>
 		<binary>moonlight</binary>

--- a/app/deploy/linux/com.moonlight_stream.Moonlight.desktop
+++ b/app/deploy/linux/com.moonlight_stream.Moonlight.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Moonlight
+Name=Moonlight V+ for PC
 Comment=Stream games and other applications from another PC running Sunshine or GeForce Experience
 Exec=moonlight
 Icon=moonlight

--- a/app/deploy/steamlink/toc.txt
+++ b/app/deploy/steamlink/toc.txt
@@ -1,3 +1,3 @@
-name=Moonlight
+name=Moonlight V+ for PC
 icon=moonlight.png
 run=moonlight.sh

--- a/app/gui/Brand.js
+++ b/app/gui/Brand.js
@@ -1,0 +1,7 @@
+.pragma library
+
+function text(translatedText) {
+    // Keep upstream proper nouns such as "Moonlight Internet Hosting Tool"
+    // intact while applying this client's short product name in translated UI.
+    return translatedText.replace(/Moonlight(?! Internet Hosting Tool)/g, "Moonlight V+")
+}

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -14,6 +14,7 @@ import SdlGamepadKeyNavigation 1.0
 import ImageUtils 1.0
 
 import "theme"
+import "Brand.js" as Brand
 
 CenteredGridView {
     // 这一页自带壁纸，main.qml 不用再垫一层
@@ -80,7 +81,7 @@ CenteredGridView {
             errorDialog.text = qsTr("Unable to connect to the specified PC.")
 
             if (detectedPortBlocking) {
-                errorDialog.text += "\n\n" + qsTr("This PC's Internet connection is blocking Moonlight. Streaming over the Internet may not work while connected to this network.")
+                errorDialog.text += "\n\n" + Brand.text(qsTr("This PC's Internet connection is blocking Moonlight. Streaming over the Internet may not work while connected to this network."))
             }
             else {
                 errorDialog.helpText = qsTr("Click the Help button for possible solutions.")
@@ -429,7 +430,7 @@ CenteredGridView {
         onClicked: {
             if (model.online) {
                 if (!model.serverSupported) {
-                    errorDialog.text = qsTr("The version of GeForce Experience on %1 is not supported by this build of Moonlight. You must update Moonlight to stream from %1.").arg(model.name)
+                    errorDialog.text = Brand.text(qsTr("The version of GeForce Experience on %1 is not supported by this build of Moonlight. You must update Moonlight to stream from %1.")).arg(model.name)
                     errorDialog.helpText = ""
                     errorDialog.open()
                 }
@@ -520,22 +521,22 @@ CenteredGridView {
         standardButtons: DialogButtonBox.Ok
 
         onAboutToShow: {
-            testConnectionDialog.text = qsTr("Moonlight is testing your network connection to determine if any required ports are blocked.") + "\n\n" + qsTr("This may take a few seconds…")
+            testConnectionDialog.text = Brand.text(qsTr("Moonlight is testing your network connection to determine if any required ports are blocked.")) + "\n\n" + qsTr("This may take a few seconds…")
             showSpinner = true
         }
 
         function connectionTestComplete(result, blockedPorts)
         {
             if (result === -1) {
-                text = qsTr("The network test could not be performed because none of Moonlight's connection testing servers were reachable from this PC. Check your Internet connection or try again later.")
+                text = Brand.text(qsTr("The network test could not be performed because none of Moonlight's connection testing servers were reachable from this PC. Check your Internet connection or try again later."))
                 imageSrc = "qrc:/res/baseline-warning-24px.svg"
             }
             else if (result === 0) {
-                text = qsTr("This network does not appear to be blocking Moonlight. If you still have trouble connecting, check your PC's firewall settings.") + "\n\n" + qsTr("If you are trying to stream over the Internet, install the Moonlight Internet Hosting Tool on your gaming PC and run the included Internet Streaming Tester to check your gaming PC's Internet connection.")
+                text = Brand.text(qsTr("This network does not appear to be blocking Moonlight. If you still have trouble connecting, check your PC's firewall settings.") + "\n\n" + qsTr("If you are trying to stream over the Internet, install the Moonlight Internet Hosting Tool on your gaming PC and run the included Internet Streaming Tester to check your gaming PC's Internet connection."))
                 imageSrc = "qrc:/res/baseline-check_circle_outline-24px.svg"
             }
             else {
-                text = qsTr("Your PC's current network connection seems to be blocking Moonlight. Streaming over the Internet may not work while connected to this network.") + "\n\n" + qsTr("The following network ports were blocked:") + "\n"
+                text = Brand.text(qsTr("Your PC's current network connection seems to be blocking Moonlight. Streaming over the Internet may not work while connected to this network.")) + "\n\n" + qsTr("The following network ports were blocked:") + "\n"
                 text += blockedPorts
                 imageSrc = "qrc:/res/baseline-error_outline-24px.svg"
             }

--- a/app/gui/StreamSegue.qml
+++ b/app/gui/StreamSegue.qml
@@ -7,6 +7,7 @@ import Session 1.0
 import SystemProperties 1.0
 
 import "theme"
+import "Brand.js" as Brand
 
 Item {
     property Session session
@@ -80,7 +81,7 @@ Item {
     function sessionFinished(portTestResult)
     {
         if (portTestResult !== 0 && portTestResult !== -1 && streamSegueErrorDialog.text) {
-            streamSegueErrorDialog.text += "\n\n" + qsTr("This PC's Internet connection is blocking Moonlight. Streaming over the Internet may not work while connected to this network.")
+            streamSegueErrorDialog.text += "\n\n" + Brand.text(qsTr("This PC's Internet connection is blocking Moonlight. Streaming over the Internet may not work while connected to this network."))
         }
 
         // Re-enable GUI gamepad usage now

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -11,6 +11,7 @@ import SystemProperties 1.0
 import SdlGamepadKeyNavigation 1.0
 
 import "theme"
+import "Brand.js" as Brand
 
 ApplicationWindow {
     property bool pollingActive: false
@@ -588,7 +589,7 @@ ApplicationWindow {
 
                 function updateAvailable(version, url)
                 {
-                    ToolTip.text = qsTr("Update available for Moonlight: Version %1").arg(version)
+                    ToolTip.text = Brand.text(qsTr("Update available for Moonlight: Version %1")).arg(version)
                     updateButton.browserUrl = url
                     updateButton.visible = true
                 }
@@ -775,8 +776,8 @@ ApplicationWindow {
 
     ErrorMessageDialog {
         id: noHwDecoderDialog
-        text: qsTr("No functioning hardware accelerated video decoder was detected by Moonlight. " +
-                   "Your streaming performance may be severely degraded in this configuration.")
+        text: Brand.text(qsTr("No functioning hardware accelerated video decoder was detected by Moonlight. " +
+                              "Your streaming performance may be severely degraded in this configuration."))
         helpText: qsTr("Click the Help button for more information on solving this problem.")
         helpUrl: "https://github.com/moonlight-stream/moonlight-docs/wiki/Fixing-Hardware-Decoding-Problems"
     }
@@ -805,7 +806,7 @@ ApplicationWindow {
     NavigableMessageDialog {
         id: wow64Dialog
         standardButtons: Dialog.Ok | Dialog.Cancel
-        text: qsTr("This version of Moonlight isn't optimized for your PC. Please download the '%1' version of Moonlight for the best streaming performance.").arg(SystemProperties.friendlyNativeArchName)
+        text: Brand.text(qsTr("This version of Moonlight isn't optimized for your PC. Please download the '%1' version of Moonlight for the best streaming performance.")).arg(SystemProperties.friendlyNativeArchName)
         onAccepted: {
             Qt.openUrlExternally("https://github.com/moonlight-stream/moonlight-qt/releases");
         }
@@ -814,7 +815,7 @@ ApplicationWindow {
     ErrorMessageDialog {
         id: unmappedGamepadDialog
         property string unmappedGamepads : ""
-        text: qsTr("Moonlight detected gamepads without a mapping:") + "\n" + unmappedGamepads
+        text: Brand.text(qsTr("Moonlight detected gamepads without a mapping:")) + "\n" + unmappedGamepads
         helpTextSeparator: "\n\n"
         helpText: qsTr("Click the Help button for information on how to map your gamepads.")
         helpUrl: "https://github.com/moonlight-stream/moonlight-docs/wiki/Gamepad-Mapping"

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -21,6 +21,7 @@ ApplicationWindow {
     property bool clearOnBack: false
 
     id: window
+    title: Qt.application.displayName
     width: 1280
     height: 640
 
@@ -459,7 +460,7 @@ ApplicationWindow {
             Text {
                 id: wordmark
                 visible: toolBar.width > 700
-                text: "MOONLIGHT"
+                text: "MOONLIGHT V+ FOR PC"
                 color: Theme.text
                 font.family: Theme.fontSans
                 font.pointSize: Theme.fontCardTitle

--- a/app/gui/settings/LegacySettingsPage.qml
+++ b/app/gui/settings/LegacySettingsPage.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Window 2.2
 import ".."
 import "../theme"
+import "../Brand.js" as Brand
 
 import StreamingPreferences 1.0
 import ComputerManager 1.0
@@ -110,7 +111,7 @@ Column {
                 HardCheckBox {
                     id: muteOnFocusLossCheck
                     width: parent.width
-                    text: qsTr("Mute audio stream when Moonlight is not the active window")
+                    text: Brand.text(qsTr("Mute audio stream when Moonlight is not the active window"))
                     font.pointSize: 12
                     visible: SystemProperties.hasDesktopEnvironment
                     checked: StreamingPreferences.muteOnFocusLoss
@@ -121,7 +122,7 @@ Column {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Mutes Moonlight's audio when you Alt+Tab out of the stream or click on a different window.")
+                    ToolTip.text: Brand.text(qsTr("Mutes Moonlight's audio when you Alt+Tab out of the stream or click on a different window."))
                 }
                 HardCheckBox {
                     id: enableMicCheck
@@ -467,7 +468,7 @@ Column {
                         if (StreamingPreferences.language !== new_language) {
                             StreamingPreferences.language = languageListModel.get(currentIndex).val
                             if (!StreamingPreferences.retranslate()) {
-                                ToolTip.show(qsTr("You must restart Moonlight for this change to take effect"), 5000)
+                                ToolTip.show(Brand.text(qsTr("You must restart Moonlight for this change to take effect")), 5000)
                             }
                             else {
                                 // Force the back operation to pop any AppView pages that exist.
@@ -605,7 +606,7 @@ Column {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Check for new versions of Moonlight when the app starts.")
+                    ToolTip.text: Brand.text(qsTr("Check for new versions of Moonlight when the app starts."))
                 }
 
                 Label {
@@ -720,7 +721,7 @@ Column {
                         ToolTip.timeout: 10000
                         ToolTip.visible: hovered
                         ToolTip.text: qsTr("This enables the capture of system-wide keyboard shortcuts like Alt+Tab that would normally be handled by the client OS while streaming.") + "\n\n" +
-                                      qsTr("NOTE: Certain keyboard shortcuts like Ctrl+Alt+Del on Windows cannot be intercepted by any application, including Moonlight.")
+                                      Brand.text(qsTr("NOTE: Certain keyboard shortcuts like Ctrl+Alt+Del on Windows cannot be intercepted by any application, including Moonlight."))
                     }
 
                     AutoResizingComboBox {
@@ -911,7 +912,7 @@ Column {
                 HardCheckBox {
                     id: backgroundGamepadCheck
                     width: parent.width
-                    text: qsTr("Process gamepad input when Moonlight is in the background")
+                    text: Brand.text(qsTr("Process gamepad input when Moonlight is in the background"))
                     font.pointSize: 12
                     visible: SystemProperties.hasDesktopEnvironment
                     checked: StreamingPreferences.backgroundGamepad
@@ -922,7 +923,7 @@ Column {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Allows Moonlight to capture gamepad inputs even if it's not the current window in focus")
+                    ToolTip.text: Brand.text(qsTr("Allows Moonlight to capture gamepad inputs even if it's not the current window in focus"))
                 }
 
                 Label {

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -779,8 +779,8 @@ int main(int argc, char *argv[])
     // Set our app name for SDL to use with PulseAudio and PipeWire. This matches what we
     // provide as our app name to libsoundio too. On SDL 2.0.18+, SDL_APP_NAME is also used
     // for screensaver inhibitor reporting.
-    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME, "Moonlight");
-    SDL_SetHint(SDL_HINT_APP_NAME, "Moonlight");
+    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME, "Moonlight V+ for PC");
+    SDL_SetHint(SDL_HINT_APP_NAME, "Moonlight V+ for PC");
 
     // SDL will try to lock the mouse cursor on Wayland if it's not visible in order to
     // support applications that assume they can warp the cursor (which isn't possible
@@ -818,6 +818,7 @@ int main(int argc, char *argv[])
     }
 
     QGuiApplication app(argc, argv);
+    QGuiApplication::setApplicationDisplayName(QStringLiteral("Moonlight V+ for PC"));
 
 #ifdef Q_OS_DARWIN
     // macOS defaults "Keyboard navigation" to text fields and lists only, which

--- a/app/qml.qrc
+++ b/app/qml.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>gui/main.qml</file>
+        <file>gui/Brand.js</file>
         <file>gui/PcView.qml</file>
         <file>gui/AppView.qml</file>
         <file>gui/SettingsView.qml</file>

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -13,7 +13,8 @@ DEPLOY_FOLDER=$BUILD_ROOT/deploy-$BUILD_CONFIG
 INSTALLER_FOLDER=$BUILD_ROOT/installer-$BUILD_CONFIG
 
 VERSION=$(python3 "$SOURCE_ROOT/scripts/derive-version.py" --source-root "$SOURCE_ROOT" --field artifact)
-LINUXDEPLOY=linuxdeploy-$(uname -m).AppImage
+APPIMAGE_ARCH=$(uname -m)
+LINUXDEPLOY=linuxdeploy-$APPIMAGE_ARCH.AppImage
 
 command -v qmake6 >/dev/null 2>&1 || fail "Unable to find 'qmake6' in your PATH!"
 command -v $LINUXDEPLOY >/dev/null 2>&1 || fail "Unable to find '$LINUXDEPLOY' in your PATH!"
@@ -86,7 +87,8 @@ if [ -n "$QT_PLUGIN_PATH" ] && [ -d "$QT_PLUGIN_PATH/multimedia" ]; then
   rm -f "$QT_PLUGIN_PATH/multimedia/libgstreamermediaplugin.so"
 fi
 pushd $INSTALLER_FOLDER
-VERSION=$VERSION $LINUXDEPLOY --appdir $DEPLOY_FOLDER \
+OUTPUT="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage" \
+  VERSION=$VERSION $LINUXDEPLOY --appdir $DEPLOY_FOLDER \
   --library=/usr/local/lib/libSDL3.so.0 \
   --plugin qt --output appimage || fail "linuxdeploy failed!"
 popd

--- a/scripts/build-arch.bat
+++ b/scripts/build-arch.bat
@@ -306,6 +306,11 @@ if defined MOONLIGHT_PORTABLE_INACTIVE (
 7z a %INSTALLER_FOLDER%\Moonlight-VPlus-Portable-%ARCH%-%VERSION%.zip %DEPLOY_FOLDER%\*
 if !ERRORLEVEL! NEQ 0 goto Error
 
+rem Keep one legacy-named alias so pre-rebrand portable clients can install
+rem the first Moonlight V+ update in-app.
+copy /Y %INSTALLER_FOLDER%\Moonlight-VPlus-Portable-%ARCH%-%VERSION%.zip %INSTALLER_FOLDER%\MoonlightPortable-%ARCH%-%VERSION%.zip
+if !ERRORLEVEL! NEQ 0 goto Error
+
 echo Build successful for Moonlight V+ for PC v%VERSION% %ARCH% binaries!
 exit /b 0
 

--- a/scripts/build-arch.bat
+++ b/scripts/build-arch.bat
@@ -303,10 +303,10 @@ if defined MOONLIGHT_PORTABLE_INACTIVE (
     if !ERRORLEVEL! NEQ 0 goto Error
 )
 
-7z a %INSTALLER_FOLDER%\MoonlightPortable-%ARCH%-%VERSION%.zip %DEPLOY_FOLDER%\*
+7z a %INSTALLER_FOLDER%\Moonlight-VPlus-Portable-%ARCH%-%VERSION%.zip %DEPLOY_FOLDER%\*
 if !ERRORLEVEL! NEQ 0 goto Error
 
-echo Build successful for Moonlight v%VERSION% %ARCH% binaries!
+echo Build successful for Moonlight V+ for PC v%VERSION% %ARCH% binaries!
 exit /b 0
 
 :Error

--- a/scripts/build-steamlink-app.sh
+++ b/scripts/build-steamlink-app.sh
@@ -49,7 +49,7 @@ mkdir -p $DEPLOY_FOLDER/steamlink/apps/moonlight/bin
 cp $BUILD_FOLDER/app/moonlight $DEPLOY_FOLDER/steamlink/apps/moonlight/bin/ || fail "Binary copy failed!"
 cp $SOURCE_ROOT/app/deploy/steamlink/* $DEPLOY_FOLDER/steamlink/apps/moonlight/ || fail "Metadata copy failed!"
 pushd $DEPLOY_FOLDER
-zip -r $INSTALLER_FOLDER/Moonlight-SteamLink-$VERSION.zip . || fail "Zip failed!"
+zip -r $INSTALLER_FOLDER/Moonlight-VPlus-SteamLink-$VERSION.zip . || fail "Zip failed!"
 popd
 
 echo Build completed

--- a/scripts/build-steamlink-app.sh
+++ b/scripts/build-steamlink-app.sh
@@ -20,36 +20,33 @@ INSTALLER_FOLDER=$BUILD_ROOT/installer-$BUILD_CONFIG
 VERSION=$(python3 "$SOURCE_ROOT/scripts/derive-version.py" --source-root "$SOURCE_ROOT" --field artifact)
 
 echo Updating dependencies
-python3 $SOURCE_ROOT/setup-deps.py
+python3 "$SOURCE_ROOT/setup-deps.py"
 
 echo Cleaning output directories
-rm -rf $BUILD_FOLDER
-rm -rf $DEPLOY_FOLDER
-rm -rf $INSTALLER_FOLDER
-mkdir $BUILD_ROOT
-mkdir $BUILD_FOLDER
-mkdir $DEPLOY_FOLDER
-mkdir $INSTALLER_FOLDER
+rm -rf "$BUILD_FOLDER"
+rm -rf "$DEPLOY_FOLDER"
+rm -rf "$INSTALLER_FOLDER"
+mkdir -p "$BUILD_ROOT" "$BUILD_FOLDER" "$DEPLOY_FOLDER" "$INSTALLER_FOLDER"
 
 echo Initializing Steam Link SDK
-source $STEAMLINK_SDK_PATH/setenv.sh || fail "SL SDK initialization failed!"
+source "$STEAMLINK_SDK_PATH/setenv.sh" || fail "SL SDK initialization failed!"
 
 echo Configuring the project
-pushd $BUILD_FOLDER
-qmake $SOURCE_ROOT/moonlight-qt.pro QMAKE_CFLAGS_ISYSTEM= CONFIG+=config_SL || fail "Qmake failed!"
+pushd "$BUILD_FOLDER"
+qmake "$SOURCE_ROOT/moonlight-qt.pro" QMAKE_CFLAGS_ISYSTEM= CONFIG+=config_SL || fail "Qmake failed!"
 popd
 
 echo Compiling Moonlight in $BUILD_CONFIG configuration
-pushd $BUILD_FOLDER
+pushd "$BUILD_FOLDER"
 make -j$(nproc) $(echo "$BUILD_CONFIG" | tr '[:upper:]' '[:lower:]') || fail "Make failed!"
 popd
 
 echo Creating app bundle
-mkdir -p $DEPLOY_FOLDER/steamlink/apps/moonlight/bin
-cp $BUILD_FOLDER/app/moonlight $DEPLOY_FOLDER/steamlink/apps/moonlight/bin/ || fail "Binary copy failed!"
-cp $SOURCE_ROOT/app/deploy/steamlink/* $DEPLOY_FOLDER/steamlink/apps/moonlight/ || fail "Metadata copy failed!"
-pushd $DEPLOY_FOLDER
-zip -r $INSTALLER_FOLDER/Moonlight-VPlus-SteamLink-$VERSION.zip . || fail "Zip failed!"
+mkdir -p "$DEPLOY_FOLDER/steamlink/apps/moonlight/bin"
+cp "$BUILD_FOLDER/app/moonlight" "$DEPLOY_FOLDER/steamlink/apps/moonlight/bin/" || fail "Binary copy failed!"
+cp "$SOURCE_ROOT"/app/deploy/steamlink/* "$DEPLOY_FOLDER/steamlink/apps/moonlight/" || fail "Metadata copy failed!"
+pushd "$DEPLOY_FOLDER"
+zip -r "$INSTALLER_FOLDER/Moonlight-VPlus-SteamLink-$VERSION.zip" . || fail "Zip failed!"
 popd
 
 echo Build completed

--- a/scripts/generate-bundle.bat
+++ b/scripts/generate-bundle.bat
@@ -74,6 +74,12 @@ if !ERRORLEVEL! NEQ 0 goto Error
 
 rem Rename the installer to match the publishing convention
 ren %INSTALLER_FOLDER%\MoonlightSetup.exe Moonlight-VPlus-Setup-%VERSION%.exe
+if !ERRORLEVEL! NEQ 0 goto Error
+
+rem Keep one legacy-named alias so installed pre-rebrand clients can find the
+rem first Moonlight V+ release asset.
+copy /Y %INSTALLER_FOLDER%\Moonlight-VPlus-Setup-%VERSION%.exe %INSTALLER_FOLDER%\MoonlightSetup-%VERSION%.exe
+if !ERRORLEVEL! NEQ 0 goto Error
 
 echo Build successful for Moonlight V+ for PC v%VERSION% installer!
 exit /b 0

--- a/scripts/generate-bundle.bat
+++ b/scripts/generate-bundle.bat
@@ -73,9 +73,9 @@ cmd /c "set VERSION= && msbuild -Restore %SOURCE_ROOT%\wix\MoonlightSetup\Moonli
 if !ERRORLEVEL! NEQ 0 goto Error
 
 rem Rename the installer to match the publishing convention
-ren %INSTALLER_FOLDER%\MoonlightSetup.exe MoonlightSetup-%VERSION%.exe
+ren %INSTALLER_FOLDER%\MoonlightSetup.exe Moonlight-VPlus-Setup-%VERSION%.exe
 
-echo Build successful for Moonlight v%VERSION% installer!
+echo Build successful for Moonlight V+ for PC v%VERSION% installer!
 exit /b 0
 
 :Error

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -129,16 +129,25 @@ else
   fi
 fi
 
+# create-dmg names the image after CFBundleDisplayName, while the hdiutil
+# fallback uses Moonlight.dmg. The installer directory was cleaned above, so
+# require exactly one generated image and use its real path from here on.
+DMG_CANDIDATES=("$INSTALLER_FOLDER"/*.dmg)
+if [ "${#DMG_CANDIDATES[@]}" -ne 1 ] || [ ! -f "${DMG_CANDIDATES[0]}" ]; then
+  fail "Expected exactly one generated DMG in $INSTALLER_FOLDER"
+fi
+GENERATED_DMG="${DMG_CANDIDATES[0]}"
+
 if [ "$NOTARY_KEYCHAIN_PROFILE" != "" ]; then
   echo Uploading to App Notary service
-  xcrun notarytool submit --keychain-profile "$NOTARY_KEYCHAIN_PROFILE" --wait $INSTALLER_FOLDER/Moonlight.dmg || fail "Notary submission failed"
+  xcrun notarytool submit --keychain-profile "$NOTARY_KEYCHAIN_PROFILE" --wait "$GENERATED_DMG" || fail "Notary submission failed"
 
   echo Stapling notary ticket to DMG
-  xcrun stapler staple -v $INSTALLER_FOLDER/Moonlight.dmg || fail "Notary ticket stapling failed!"
+  xcrun stapler staple -v "$GENERATED_DMG" || fail "Notary ticket stapling failed!"
 fi
 
 # 名字里带上架构。这里只出一个架构的包（见上面 MOONLIGHT_ARCH 的注释），叫
 # Moonlight-<版本>.dmg 的话下载的人无法从名字判断能不能装 —— Intel Mac 上装了
 # 才发现打不开。app 侧的更新器也靠这个后缀挑对应架构的资产。
-mv "$INSTALLER_FOLDER/Moonlight.dmg" "$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$MOONLIGHT_ARCH.dmg"
+mv "$GENERATED_DMG" "$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$MOONLIGHT_ARCH.dmg"
 echo Build successful

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -146,5 +146,5 @@ fi
 # 名字里带上架构。这里只出一个架构的包（见上面 MOONLIGHT_ARCH 的注释），叫
 # Moonlight-<版本>.dmg 的话下载的人无法从名字判断能不能装 —— Intel Mac 上装了
 # 才发现打不开。app 侧的更新器也靠这个后缀挑对应架构的资产。
-mv "$INSTALLER_FOLDER/Moonlight.dmg" "$INSTALLER_FOLDER/Moonlight-$VERSION-$MOONLIGHT_ARCH.dmg"
+mv "$INSTALLER_FOLDER/Moonlight.dmg" "$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$MOONLIGHT_ARCH.dmg"
 echo Build successful

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -122,17 +122,11 @@ echo Creating DMG
 if [ "$SIGNING_IDENTITY" != "" ]; then
   create-dmg $BUILD_FOLDER/app/Moonlight.app $INSTALLER_FOLDER --identity="$SIGNING_IDENTITY" --no-version-in-filename || fail "create-dmg failed!"
 else
-  create-dmg $BUILD_FOLDER/app/Moonlight.app $INSTALLER_FOLDER --no-version-in-filename
-  CREATE_DMG_STATUS=$?
-  case $CREATE_DMG_STATUS in
-    0) ;;
-    2) ;;
-    *)
-      echo "create-dmg failed with status $CREATE_DMG_STATUS; falling back to hdiutil"
-      rm -f $INSTALLER_FOLDER/Moonlight.dmg
-      hdiutil create -volname Moonlight -srcfolder $BUILD_FOLDER/app/Moonlight.app -ov -format UDZO $INSTALLER_FOLDER/Moonlight.dmg || fail "fallback hdiutil DMG creation failed!"
-      ;;
-  esac
+  if ! create-dmg "$BUILD_FOLDER/app/Moonlight.app" "$INSTALLER_FOLDER" --no-version-in-filename; then
+    echo "create-dmg failed; falling back to hdiutil"
+    rm -f "$INSTALLER_FOLDER/Moonlight.dmg"
+    hdiutil create -volname "Moonlight V+" -srcfolder "$BUILD_FOLDER/app/Moonlight.app" -ov -format UDZO "$INSTALLER_FOLDER/Moonlight.dmg" || fail "fallback hdiutil DMG creation failed!"
+  fi
 fi
 
 if [ "$NOTARY_KEYCHAIN_PROFILE" != "" ]; then

--- a/scripts/generate-dmg.sh
+++ b/scripts/generate-dmg.sh
@@ -122,7 +122,7 @@ echo Creating DMG
 if [ "$SIGNING_IDENTITY" != "" ]; then
   create-dmg $BUILD_FOLDER/app/Moonlight.app $INSTALLER_FOLDER --identity="$SIGNING_IDENTITY" --no-version-in-filename || fail "create-dmg failed!"
 else
-  if ! create-dmg "$BUILD_FOLDER/app/Moonlight.app" "$INSTALLER_FOLDER" --no-version-in-filename; then
+  if ! create-dmg "$BUILD_FOLDER/app/Moonlight.app" "$INSTALLER_FOLDER" --no-version-in-filename --no-code-sign; then
     echo "create-dmg failed; falling back to hdiutil"
     rm -f "$INSTALLER_FOLDER/Moonlight.dmg"
     hdiutil create -volname "Moonlight V+" -srcfolder "$BUILD_FOLDER/app/Moonlight.app" -ov -format UDZO "$INSTALLER_FOLDER/Moonlight.dmg" || fail "fallback hdiutil DMG creation failed!"

--- a/wix/Moonlight/Product.wxs
+++ b/wix/Moonlight/Product.wxs
@@ -1,7 +1,7 @@
 ﻿<?define ShortName = "Moonlight" ?>
-<?define FullName = "Moonlight Game Streaming Client" ?>
+<?define FullName = "Moonlight V+ for PC Game Streaming Client" ?>
 
-<?define ShortcutName = "$(var.ShortName)" ?>
+<?define ShortcutName = "Moonlight V+ for PC" ?>
 <?define ShortcutDesc = "Stream games and other applications from another PC" ?>
 <?define InstallFolder = "Moonlight Game Streaming" ?>
 
@@ -10,7 +10,7 @@
   <Package Name="$(var.FullName)"
            Language="1033"
            Version="!(bind.fileVersion.MoonlightExe)"
-           Manufacturer="Moonlight Game Streaming Project"
+           Manufacturer="Moonlight V+ Project"
            UpgradeCode="5c09f94e-f809-4c6a-9b7b-597c99f041fe">
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." Schedule="afterInstallInitialize" />
     <MediaTemplate CompressionLevel="high" EmbedCab="yes" />

--- a/wix/MoonlightSetup/Bundle.wxs
+++ b/wix/MoonlightSetup/Bundle.wxs
@@ -11,17 +11,17 @@
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
-  <Bundle Name="Moonlight Game Streaming Client"
+  <Bundle Name="Moonlight V+ for PC Game Streaming Client"
           Version="!(bind.PackageVersion.Moonlight_x64)"
-          Manufacturer="Moonlight Game Streaming Project"
+          Manufacturer="Moonlight V+ Project"
           UpgradeCode="466fa35d-4be4-40ef-9ce5-afadc3b63bc5"
           HelpUrl="https://github.com/moonlight-stream/moonlight-docs/wiki/Setup-Guide"
-          UpdateUrl="https://github.com/moonlight-stream/moonlight-qt/releases"
+          UpdateUrl="https://github.com/qiin2333/moonlight-qt/releases"
           DisableModify="yes"
           IconSourceFile="..\..\app\moonlight.ico">
 
-    <bal:Condition Message="This version of Moonlight requires Windows 10 or later." Condition="VersionNT &gt;= v10.0" />
-    <bal:Condition Message="This version of Moonlight requires a 64-bit version of Windows." Condition="NativeMachine &lt;&gt; 332" />
+    <bal:Condition Message="This version of Moonlight V+ for PC requires Windows 10 or later." Condition="VersionNT &gt;= v10.0" />
+    <bal:Condition Message="This version of Moonlight V+ for PC requires a 64-bit version of Windows." Condition="NativeMachine &lt;&gt; 332" />
 
     <Variable Name="InstallFolder" Type="formatted" Value="[ProgramFiles6432Folder]Moonlight Game Streaming" />
 


### PR DESCRIPTION
## 改了啥呀

- 把桌面客户端的正式品牌统一为 **Moonlight V+ for PC**
- 更新应用窗口字标、Windows 文件元数据、macOS/Linux/Steam Link 展示名
- 安装器、快捷方式、CI 工作流和发布资产统一使用 `Moonlight-VPlus-*` 命名
- 中英文 README 改成 V+ 产品家族定位，并保留 x86_64 / aarch64 AppImage 说明
- 新版更新器继续识别旧的 `MoonlightPortable-*` / `MoonlightSetup-*` 资产

## 为啥要改

Android 和 HarmonyOS 客户端早就是 Moonlight V+，桌面端还孤零零挂着 Moonlight PC 的旧名，品牌队伍站得歪歪扭扭的，杂鱼状态终于收拾掉啦。

内部的 `Moonlight.exe`、配置目录、注册表路径、Bundle ID 和 Linux desktop ID 没有乱动，老用户升级后不会突然喜提一套全新配置。

## 验证

- Windows Debug 完整构建通过（Qt 6.9.2 + MSVC 2022）
- 生成的 EXE 元数据确认：
  - ProductName: `Moonlight V+ for PC`
  - FileDescription: `Moonlight V+ for PC Game Streaming Client`
  - CompanyName: `Moonlight V+ Project`
- GitHub Actions YAML 解析通过
- plist / manifest / AppStream XML 解析通过
- AppImage、DMG、Steam Link Shell 脚本通过 `bash -n`
- `git diff --check` 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebranded the application as **Moonlight V+ for PC** across the desktop app, installers, menus, and platform metadata.
  * Added updated artifact naming for Windows, macOS, Linux, and Steam Link releases, including Linux ARM64 builds.
  * Improved update checks for architecture-specific and legacy release filenames.
  * Added compatibility aliases for portable and setup downloads.
  * Added a fallback for creating unsigned macOS disk images.

* **Documentation**
  * Updated README content with new branding, download details, compatibility information, and project links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->