### PR TITLE
feat(streaming): play native DualSense haptics on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,20 @@ jobs:
         
         echo Build Windows x64 completed successfully!
 
+    - name: Test DualSense haptics rendering
+      shell: cmd
+      run: |
+        for /f "usebackq delims=" %%i in (`scripts\vswhere.exe -latest -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvarsall.bat" AMD64
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        pushd tests\ds5_ir_renderer
+        qmake ds5_ir_renderer.pro
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        ..\..\scripts\jom.exe release
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        release\ds5_ir_renderer_test.exe
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        popd
+
     - name: Install Qt arm64
       uses: jdpurcell/install-qt-action@v5
       with:

--- a/app/app.pro
+++ b/app/app.pro
@@ -284,6 +284,7 @@ HEADERS += \
     streaming/audio/renderers/renderer.h \
     streaming/audio/dualsensehaptics.h \
     streaming/audio/dualsensehapticscalibration.h \
+    streaming/audio/dualsensehapticsstream.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \
     gui/appmodel.h \

--- a/app/app.pro
+++ b/app/app.pro
@@ -67,7 +67,7 @@ win32 {
     }
 
     INCLUDEPATH += $$PWD/../libs/windows/include
-    LIBS += ws2_32.lib winmm.lib dxva2.lib ole32.lib gdi32.lib user32.lib d3d9.lib dwmapi.lib dbghelp.lib
+    LIBS += ws2_32.lib winmm.lib dxva2.lib ole32.lib uuid.lib gdi32.lib user32.lib d3d9.lib dwmapi.lib dbghelp.lib
 }
 macx:!disable-prebuilts {
     !exists($$PWD/../libs/mac) {
@@ -229,6 +229,7 @@ SOURCES += \
     streaming/clipboardhelperclient.cpp \
     streaming/clipboardipc.cpp \
     streaming/audio/audio.cpp \
+    streaming/audio/dualsensehaptics.cpp \
     streaming/audio/renderers/sdlaud.cpp \
     streaming/network/bandwidth.cpp \
     gui/computermodel.cpp \
@@ -281,6 +282,7 @@ HEADERS += \
     streaming/clipboardhelperclient.h \
     streaming/clipboardipc.h \
     streaming/audio/renderers/renderer.h \
+    streaming/audio/dualsensehaptics.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \
     gui/appmodel.h \

--- a/app/app.pro
+++ b/app/app.pro
@@ -283,6 +283,7 @@ HEADERS += \
     streaming/clipboardipc.h \
     streaming/audio/renderers/renderer.h \
     streaming/audio/dualsensehaptics.h \
+    streaming/audio/dualsensehapticscalibration.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \
     gui/appmodel.h \

--- a/app/gui/settings/LegacySettingsPage.qml
+++ b/app/gui/settings/LegacySettingsPage.qml
@@ -815,6 +815,24 @@ Column {
                 }
 
                 HardCheckBox {
+                    id: dualSenseHapticsCheck
+                    visible: Qt.platform.os === "windows"
+                    hoverEnabled: true
+                    width: parent.width
+                    text: qsTr("Play native DualSense haptics on a connected controller")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.enableDualSenseHaptics
+                    onCheckedChanged: {
+                        StreamingPreferences.enableDualSenseHaptics = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 10000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Receives games' authored DualSense haptic audio and writes it to channels 3 and 4 of a USB-connected DualSense. Bluetooth and ordinary rumble are unaffected. Changes apply to the next stream.")
+                }
+
+                HardCheckBox {
                     id: swapMouseButtonsCheck
                     hoverEnabled: true
                     width: parent.width

--- a/app/gui/settings/LegacySettingsPage.qml
+++ b/app/gui/settings/LegacySettingsPage.qml
@@ -840,7 +840,15 @@ Column {
                             }
                         }
                         Component.onCompleted: {
-                            currentIndex = StreamingPreferences.dualSenseHapticsMode === StreamingPreferences.DSHM_EMULATED ? 1 : 0
+                            if (Qt.platform.os !== "windows") {
+                                dualSenseHapticsModeListModel.remove(0)
+                            }
+                            for (var i = 0; i < dualSenseHapticsModeListModel.count; i++) {
+                                if (dualSenseHapticsModeListModel.get(i).val === StreamingPreferences.dualSenseHapticsMode) {
+                                    currentIndex = i
+                                    break
+                                }
+                            }
                         }
                         onActivated: {
                             StreamingPreferences.dualSenseHapticsMode = dualSenseHapticsModeListModel.get(currentIndex).val
@@ -849,8 +857,9 @@ Column {
                         ToolTip.delay: 1000
                         ToolTip.timeout: 10000
                         ToolTip.visible: hovered
-                        ToolTip.text: currentIndex === 0 ?
-                            qsTr("Sends the original authored PCM to channels 3 and 4 of a USB-connected DualSense. The endpoint is checked before connecting.") :
+                        ToolTip.text: currentIndex >= 0 &&
+                                      dualSenseHapticsModeListModel.get(currentIndex).val === StreamingPreferences.DSHM_PHYSICAL ?
+                            qsTr("Sends the original authored PCM to channels 3 and 4 of a USB-connected DualSense. The endpoint is checked before connecting. Changes apply to the next stream.") :
                             qsTr("Receives a compact analyzed haptics signal and renders it through the connected controller's vibration motors. Changes apply to the next stream.")
                     }
                 }

--- a/app/gui/settings/LegacySettingsPage.qml
+++ b/app/gui/settings/LegacySettingsPage.qml
@@ -814,22 +814,45 @@ Column {
                     ToolTip.text: qsTr("Sends native multi-touch trackpad contacts to compatible Sunshine hosts. Unsupported devices and hosts fall back to pointer input. Changes apply to the next stream.")
                 }
 
-                HardCheckBox {
-                    id: dualSenseHapticsCheck
-                    visible: Qt.platform.os === "windows"
-                    hoverEnabled: true
+                Row {
+                    spacing: 5
                     width: parent.width
-                    text: qsTr("Play native DualSense haptics on a connected controller")
-                    font.pointSize: 12
-                    checked: StreamingPreferences.enableDualSenseHaptics
-                    onCheckedChanged: {
-                        StreamingPreferences.enableDualSenseHaptics = checked
+
+                    Text {
+                        text: qsTr("DualSense haptics")
+                        font.pointSize: 12
+                        color: "white"
+                        anchors.verticalCenter: parent.verticalCenter
                     }
 
-                    ToolTip.delay: 1000
-                    ToolTip.timeout: 10000
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Receives games' authored DualSense haptic audio and writes it to channels 3 and 4 of a USB-connected DualSense. Bluetooth and ordinary rumble are unaffected. Changes apply to the next stream.")
+                    AutoResizingComboBox {
+                        id: dualSenseHapticsModeComboBox
+                        textRole: "text"
+                        model: ListModel {
+                            id: dualSenseHapticsModeListModel
+                            ListElement {
+                                text: qsTr("Physical DualSense (native HD haptics)")
+                                val: StreamingPreferences.DSHM_PHYSICAL
+                            }
+                            ListElement {
+                                text: qsTr("Simulated DualSense (analyzed vibration)")
+                                val: StreamingPreferences.DSHM_EMULATED
+                            }
+                        }
+                        Component.onCompleted: {
+                            currentIndex = StreamingPreferences.dualSenseHapticsMode === StreamingPreferences.DSHM_EMULATED ? 1 : 0
+                        }
+                        onActivated: {
+                            StreamingPreferences.dualSenseHapticsMode = dualSenseHapticsModeListModel.get(currentIndex).val
+                        }
+
+                        ToolTip.delay: 1000
+                        ToolTip.timeout: 10000
+                        ToolTip.visible: hovered
+                        ToolTip.text: currentIndex === 0 ?
+                            qsTr("Sends the original authored PCM to channels 3 and 4 of a USB-connected DualSense. The endpoint is checked before connecting.") :
+                            qsTr("Receives a compact analyzed haptics signal and renders it through the connected controller's vibration motors. Changes apply to the next stream.")
+                    }
                 }
 
                 HardCheckBox {

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -35,7 +35,6 @@
 #define SER_ABSMOUSEMODE "mouseacceleration"
 #define SER_ABSTOUCHMODE "abstouchmode"
 #define SER_NATIVETOUCHPAD "nativeTouchpad"
-#define SER_DUALSENSEHAPTICS "dualSenseHaptics"
 #define SER_DUALSENSEHAPTICSMODE "dualSenseHapticsMode"
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
@@ -171,19 +170,10 @@ void StreamingPreferences::reload()
 #else
     constexpr auto defaultDualSenseHapticsMode = DSHM_EMULATED;
 #endif
-    if (settings.contains(SER_DUALSENSEHAPTICSMODE)) {
-        dualSenseHapticsMode = static_cast<DualSenseHapticsMode>(
-            settings.value(SER_DUALSENSEHAPTICSMODE, defaultDualSenseHapticsMode).toInt());
-        if (dualSenseHapticsMode != DSHM_PHYSICAL && dualSenseHapticsMode != DSHM_EMULATED) {
-            dualSenseHapticsMode = defaultDualSenseHapticsMode;
-        }
-    }
-    else {
-        // The old checkbox disabled native PCM. Preserve that intent by moving
-        // unchecked users to the analyzed, device-independent renderer.
-        dualSenseHapticsMode = settings.value(SER_DUALSENSEHAPTICS,
-                                              defaultDualSenseHapticsMode == DSHM_PHYSICAL).toBool() ?
-                                   DSHM_PHYSICAL : DSHM_EMULATED;
+    dualSenseHapticsMode = static_cast<DualSenseHapticsMode>(
+        settings.value(SER_DUALSENSEHAPTICSMODE, defaultDualSenseHapticsMode).toInt());
+    if (dualSenseHapticsMode != DSHM_PHYSICAL && dualSenseHapticsMode != DSHM_EMULATED) {
+        dualSenseHapticsMode = defaultDualSenseHapticsMode;
     }
 #ifndef Q_OS_WIN32
     // Native authored PCM currently requires the Windows WASAPI renderer.
@@ -430,7 +420,6 @@ void StreamingPreferences::save()
     settings.setValue(SER_ABSTOUCHMODE, absoluteTouchMode);
     settings.setValue(SER_NATIVETOUCHPAD, enableNativeTouchpad);
     settings.setValue(SER_DUALSENSEHAPTICSMODE, dualSenseHapticsMode);
-    settings.remove(SER_DUALSENSEHAPTICS);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_VIDEOENHANCEMENT, videoEnhancement);
     settings.setValue(SER_STREAMRESOLUTIONSCALE, streamResolutionScale);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -36,6 +36,7 @@
 #define SER_ABSTOUCHMODE "abstouchmode"
 #define SER_NATIVETOUCHPAD "nativeTouchpad"
 #define SER_DUALSENSEHAPTICS "dualSenseHaptics"
+#define SER_DUALSENSEHAPTICSMODE "dualSenseHapticsMode"
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_VIDEOENHANCEMENT "videoenhancement"
@@ -166,10 +167,24 @@ void StreamingPreferences::reload()
     absoluteTouchMode = settings.value(SER_ABSTOUCHMODE, true).toBool();
     enableNativeTouchpad = settings.value(SER_NATIVETOUCHPAD, false).toBool();
 #ifdef Q_OS_WIN32
-    enableDualSenseHaptics = settings.value(SER_DUALSENSEHAPTICS, true).toBool();
+    constexpr auto defaultDualSenseHapticsMode = DSHM_PHYSICAL;
 #else
-    enableDualSenseHaptics = false;
+    constexpr auto defaultDualSenseHapticsMode = DSHM_EMULATED;
 #endif
+    if (settings.contains(SER_DUALSENSEHAPTICSMODE)) {
+        dualSenseHapticsMode = static_cast<DualSenseHapticsMode>(
+            settings.value(SER_DUALSENSEHAPTICSMODE, defaultDualSenseHapticsMode).toInt());
+        if (dualSenseHapticsMode != DSHM_PHYSICAL && dualSenseHapticsMode != DSHM_EMULATED) {
+            dualSenseHapticsMode = defaultDualSenseHapticsMode;
+        }
+    }
+    else {
+        // The old checkbox disabled native PCM. Preserve that intent by moving
+        // unchecked users to the analyzed, device-independent renderer.
+        dualSenseHapticsMode = settings.value(SER_DUALSENSEHAPTICS,
+                                              defaultDualSenseHapticsMode == DSHM_PHYSICAL).toBool() ?
+                                   DSHM_PHYSICAL : DSHM_EMULATED;
+    }
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     videoEnhancement = settings.value(SER_VIDEOENHANCEMENT, false).toBool();
     enableMicrophone = settings.value(SER_MICROPHONE, false).toBool();
@@ -407,7 +422,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_SHOWLOCALCURSOR, showLocalCursor);
     settings.setValue(SER_ABSTOUCHMODE, absoluteTouchMode);
     settings.setValue(SER_NATIVETOUCHPAD, enableNativeTouchpad);
-    settings.setValue(SER_DUALSENSEHAPTICS, enableDualSenseHaptics);
+    settings.setValue(SER_DUALSENSEHAPTICSMODE, dualSenseHapticsMode);
+    settings.remove(SER_DUALSENSEHAPTICS);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_VIDEOENHANCEMENT, videoEnhancement);
     settings.setValue(SER_STREAMRESOLUTIONSCALE, streamResolutionScale);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -35,6 +35,7 @@
 #define SER_ABSMOUSEMODE "mouseacceleration"
 #define SER_ABSTOUCHMODE "abstouchmode"
 #define SER_NATIVETOUCHPAD "nativeTouchpad"
+#define SER_DUALSENSEHAPTICS "dualSenseHaptics"
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_VIDEOENHANCEMENT "videoenhancement"
@@ -164,6 +165,11 @@ void StreamingPreferences::reload()
     showLocalCursor = settings.value(SER_SHOWLOCALCURSOR, false).toBool();
     absoluteTouchMode = settings.value(SER_ABSTOUCHMODE, true).toBool();
     enableNativeTouchpad = settings.value(SER_NATIVETOUCHPAD, false).toBool();
+#ifdef Q_OS_WIN32
+    enableDualSenseHaptics = settings.value(SER_DUALSENSEHAPTICS, true).toBool();
+#else
+    enableDualSenseHaptics = false;
+#endif
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     videoEnhancement = settings.value(SER_VIDEOENHANCEMENT, false).toBool();
     enableMicrophone = settings.value(SER_MICROPHONE, false).toBool();
@@ -401,6 +407,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SHOWLOCALCURSOR, showLocalCursor);
     settings.setValue(SER_ABSTOUCHMODE, absoluteTouchMode);
     settings.setValue(SER_NATIVETOUCHPAD, enableNativeTouchpad);
+    settings.setValue(SER_DUALSENSEHAPTICS, enableDualSenseHaptics);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_VIDEOENHANCEMENT, videoEnhancement);
     settings.setValue(SER_STREAMRESOLUTIONSCALE, streamResolutionScale);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -185,6 +185,13 @@ void StreamingPreferences::reload()
                                               defaultDualSenseHapticsMode == DSHM_PHYSICAL).toBool() ?
                                    DSHM_PHYSICAL : DSHM_EMULATED;
     }
+#ifndef Q_OS_WIN32
+    // Native authored PCM currently requires the Windows WASAPI renderer.
+    // Do not retain a value that this build can neither negotiate nor render.
+    if (dualSenseHapticsMode == DSHM_PHYSICAL) {
+        dualSenseHapticsMode = DSHM_EMULATED;
+    }
+#endif
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     videoEnhancement = settings.value(SER_VIDEOENHANCEMENT, false).toBool();
     enableMicrophone = settings.value(SER_MICROPHONE, false).toBool();

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -144,6 +144,13 @@ public:
     };
     Q_ENUM(HdrBrightnessMode);
 
+    enum DualSenseHapticsMode
+    {
+        DSHM_PHYSICAL = 0,
+        DSHM_EMULATED = 1,
+    };
+    Q_ENUM(DualSenseHapticsMode);
+
     enum GamepadQuitCombo
     {
         GQC_DEFAULT         = 0,  // Start + Select + L1 + R1 (original)
@@ -173,7 +180,7 @@ public:
     Q_PROPERTY(bool showLocalCursor MEMBER showLocalCursor NOTIFY showLocalCursorChanged)
     Q_PROPERTY(bool absoluteTouchMode MEMBER absoluteTouchMode NOTIFY absoluteTouchModeChanged)
     Q_PROPERTY(bool enableNativeTouchpad MEMBER enableNativeTouchpad NOTIFY enableNativeTouchpadChanged)
-    Q_PROPERTY(bool enableDualSenseHaptics MEMBER enableDualSenseHaptics NOTIFY enableDualSenseHapticsChanged)
+    Q_PROPERTY(DualSenseHapticsMode dualSenseHapticsMode MEMBER dualSenseHapticsMode NOTIFY dualSenseHapticsModeChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool videoEnhancement MEMBER videoEnhancement NOTIFY videoEnhancementChanged)
     Q_PROPERTY(bool streamResolutionScale MEMBER streamResolutionScale NOTIFY streamResolutionScaleChanged)
@@ -239,7 +246,7 @@ public:
     bool showLocalCursor;
     bool absoluteTouchMode;
     bool enableNativeTouchpad;
-    bool enableDualSenseHaptics;
+    DualSenseHapticsMode dualSenseHapticsMode;
     bool framePacing;
     bool videoEnhancement;
     bool streamResolutionScale;
@@ -303,7 +310,7 @@ signals:
     void showLocalCursorChanged();
     void absoluteTouchModeChanged();
     void enableNativeTouchpadChanged();
-    void enableDualSenseHapticsChanged();
+    void dualSenseHapticsModeChanged();
     void audioConfigChanged();
     void videoCodecConfigChanged();
     void enableHdrChanged();

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -173,6 +173,7 @@ public:
     Q_PROPERTY(bool showLocalCursor MEMBER showLocalCursor NOTIFY showLocalCursorChanged)
     Q_PROPERTY(bool absoluteTouchMode MEMBER absoluteTouchMode NOTIFY absoluteTouchModeChanged)
     Q_PROPERTY(bool enableNativeTouchpad MEMBER enableNativeTouchpad NOTIFY enableNativeTouchpadChanged)
+    Q_PROPERTY(bool enableDualSenseHaptics MEMBER enableDualSenseHaptics NOTIFY enableDualSenseHapticsChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool videoEnhancement MEMBER videoEnhancement NOTIFY videoEnhancementChanged)
     Q_PROPERTY(bool streamResolutionScale MEMBER streamResolutionScale NOTIFY streamResolutionScaleChanged)
@@ -238,6 +239,7 @@ public:
     bool showLocalCursor;
     bool absoluteTouchMode;
     bool enableNativeTouchpad;
+    bool enableDualSenseHaptics;
     bool framePacing;
     bool videoEnhancement;
     bool streamResolutionScale;
@@ -301,6 +303,7 @@ signals:
     void showLocalCursorChanged();
     void absoluteTouchModeChanged();
     void enableNativeTouchpadChanged();
+    void enableDualSenseHapticsChanged();
     void audioConfigChanged();
     void videoCodecConfigChanged();
     void enableHdrChanged();

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -1,4 +1,5 @@
 #include "dualsensehaptics.h"
+#include "dualsensehapticsstream.h"
 
 #include "SDL_compat.h"
 
@@ -37,7 +38,6 @@ using Microsoft::WRL::ComPtr;
 namespace {
 constexpr std::size_t MaxQueuedPackets = 32;
 constexpr std::uint32_t PrebufferFrames = 720; // 15 ms at 48 kHz
-constexpr auto StreamStarvationTimeout = std::chrono::milliseconds(20);
 
 struct Packet
 {
@@ -63,9 +63,7 @@ struct DualSenseHapticsRenderer::Impl
     WORD bitsPerSample = 0;
     bool floatSamples = false;
     bool streamStarted = false;
-    bool sequenceValid = false;
-    std::uint32_t expectedSequence = 0;
-    std::uint16_t activeController = 0;
+    dualsense_haptics::PcmStreamTracker streamTracker;
     std::deque<Packet> prebuffer;
     std::uint32_t prebufferedFrames = 0;
     std::chrono::steady_clock::time_point nextEndpointProbe{};
@@ -195,16 +193,21 @@ struct DualSenseHapticsRenderer::Impl
         return false;
     }
 
-    void resetStream()
+    void resetAudioStream()
     {
         if (audioClient) {
             if (streamStarted) audioClient->Stop();
             audioClient->Reset();
         }
         streamStarted = false;
-        sequenceValid = false;
         prebuffer.clear();
         prebufferedFrames = 0;
+    }
+
+    void resetStream()
+    {
+        resetAudioStream();
+        streamTracker.reset();
     }
 
     bool writePacket(const Packet& packet)
@@ -262,23 +265,18 @@ struct DualSenseHapticsRenderer::Impl
 
     void process(Packet packet)
     {
-        if (packet.flags & LI_DS5_HAPTICS_PCM_FLAG_STREAM_END) {
-            resetStream();
+        const auto action = streamTracker.observe(packet.flags, packet.controllerNumber,
+                                                  packet.sequenceNumber);
+        if (action == dualsense_haptics::PcmStreamTracker::Action::Ignore) {
             return;
         }
-
-        const bool discontinuity =
-            (packet.flags & (LI_DS5_HAPTICS_PCM_FLAG_STREAM_START |
-                             LI_DS5_HAPTICS_PCM_FLAG_DISCONTINUITY)) ||
-            (sequenceValid && packet.sequenceNumber != expectedSequence) ||
-            (sequenceValid && packet.controllerNumber != activeController);
-        if (discontinuity) {
-            resetStream();
+        if (action == dualsense_haptics::PcmStreamTracker::Action::End) {
+            resetAudioStream();
+            return;
         }
-
-        activeController = packet.controllerNumber;
-        expectedSequence = packet.sequenceNumber + 1;
-        sequenceValid = true;
+        if (action == dualsense_haptics::PcmStreamTracker::Action::ResetAndAccept) {
+            resetAudioStream();
+        }
 
         if (!audioClient) {
             const auto now = std::chrono::steady_clock::now();
@@ -352,15 +350,7 @@ struct DualSenseHapticsRenderer::Impl
             Packet packet;
             {
                 std::unique_lock lock(mutex);
-                if (!condition.wait_for(lock, StreamStarvationTimeout,
-                                        [this] { return stopping || !queue.empty(); })) {
-                    if (streamStarted || !prebuffer.empty()) {
-                        SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
-                                    "DualSense haptics stream starved; resetting jitter buffer");
-                        resetStream();
-                    }
-                    continue;
-                }
+                condition.wait(lock, [this] { return stopping || !queue.empty(); });
                 if (stopping) break;
                 packet = std::move(queue.front());
                 queue.pop_front();

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -1,0 +1,406 @@
+#include "dualsensehaptics.h"
+
+#include "SDL_compat.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <chrono>
+#include <cstdint>
+#include <cwctype>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <QtGlobal>
+
+#ifdef Q_OS_WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <audioclient.h>
+#include <propkey.h>
+#include <functiondiscoverykeys_devpkey.h>
+#include <ksmedia.h>
+#include <mmdeviceapi.h>
+#include <propvarutil.h>
+#include <wrl/client.h>
+
+#include <QString>
+
+using Microsoft::WRL::ComPtr;
+#endif
+
+namespace {
+constexpr std::size_t MaxQueuedPackets = 32;
+constexpr std::uint32_t PrebufferFrames = 720; // 15 ms at 48 kHz
+constexpr auto StreamStarvationTimeout = std::chrono::milliseconds(20);
+
+struct Packet
+{
+    std::uint8_t flags = 0;
+    std::uint16_t controllerNumber = 0;
+    std::uint16_t frameCount = 0;
+    std::uint32_t sequenceNumber = 0;
+    std::vector<std::uint8_t> pcm;
+};
+}
+
+struct DualSenseHapticsRenderer::Impl
+{
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::deque<Packet> queue;
+    std::thread worker;
+    std::atomic_bool stopping{false};
+
+#ifdef Q_OS_WIN32
+    ComPtr<IAudioClient> audioClient;
+    ComPtr<IAudioRenderClient> renderClient;
+    UINT32 bufferFrames = 0;
+    WORD bitsPerSample = 0;
+    bool floatSamples = false;
+    bool streamStarted = false;
+    bool sequenceValid = false;
+    std::uint32_t expectedSequence = 0;
+    std::uint16_t activeController = 0;
+    std::deque<Packet> prebuffer;
+    std::uint32_t prebufferedFrames = 0;
+    std::chrono::steady_clock::time_point nextEndpointProbe{};
+
+    Impl() : worker([this] { run(); }) {}
+
+    ~Impl()
+    {
+        stopping = true;
+        condition.notify_all();
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+
+    static bool isDualSenseName(const std::wstring& name)
+    {
+        auto lower = name;
+        std::transform(lower.begin(), lower.end(), lower.begin(), towlower);
+        return lower.find(L"dualsense") != std::wstring::npos ||
+               lower.find(L"wireless controller") != std::wstring::npos ||
+               lower.find(L"hidmaestro") != std::wstring::npos;
+    }
+
+    static bool classifyFormat(const WAVEFORMATEX* format, bool& isFloat, WORD& bits)
+    {
+        if (format->nSamplesPerSec != 48000 || format->nChannels != 4) {
+            return false;
+        }
+
+        GUID subtype = GUID_NULL;
+        if (format->wFormatTag == WAVE_FORMAT_EXTENSIBLE &&
+            format->cbSize >= sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)) {
+            subtype = reinterpret_cast<const WAVEFORMATEXTENSIBLE*>(format)->SubFormat;
+        }
+        else if (format->wFormatTag == WAVE_FORMAT_IEEE_FLOAT) {
+            subtype = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
+        }
+        else if (format->wFormatTag == WAVE_FORMAT_PCM) {
+            subtype = KSDATAFORMAT_SUBTYPE_PCM;
+        }
+
+        bits = format->wBitsPerSample;
+        isFloat = subtype == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT && bits == 32;
+        return isFloat || (subtype == KSDATAFORMAT_SUBTYPE_PCM && (bits == 16 || bits == 32));
+    }
+
+    bool openEndpoint()
+    {
+        ComPtr<IMMDeviceEnumerator> enumerator;
+        if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                    IID_PPV_ARGS(&enumerator)))) {
+            return false;
+        }
+
+        ComPtr<IMMDeviceCollection> devices;
+        if (FAILED(enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices))) {
+            return false;
+        }
+
+        UINT count = 0;
+        devices->GetCount(&count);
+        for (UINT i = 0; i < count; i++) {
+            ComPtr<IMMDevice> device;
+            if (FAILED(devices->Item(i, &device))) continue;
+
+            std::wstring friendlyName;
+            ComPtr<IPropertyStore> properties;
+            if (SUCCEEDED(device->OpenPropertyStore(STGM_READ, &properties))) {
+                PROPVARIANT value;
+                PropVariantInit(&value);
+                if (SUCCEEDED(properties->GetValue(PKEY_Device_FriendlyName, &value)) &&
+                    value.vt == VT_LPWSTR && value.pwszVal != nullptr) {
+                    friendlyName = value.pwszVal;
+                }
+                PropVariantClear(&value);
+            }
+            if (!isDualSenseName(friendlyName)) continue;
+
+            ComPtr<IAudioClient> candidate;
+            if (FAILED(device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                                        reinterpret_cast<void**>(candidate.GetAddressOf())))) {
+                continue;
+            }
+
+            WAVEFORMATEX* mix = nullptr;
+            if (FAILED(candidate->GetMixFormat(&mix)) || mix == nullptr) {
+                CoTaskMemFree(mix);
+                continue;
+            }
+            bool candidateFloat = false;
+            WORD candidateBits = 0;
+            const bool supported = classifyFormat(mix, candidateFloat, candidateBits);
+            if (!supported || FAILED(candidate->Initialize(
+                    AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_NOPERSIST,
+                    500000, 0, mix, nullptr))) {
+                CoTaskMemFree(mix);
+                continue;
+            }
+            CoTaskMemFree(mix);
+
+            ComPtr<IAudioRenderClient> candidateRenderer;
+            if (FAILED(candidate->GetService(IID_PPV_ARGS(&candidateRenderer))) ||
+                FAILED(candidate->GetBufferSize(&bufferFrames))) {
+                continue;
+            }
+
+            audioClient = candidate;
+            renderClient = candidateRenderer;
+            floatSamples = candidateFloat;
+            bitsPerSample = candidateBits;
+            const QByteArray name = QString::fromStdWString(friendlyName).toUtf8();
+            SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO,
+                        "DualSense haptics endpoint ready: %s (48 kHz, 4 ch, %u-bit%s)",
+                        name.constData(), bitsPerSample, floatSamples ? " float" : " PCM");
+            return true;
+        }
+
+        SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                    "No active 48 kHz four-channel DualSense audio endpoint was found");
+        return false;
+    }
+
+    void resetStream()
+    {
+        if (audioClient) {
+            if (streamStarted) audioClient->Stop();
+            audioClient->Reset();
+        }
+        streamStarted = false;
+        sequenceValid = false;
+        prebuffer.clear();
+        prebufferedFrames = 0;
+    }
+
+    bool writePacket(const Packet& packet)
+    {
+        if (!audioClient || !renderClient || packet.frameCount == 0) return true;
+        while (!stopping) {
+            UINT32 padding = 0;
+            if (FAILED(audioClient->GetCurrentPadding(&padding))) return false;
+            if (bufferFrames - padding >= packet.frameCount) break;
+            Sleep(1);
+        }
+        if (stopping) return false;
+
+        BYTE* output = nullptr;
+        if (FAILED(renderClient->GetBuffer(packet.frameCount, &output))) return false;
+        const auto* input = reinterpret_cast<const std::int16_t*>(packet.pcm.data());
+        if (floatSamples) {
+            auto* samples = reinterpret_cast<float*>(output);
+            std::fill_n(samples, static_cast<std::size_t>(packet.frameCount) * 4, 0.0f);
+            for (std::uint16_t i = 0; i < packet.frameCount; i++) {
+                samples[i * 4 + 2] = input[i * 2] / 32768.0f;
+                samples[i * 4 + 3] = input[i * 2 + 1] / 32768.0f;
+            }
+        }
+        else if (bitsPerSample == 16) {
+            auto* samples = reinterpret_cast<std::int16_t*>(output);
+            std::fill_n(samples, static_cast<std::size_t>(packet.frameCount) * 4, 0);
+            for (std::uint16_t i = 0; i < packet.frameCount; i++) {
+                samples[i * 4 + 2] = input[i * 2];
+                samples[i * 4 + 3] = input[i * 2 + 1];
+            }
+        }
+        else {
+            auto* samples = reinterpret_cast<std::int32_t*>(output);
+            std::fill_n(samples, static_cast<std::size_t>(packet.frameCount) * 4, 0);
+            for (std::uint16_t i = 0; i < packet.frameCount; i++) {
+                samples[i * 4 + 2] = static_cast<std::int32_t>(input[i * 2]) * 65536;
+                samples[i * 4 + 3] = static_cast<std::int32_t>(input[i * 2 + 1]) * 65536;
+            }
+        }
+        return SUCCEEDED(renderClient->ReleaseBuffer(packet.frameCount, 0));
+    }
+
+    bool startPrebufferedStream()
+    {
+        for (const auto& buffered : prebuffer) {
+            if (!writePacket(buffered)) return false;
+        }
+        prebuffer.clear();
+        prebufferedFrames = 0;
+        if (FAILED(audioClient->Start())) return false;
+        streamStarted = true;
+        return true;
+    }
+
+    void process(Packet packet)
+    {
+        if (packet.flags & LI_DS5_HAPTICS_PCM_FLAG_STREAM_END) {
+            resetStream();
+            return;
+        }
+
+        const bool discontinuity =
+            (packet.flags & (LI_DS5_HAPTICS_PCM_FLAG_STREAM_START |
+                             LI_DS5_HAPTICS_PCM_FLAG_DISCONTINUITY)) ||
+            (sequenceValid && packet.sequenceNumber != expectedSequence) ||
+            (sequenceValid && packet.controllerNumber != activeController);
+        if (discontinuity) {
+            resetStream();
+        }
+
+        activeController = packet.controllerNumber;
+        expectedSequence = packet.sequenceNumber + 1;
+        sequenceValid = true;
+
+        if (!audioClient) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now < nextEndpointProbe || !openEndpoint()) {
+                nextEndpointProbe = now + std::chrono::seconds(2);
+                return;
+            }
+        }
+        if (!streamStarted) {
+            if (packet.frameCount > bufferFrames) {
+                SDL_LogError(SDL_LOG_CATEGORY_AUDIO,
+                             "DualSense haptics packet (%u frames) exceeds the endpoint buffer (%u frames)",
+                             packet.frameCount, bufferFrames);
+                audioClient.Reset();
+                renderClient.Reset();
+                resetStream();
+                return;
+            }
+
+            // A shared-mode endpoint may expose less than our preferred 15 ms
+            // jitter buffer. Never queue more than the endpoint can accept before
+            // Start(), or writePacket() would wait for a device that is not running.
+            if (!prebuffer.empty() && prebufferedFrames + packet.frameCount > bufferFrames) {
+                if (!startPrebufferedStream()) {
+                    audioClient.Reset();
+                    renderClient.Reset();
+                    resetStream();
+                    return;
+                }
+                if (!writePacket(packet)) {
+                    audioClient.Reset();
+                    renderClient.Reset();
+                    resetStream();
+                }
+                return;
+            }
+
+            prebufferedFrames += packet.frameCount;
+            prebuffer.emplace_back(std::move(packet));
+            const auto targetFrames = std::min(PrebufferFrames, bufferFrames);
+            if (prebufferedFrames < targetFrames) return;
+
+            if (!startPrebufferedStream()) {
+                audioClient.Reset();
+                renderClient.Reset();
+                resetStream();
+                return;
+            }
+        }
+        else if (!writePacket(packet)) {
+            audioClient.Reset();
+            renderClient.Reset();
+            resetStream();
+        }
+    }
+
+    void run()
+    {
+        const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        if (FAILED(comResult)) {
+            SDL_LogError(SDL_LOG_CATEGORY_AUDIO,
+                         "Unable to initialize COM for DualSense haptics: 0x%08lx",
+                         static_cast<unsigned long>(comResult));
+            return;
+        }
+
+        while (!stopping) {
+            Packet packet;
+            {
+                std::unique_lock lock(mutex);
+                if (!condition.wait_for(lock, StreamStarvationTimeout,
+                                        [this] { return stopping || !queue.empty(); })) {
+                    if (streamStarted || !prebuffer.empty()) {
+                        SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                                    "DualSense haptics stream starved; resetting jitter buffer");
+                        resetStream();
+                    }
+                    continue;
+                }
+                if (stopping) break;
+                packet = std::move(queue.front());
+                queue.pop_front();
+            }
+            process(std::move(packet));
+        }
+
+        resetStream();
+        renderClient.Reset();
+        audioClient.Reset();
+        CoUninitialize();
+    }
+#else
+    Impl() = default;
+    ~Impl() = default;
+#endif
+};
+
+DualSenseHapticsRenderer::DualSenseHapticsRenderer() : m_Impl(std::make_unique<Impl>()) {}
+DualSenseHapticsRenderer::~DualSenseHapticsRenderer() = default;
+
+void DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_PCM_FRAME& frame)
+{
+#ifdef Q_OS_WIN32
+    if (frame.sampleRate != 48000 || frame.channelCount != 2 || frame.bitsPerSample != 16 ||
+        frame.frameCount > 480 || frame.pcmDataLength != frame.frameCount * 4 ||
+        (frame.pcmDataLength != 0 && frame.pcmData == nullptr)) {
+        return;
+    }
+
+    Packet packet;
+    packet.flags = frame.flags;
+    packet.controllerNumber = frame.controllerNumber;
+    packet.frameCount = frame.frameCount;
+    packet.sequenceNumber = frame.sequenceNumber;
+    if (frame.pcmDataLength != 0) {
+        packet.pcm.assign(frame.pcmData, frame.pcmData + frame.pcmDataLength);
+    }
+    {
+        std::lock_guard lock(m_Impl->mutex);
+        if (m_Impl->queue.size() == MaxQueuedPackets) {
+            m_Impl->queue.pop_front();
+            packet.flags |= LI_DS5_HAPTICS_PCM_FLAG_DISCONTINUITY;
+        }
+        m_Impl->queue.emplace_back(std::move(packet));
+    }
+    m_Impl->condition.notify_one();
+#else
+    (void)frame;
+#endif
+}

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -382,6 +382,64 @@ struct DualSenseHapticsRenderer::Impl
 DualSenseHapticsRenderer::DualSenseHapticsRenderer() : m_Impl(std::make_unique<Impl>()) {}
 DualSenseHapticsRenderer::~DualSenseHapticsRenderer() = default;
 
+bool DualSenseHapticsRenderer::isAvailable()
+{
+#ifdef Q_OS_WIN32
+    const HRESULT comResult = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    const bool shouldUninitialize = SUCCEEDED(comResult);
+    if (FAILED(comResult) && comResult != RPC_E_CHANGED_MODE) {
+        return false;
+    }
+
+    bool found = false;
+    ComPtr<IMMDeviceEnumerator> enumerator;
+    ComPtr<IMMDeviceCollection> devices;
+    if (SUCCEEDED(CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                   IID_PPV_ARGS(&enumerator))) &&
+        SUCCEEDED(enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &devices))) {
+        UINT count = 0;
+        devices->GetCount(&count);
+        for (UINT i = 0; i < count && !found; i++) {
+            ComPtr<IMMDevice> device;
+            if (FAILED(devices->Item(i, &device))) continue;
+
+            std::wstring friendlyName;
+            ComPtr<IPropertyStore> properties;
+            if (SUCCEEDED(device->OpenPropertyStore(STGM_READ, &properties))) {
+                PROPVARIANT value;
+                PropVariantInit(&value);
+                if (SUCCEEDED(properties->GetValue(PKEY_Device_FriendlyName, &value)) &&
+                    value.vt == VT_LPWSTR && value.pwszVal != nullptr) {
+                    friendlyName = value.pwszVal;
+                }
+                PropVariantClear(&value);
+            }
+            if (!Impl::isDualSenseName(friendlyName)) continue;
+
+            ComPtr<IAudioClient> candidate;
+            if (FAILED(device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                                        reinterpret_cast<void**>(candidate.GetAddressOf())))) {
+                continue;
+            }
+            WAVEFORMATEX* mix = nullptr;
+            if (SUCCEEDED(candidate->GetMixFormat(&mix)) && mix != nullptr) {
+                bool isFloat = false;
+                WORD bits = 0;
+                found = Impl::classifyFormat(mix, isFloat, bits);
+            }
+            CoTaskMemFree(mix);
+        }
+    }
+
+    if (shouldUninitialize) {
+        CoUninitialize();
+    }
+    return found;
+#else
+    return false;
+#endif
+}
+
 void DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_PCM_FRAME& frame)
 {
 #ifdef Q_OS_WIN32

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -54,7 +54,6 @@ struct DualSenseHapticsRenderer::Impl
     std::mutex mutex;
     std::condition_variable condition;
     std::deque<Packet> queue;
-    std::thread worker;
     std::atomic_bool stopping{false};
 
 #ifdef Q_OS_WIN32
@@ -71,7 +70,13 @@ struct DualSenseHapticsRenderer::Impl
     std::uint32_t prebufferedFrames = 0;
     std::chrono::steady_clock::time_point nextEndpointProbe{};
 
-    Impl() : worker([this] { run(); }) {}
+    // Keep this last: run() may access every member as soon as the thread starts.
+    std::thread worker;
+
+    Impl()
+    {
+        worker = std::thread([this] { run(); });
+    }
 
     ~Impl()
     {
@@ -277,7 +282,10 @@ struct DualSenseHapticsRenderer::Impl
 
         if (!audioClient) {
             const auto now = std::chrono::steady_clock::now();
-            if (now < nextEndpointProbe || !openEndpoint()) {
+            if (now < nextEndpointProbe) {
+                return;
+            }
+            if (!openEndpoint()) {
                 nextEndpointProbe = now + std::chrono::seconds(2);
                 return;
             }

--- a/app/streaming/audio/dualsensehaptics.h
+++ b/app/streaming/audio/dualsensehaptics.h
@@ -13,6 +13,7 @@ public:
     DualSenseHapticsRenderer(const DualSenseHapticsRenderer&) = delete;
     DualSenseHapticsRenderer& operator=(const DualSenseHapticsRenderer&) = delete;
 
+    static bool isAvailable();
     void submit(const LI_DS5_HAPTICS_PCM_FRAME& frame);
 
 private:

--- a/app/streaming/audio/dualsensehaptics.h
+++ b/app/streaming/audio/dualsensehaptics.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+#include <Limelight.h>
+
+class DualSenseHapticsRenderer
+{
+public:
+    DualSenseHapticsRenderer();
+    ~DualSenseHapticsRenderer();
+
+    DualSenseHapticsRenderer(const DualSenseHapticsRenderer&) = delete;
+    DualSenseHapticsRenderer& operator=(const DualSenseHapticsRenderer&) = delete;
+
+    void submit(const LI_DS5_HAPTICS_PCM_FRAME& frame);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_Impl;
+};

--- a/app/streaming/audio/dualsensehapticscalibration.h
+++ b/app/streaming/audio/dualsensehapticscalibration.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include <Limelight.h>
+
+namespace dualsense_haptics {
+struct RumbleOutput
+{
+    std::uint16_t lowFrequency;
+    std::uint16_t highFrequency;
+};
+
+inline RumbleOutput renderIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+{
+    if (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) {
+        return {0, 0};
+    }
+
+    float low = 0.0f;
+    float high = 0.0f;
+    for (const auto& lane : frame.lanes) {
+        low += lane.rmsAmplitude * (0.35f + 0.65f * lane.lowBandRatio);
+        high += lane.rmsAmplitude * (1.0f - lane.lowBandRatio) * 0.65f +
+                lane.transientStrength * 0.35f;
+    }
+    low = std::sqrt(std::clamp(low * 0.5f, 0.0f, 1.0f));
+    high = std::sqrt(std::clamp(high * 0.5f, 0.0f, 1.0f));
+    return {
+        static_cast<std::uint16_t>(low * 65535.0f),
+        static_cast<std::uint16_t>(high * 65535.0f),
+    };
+}
+} // namespace dualsense_haptics

--- a/app/streaming/audio/dualsensehapticsstream.h
+++ b/app/streaming/audio/dualsensehapticsstream.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstdint>
+
+#include <Limelight.h>
+
+namespace dualsense_haptics {
+
+class PcmStreamTracker
+{
+public:
+    enum class Action
+    {
+        Accept,
+        ResetAndAccept,
+        End,
+        Ignore,
+    };
+
+    Action observe(std::uint8_t flags, std::uint16_t controllerNumber,
+                   std::uint32_t sequenceNumber)
+    {
+        if (flags & LI_DS5_HAPTICS_PCM_FLAG_STREAM_END) {
+            if (!m_Active || controllerNumber != m_ControllerNumber) {
+                return Action::Ignore;
+            }
+
+            m_Active = false;
+            return Action::End;
+        }
+
+        if (m_Active && controllerNumber != m_ControllerNumber) {
+            return Action::Ignore;
+        }
+
+        const bool streamStart = flags & LI_DS5_HAPTICS_PCM_FLAG_STREAM_START;
+        const bool needsReset =
+            streamStart ||
+            (flags & LI_DS5_HAPTICS_PCM_FLAG_DISCONTINUITY) ||
+            (m_Active && controllerNumber == m_ControllerNumber &&
+             sequenceNumber != m_ExpectedSequence);
+
+        m_Active = true;
+        m_ControllerNumber = controllerNumber;
+        m_ExpectedSequence = sequenceNumber + 1;
+        return needsReset ? Action::ResetAndAccept : Action::Accept;
+    }
+
+    void reset()
+    {
+        m_Active = false;
+    }
+
+private:
+    bool m_Active = false;
+    std::uint16_t m_ControllerNumber = 0;
+    std::uint32_t m_ExpectedSequence = 0;
+};
+
+}

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -712,6 +712,12 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
         if (SDL_GameControllerHasLED(state->controller)) {
             capabilities |= LI_CCAP_RGB_LED;
         }
+#ifdef Q_OS_WIN32
+        if (m_EnableDualSenseHaptics &&
+            SDL_GameControllerGetType(state->controller) == SDL_CONTROLLER_TYPE_PS5) {
+            capabilities |= LI_CCAP_DS5_HAPTICS_PCM;
+        }
+#endif
 
         uint8_t type;
         switch (SDL_GameControllerGetType(state->controller)) {

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -79,10 +79,11 @@ bool toSdlSystemCursor(NativeCursorShape shape, SDL_SystemCursor& systemCursor)
 
 } // namespace
 
-SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, int streamHeight)
+SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, int streamHeight,
+                                 bool enablePhysicalDualSenseHaptics)
     : m_MultiController(prefs.multiController),
       m_GamepadMouse(prefs.gamepadMouse),
-      m_EnableDualSenseHaptics(prefs.enableDualSenseHaptics),
+      m_EnableDualSenseHaptics(enablePhysicalDualSenseHaptics),
       m_SwapMouseButtons(prefs.swapMouseButtons),
       m_SwapWinAltKeys(prefs.swapWinAltKeys),
       m_ReverseScrollDirection(prefs.reverseScrollDirection),

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -82,6 +82,7 @@ bool toSdlSystemCursor(NativeCursorShape shape, SDL_SystemCursor& systemCursor)
 SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, int streamHeight)
     : m_MultiController(prefs.multiController),
       m_GamepadMouse(prefs.gamepadMouse),
+      m_EnableDualSenseHaptics(prefs.enableDualSenseHaptics),
       m_SwapMouseButtons(prefs.swapMouseButtons),
       m_SwapWinAltKeys(prefs.swapWinAltKeys),
       m_ReverseScrollDirection(prefs.reverseScrollDirection),

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -355,6 +355,7 @@ private:
     SDL_Window* m_Window;
     bool m_MultiController;
     bool m_GamepadMouse;
+    bool m_EnableDualSenseHaptics;
     bool m_SwapMouseButtons;
     bool m_SwapWinAltKeys;
     bool m_ReverseScrollDirection;

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -127,7 +127,8 @@ struct RemoteCursorUpdate {
 class SdlInputHandler
 {
 public:
-    explicit SdlInputHandler(StreamingPreferences& prefs, int streamWidth, int streamHeight);
+    explicit SdlInputHandler(StreamingPreferences& prefs, int streamWidth, int streamHeight,
+                             bool enablePhysicalDualSenseHaptics);
 
     ~SdlInputHandler();
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -5,6 +5,7 @@
 #include "settings/streamingpreferences.h"
 #include "streaming/streamutils.h"
 #include "streaming/audio/dualsensehaptics.h"
+#include "streaming/audio/dualsensehapticscalibration.h"
 #include "backend/richpresencemanager.h"
 #include "backend/nvhttp.h"
 #include "backend/identitymanager.h"
@@ -549,6 +550,19 @@ void Session::clDs5HapticsPcm(const LI_DS5_HAPTICS_PCM_FRAME* frame)
         // submit() copies into a bounded queue before this receive callback returns.
         session->m_DualSenseHapticsRenderer->submit(*frame);
     }
+}
+
+void Session::clDs5HapticsIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2* frame)
+{
+    if (frame == nullptr) {
+        return;
+    }
+
+    // IR lanes preserve authored left/right intent, while SDL exposes the
+    // common low/high-frequency motor model. Fold both lanes into spectral
+    // energy here; device-specific renderers can replace this calibration.
+    const auto output = dualsense_haptics::renderIrV2(*frame);
+    clRumble(frame->controllerNumber, output.lowFrequency, output.highFrequency);
 }
 
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
@@ -3309,16 +3323,33 @@ void Session::start()
     }
 #endif
 
-    // Initialize the gamepad code with our preferences
-    // NB: m_InputHandler must be initialize before starting the connection.
-    m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width, m_StreamConfig.height);
+    bool enablePhysicalDualSenseHaptics = false;
+    k_ConnCallbacks.ds5HapticsPcm = nullptr;
+    k_ConnCallbacks.ds5HapticsIrV2 = nullptr;
+    if (m_Preferences->dualSenseHapticsMode == StreamingPreferences::DSHM_PHYSICAL) {
 #ifdef Q_OS_WIN32
-    k_ConnCallbacks.ds5HapticsPcm = m_Preferences->enableDualSenseHaptics ?
-                                        Session::clDs5HapticsPcm : nullptr;
-    if (m_Preferences->enableDualSenseHaptics && m_DualSenseHapticsRenderer == nullptr) {
-        m_DualSenseHapticsRenderer = new DualSenseHapticsRenderer();
-    }
+        if (DualSenseHapticsRenderer::isAvailable()) {
+            enablePhysicalDualSenseHaptics = true;
+            k_ConnCallbacks.ds5HapticsPcm = Session::clDs5HapticsPcm;
+            if (m_DualSenseHapticsRenderer == nullptr) {
+                m_DualSenseHapticsRenderer = new DualSenseHapticsRenderer();
+            }
+        }
+        else {
+            emitLaunchWarning(tr("Physical DualSense haptics was selected, but no active USB DualSense four-channel audio endpoint was found."));
+        }
+#else
+        emitLaunchWarning(tr("Physical DualSense haptics is only available on Windows in this build."));
 #endif
+    }
+    else {
+        k_ConnCallbacks.ds5HapticsIrV2 = Session::clDs5HapticsIrV2;
+    }
+
+    // Initialize the gamepad code with the effective (post-preflight) capability.
+    // NB: m_InputHandler must be initialized before starting the connection.
+    m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width,
+                                         m_StreamConfig.height, enablePhysicalDualSenseHaptics);
 
     // Kick off the async connection thread then return to the caller to pump the event loop
     auto thread = new AsyncConnectionStartThread(this);

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -92,6 +92,7 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
     nullptr, // resolutionChanged (unused on Qt client)
     Session::clClipboardData,
     Session::clCursorUpdate,
+    nullptr,
     nullptr
 };
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -3328,15 +3328,13 @@ void Session::start()
     k_ConnCallbacks.ds5HapticsIrV2 = nullptr;
     if (m_Preferences->dualSenseHapticsMode == StreamingPreferences::DSHM_PHYSICAL) {
 #ifdef Q_OS_WIN32
-        if (DualSenseHapticsRenderer::isAvailable()) {
-            enablePhysicalDualSenseHaptics = true;
-            k_ConnCallbacks.ds5HapticsPcm = Session::clDs5HapticsPcm;
-            if (m_DualSenseHapticsRenderer == nullptr) {
-                m_DualSenseHapticsRenderer = new DualSenseHapticsRenderer();
-            }
+        enablePhysicalDualSenseHaptics = true;
+        k_ConnCallbacks.ds5HapticsPcm = Session::clDs5HapticsPcm;
+        if (m_DualSenseHapticsRenderer == nullptr) {
+            m_DualSenseHapticsRenderer = new DualSenseHapticsRenderer();
         }
-        else {
-            emitLaunchWarning(tr("Physical DualSense haptics was selected, but no active USB DualSense four-channel audio endpoint was found."));
+        if (!DualSenseHapticsRenderer::isAvailable()) {
+            emitLaunchWarning(tr("Physical DualSense haptics was selected, but no active USB DualSense four-channel audio endpoint was found yet. Moonlight will keep checking during this stream."));
         }
 #else
         emitLaunchWarning(tr("Physical DualSense haptics is only available on Windows in this build."));

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -4,6 +4,7 @@
 #include "filemappingux.h"
 #include "settings/streamingpreferences.h"
 #include "streaming/streamutils.h"
+#include "streaming/audio/dualsensehaptics.h"
 #include "backend/richpresencemanager.h"
 #include "backend/nvhttp.h"
 #include "backend/identitymanager.h"
@@ -89,7 +90,8 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
     Session::clSetAdaptiveTriggers,
     nullptr, // resolutionChanged (unused on Qt client)
     Session::clClipboardData,
-    Session::clCursorUpdate
+    Session::clCursorUpdate,
+    nullptr
 };
 
 Session* Session::s_ActiveSession;
@@ -540,6 +542,15 @@ void Session::clCursorUpdate(const LI_CURSOR_UPDATE* update)
     }
 }
 
+void Session::clDs5HapticsPcm(const LI_DS5_HAPTICS_PCM_FRAME* frame)
+{
+    Session* session = s_ActiveSession;
+    if (session != nullptr && session->m_DualSenseHapticsRenderer != nullptr && frame != nullptr) {
+        // submit() copies into a bounded queue before this receive callback returns.
+        session->m_DualSenseHapticsRenderer->submit(*frame);
+    }
+}
+
 void Session::clRumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger)
 {
     // We push an event for the main thread to handle in order to properly synchronize
@@ -919,6 +930,7 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_PortTestResults(0),
       m_OpusDecoder(nullptr),
       m_AudioRenderer(nullptr),
+      m_DualSenseHapticsRenderer(nullptr),
       m_AudioSampleCount(0),
       m_DropAudioEndTime(0),
       m_MenuPanel(nullptr),
@@ -954,6 +966,9 @@ Session::~Session()
         delete m_ClipboardHelper;
         m_ClipboardHelper = nullptr;
     }
+
+    delete m_DualSenseHapticsRenderer;
+    m_DualSenseHapticsRenderer = nullptr;
 
     SDL_DestroyMutex(m_DecoderLock);
 }
@@ -1679,6 +1694,8 @@ private:
         // Finish cleanup of the connection state
         QMetaObject::invokeMethod(m_Session, &Session::stopMicrophone, Qt::BlockingQueuedConnection);
         LiStopConnection();
+        delete m_Session->m_DualSenseHapticsRenderer;
+        m_Session->m_DualSenseHapticsRenderer = nullptr;
 
         // Perform a best-effort app quit
         if (shouldQuit) {
@@ -3295,6 +3312,13 @@ void Session::start()
     // Initialize the gamepad code with our preferences
     // NB: m_InputHandler must be initialize before starting the connection.
     m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width, m_StreamConfig.height);
+#ifdef Q_OS_WIN32
+    k_ConnCallbacks.ds5HapticsPcm = m_Preferences->enableDualSenseHaptics ?
+                                        Session::clDs5HapticsPcm : nullptr;
+    if (m_Preferences->enableDualSenseHaptics && m_DualSenseHapticsRenderer == nullptr) {
+        m_DualSenseHapticsRenderer = new DualSenseHapticsRenderer();
+    }
+#endif
 
     // Kick off the async connection thread then return to the caller to pump the event loop
     auto thread = new AsyncConnectionStartThread(this);

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -278,6 +278,9 @@ private:
     void clDs5HapticsPcm(const LI_DS5_HAPTICS_PCM_FRAME* frame);
 
     static
+    void clDs5HapticsIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2* frame);
+
+    static
     int arInit(int audioConfiguration,
                const POPUS_MULTISTREAM_CONFIGURATION opusConfig,
                void* arContext, int arFlags);

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -26,6 +26,8 @@ struct ProbeState;
 struct MountState;
 }
 
+class DualSenseHapticsRenderer;
+
 class SupportedVideoFormatList : public QList<int>
 {
 public:
@@ -273,6 +275,9 @@ private:
     void clCursorUpdate(const LI_CURSOR_UPDATE* update);
 
     static
+    void clDs5HapticsPcm(const LI_DS5_HAPTICS_PCM_FRAME* frame);
+
+    static
     int arInit(int audioConfiguration,
                const POPUS_MULTISTREAM_CONFIGURATION opusConfig,
                void* arContext, int arFlags);
@@ -343,6 +348,7 @@ private:
 
     OpusMSDecoder* m_OpusDecoder;
     IAudioRenderer* m_AudioRenderer;
+    DualSenseHapticsRenderer* m_DualSenseHapticsRenderer;
     OPUS_MULTISTREAM_CONFIGURATION m_ActiveAudioConfig;
     OPUS_MULTISTREAM_CONFIGURATION m_OriginalAudioConfig;
     int m_AudioSampleCount;

--- a/moonlight-common-c/moonlight-common-c.pro
+++ b/moonlight-common-c/moonlight-common-c.pro
@@ -59,6 +59,7 @@ SOURCES += \
     $$COMMON_C_DIR/src/ConnectionTester.c \
     $$COMMON_C_DIR/src/ControlStream.c \
     $$COMMON_C_DIR/src/CursorStream.c \
+    $$COMMON_C_DIR/src/Ds5HapticsStream.c \
     $$COMMON_C_DIR/src/FakeCallbacks.c \
     $$COMMON_C_DIR/src/InputStream.c \
     $$COMMON_C_DIR/src/MicrophoneStream.c \
@@ -77,6 +78,7 @@ SOURCES += \
     $$COMMON_C_DIR/src/VideoStream.c
 HEADERS += \
     $$COMMON_C_DIR/src/CursorStream.h \
+    $$COMMON_C_DIR/src/Ds5HapticsStream.h \
     $$COMMON_C_DIR/src/Limelight.h
 INCLUDEPATH += \
     $$ENET_DIR/include \

--- a/moonlight-common-c/moonlight-common-c.pro
+++ b/moonlight-common-c/moonlight-common-c.pro
@@ -60,6 +60,7 @@ SOURCES += \
     $$COMMON_C_DIR/src/ControlStream.c \
     $$COMMON_C_DIR/src/CursorStream.c \
     $$COMMON_C_DIR/src/Ds5HapticsStream.c \
+    $$COMMON_C_DIR/src/Ds5HapticsIrStream.c \
     $$COMMON_C_DIR/src/FakeCallbacks.c \
     $$COMMON_C_DIR/src/InputStream.c \
     $$COMMON_C_DIR/src/MicrophoneStream.c \
@@ -79,6 +80,7 @@ SOURCES += \
 HEADERS += \
     $$COMMON_C_DIR/src/CursorStream.h \
     $$COMMON_C_DIR/src/Ds5HapticsStream.h \
+    $$COMMON_C_DIR/src/Ds5HapticsIrStream.h \
     $$COMMON_C_DIR/src/Limelight.h
 INCLUDEPATH += \
     $$ENET_DIR/include \

--- a/tests/ds5_ir_renderer/ds5_ir_renderer.pro
+++ b/tests/ds5_ir_renderer/ds5_ir_renderer.pro
@@ -1,0 +1,11 @@
+QT -= core gui
+CONFIG += console c++17
+CONFIG -= app_bundle
+TEMPLATE = app
+TARGET = ds5_ir_renderer_test
+
+INCLUDEPATH += \
+    ../../app \
+    ../../moonlight-common-c/moonlight-common-c/src
+
+SOURCES += main.cpp

--- a/tests/ds5_ir_renderer/main.cpp
+++ b/tests/ds5_ir_renderer/main.cpp
@@ -1,0 +1,22 @@
+#include "streaming/audio/dualsensehapticscalibration.h"
+
+#include <cassert>
+
+int main()
+{
+    LI_DS5_HAPTICS_IR_FRAME_V2 frame = {};
+    frame.lanes[0].rmsAmplitude = 0.5f;
+    frame.lanes[0].lowBandRatio = 1.0f;
+    frame.lanes[1].rmsAmplitude = 0.4f;
+    frame.lanes[1].transientStrength = 1.0f;
+
+    const auto active = dualsense_haptics::renderIrV2(frame);
+    assert(active.lowFrequency > 0);
+    assert(active.highFrequency > 0);
+
+    frame.flags = LI_DS5_HAPTICS_IR_FLAG_STREAM_END;
+    const auto ended = dualsense_haptics::renderIrV2(frame);
+    assert(ended.lowFrequency == 0);
+    assert(ended.highFrequency == 0);
+    return 0;
+}

--- a/tests/ds5_ir_renderer/main.cpp
+++ b/tests/ds5_ir_renderer/main.cpp
@@ -1,6 +1,7 @@
 #include "streaming/audio/dualsensehapticscalibration.h"
+#include "streaming/audio/dualsensehapticsstream.h"
 
-#include <cassert>
+#define CHECK(condition) do { if (!(condition)) return __LINE__; } while (false)
 
 int main()
 {
@@ -11,12 +12,39 @@ int main()
     frame.lanes[1].transientStrength = 1.0f;
 
     const auto active = dualsense_haptics::renderIrV2(frame);
-    assert(active.lowFrequency > 0);
-    assert(active.highFrequency > 0);
+    CHECK(active.lowFrequency > 0);
+    CHECK(active.highFrequency > 0);
 
     frame.flags = LI_DS5_HAPTICS_IR_FLAG_STREAM_END;
     const auto ended = dualsense_haptics::renderIrV2(frame);
-    assert(ended.lowFrequency == 0);
-    assert(ended.highFrequency == 0);
+    CHECK(ended.lowFrequency == 0);
+    CHECK(ended.highFrequency == 0);
+
+    using Action = dualsense_haptics::PcmStreamTracker::Action;
+    dualsense_haptics::PcmStreamTracker tracker;
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_START, 0, 10) ==
+          Action::ResetAndAccept);
+    CHECK(tracker.observe(0, 0, 11) == Action::Accept);
+
+    // A second controller must not continually reset the endpoint owned by the
+    // first controller, even when its stream starts while the first is active.
+    CHECK(tracker.observe(0, 1, 20) == Action::Ignore);
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_START, 1, 20) == Action::Ignore);
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_END, 1, 21) == Action::Ignore);
+    CHECK(tracker.observe(0, 0, 12) == Action::Accept);
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_END, 0, 13) == Action::End);
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_START, 1, 20) ==
+          Action::ResetAndAccept);
+    CHECK(tracker.observe(0, 0, 13) == Action::Ignore);
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_END, 1, 21) == Action::End);
+
+    // A long quiet period does not alter state: the next contiguous packet is
+    // accepted without forcing another endpoint reset and prebuffer delay.
+    CHECK(tracker.observe(LI_DS5_HAPTICS_PCM_FLAG_STREAM_START, 0, 100) ==
+          Action::ResetAndAccept);
+    CHECK(tracker.observe(0, 0, 101) == Action::Accept);
+
+    // Missing packets still force the jitter buffer to resynchronize.
+    CHECK(tracker.observe(0, 0, 103) == Action::ResetAndAccept);
     return 0;
 }


### PR DESCRIPTION
## 改了啥呀

- 接入 qiin2333/moonlight-common-c#19 的 DS5 PCM 协议。
- Windows 客户端检测到物理 PS5 手柄且用户启用选项时才声明能力。
- 将原生双声道触觉 PCM 写入 48 kHz 四声道 DualSense 端点的 channel 3/4。
- 增加有界队列、自适应预缓冲、断序/控制器切换/20 ms 饥饿恢复，端点异常不会拖住串流线程。
- 新增设置项并明确 USB、有原生 authored haptics、下次串流生效等限制。

## 为啥要改

普通 rumble 转换会丢掉游戏已经编写好的相位、频率和左右执行器细节。这条路线原样传输，杂鱼网络抖动则交给小型 jitter buffer 收拾。

## 验证

- Qt 6.9.2 / MSVC Release 完整链接通过：`build/ds5-native-haptics-692/app/release/Moonlight.exe`。
- 实机端到端环路通过：WASAPI renderer 写入 HIDMaestro 48 kHz 四声道端点，host sidecar 收到 channel 3/4 的 960-byte 非静音 PCM。
- endpoint 容量小于 15 ms 时的预缓冲上限、队列溢出断序和饥饿重置路径已覆盖本机检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support for physical DualSense haptics during streaming.
  * Added a haptics mode selector for physical native haptics or simulated analyzed vibration.
  * Added automatic detection of compatible DualSense devices and supported audio endpoints.
  * Existing haptics settings migrate automatically with platform-appropriate defaults.
  * Added rumble fallback for supported DualSense haptics data.

* **Bug Fixes**
  * Improved haptics buffering, reconnection, and recovery when streams are interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->