### PR TITLE
fix(ui): 修复窗口位置漂移和串流窗口显示器选择

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -244,6 +244,7 @@ SOURCES += \
     settings/mappingmanager.cpp \
     gui/sdlgamepadkeynavigation.cpp \
     gui/windowplacement.cpp \
+    gui/windowsdisplaygeometry.cpp \
     gui/windowswindowchrome.cpp \
     streaming/video/overlaymanager.cpp \
     streaming/video/overlaymenupanel.cpp \
@@ -302,6 +303,7 @@ HEADERS += \
     settings/mappingmanager.h \
     gui/sdlgamepadkeynavigation.h \
     gui/windowplacement.h \
+    gui/windowsdisplaygeometry.h \
     gui/windowswindowchrome.h \
     streaming/video/overlaymanager.h \
     streaming/video/overlaymenupanel.h \

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -95,8 +95,8 @@ ApplicationWindow {
     Component.onCompleted: {
         // Always fit the initial window to the current screen. If the user opted
         // in, restore the last normal window geometry before showing it.
-        windowPlacement.restore()
         windowsWindowChrome.activate()
+        windowPlacement.restore()
 
         // Show the window according to the user's preferences
         if (SystemProperties.hasDesktopEnvironment) {

--- a/app/gui/windowplacement.cpp
+++ b/app/gui/windowplacement.cpp
@@ -1,29 +1,211 @@
 #include "windowplacement.h"
 
+#include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QSettings>
 #include <QWindow>
 
+#ifdef Q_OS_WIN32
+#include <windows.h>
+#endif
+
 namespace {
 constexpr auto GeometryKey = "mainwindow/geometry";
+constexpr auto WindowsOuterGeometryKey = "mainwindow/windowsOuterGeometry";
+constexpr auto WindowsScreenNameKey = "mainwindow/windowsScreen";
 constexpr auto ScreenNameKey = "mainwindow/screen";
 constexpr int OversizedWindowInset = 32;
 
-int constrainedLength(int requested, int available)
+int constrainedLength(int requested, int available, int oversizedInset = OversizedWindowInset)
 {
     if (available <= 0) {
         return qMax(1, requested);
     }
 
     if (requested >= available) {
-        return qMax(1, available > OversizedWindowInset
-                           ? available - OversizedWindowInset
+        return qMax(1, available > oversizedInset
+                           ? available - oversizedInset
                            : available);
     }
 
     return qMax(1, requested);
 }
+
+QRect constrainedGeometry(const QRect& geometry,
+                          const QRect& availableGeometry,
+                          int oversizedInset = OversizedWindowInset)
+{
+    if (!availableGeometry.isValid()) {
+        return geometry;
+    }
+
+    QRect result = geometry;
+    result.setWidth(constrainedLength(result.width(), availableGeometry.width(), oversizedInset));
+    result.setHeight(constrainedLength(result.height(), availableGeometry.height(), oversizedInset));
+
+    const int maximumX = availableGeometry.right() - result.width() + 1;
+    const int maximumY = availableGeometry.bottom() - result.height() + 1;
+    result.moveLeft(qBound(availableGeometry.left(), result.left(), maximumX));
+    result.moveTop(qBound(availableGeometry.top(), result.top(), maximumY));
+    return result;
+}
+
+QScreen* screenForName(const QString& name)
+{
+    const auto screens = QGuiApplication::screens();
+    for (QScreen* screen : screens) {
+        if (screen->name() == name) {
+            return screen;
+        }
+    }
+
+    return nullptr;
+}
+
+#ifdef Q_OS_WIN32
+struct NativeMonitorGeometry
+{
+    HMONITOR handle = nullptr;
+    QRect monitor;
+    QRect workArea;
+    QString name;
+
+    bool isValid() const
+    {
+        return handle && monitor.isValid() && workArea.isValid();
+    }
+};
+
+QRect fromNativeRect(const RECT& rect)
+{
+    return QRect(rect.left,
+                 rect.top,
+                 rect.right - rect.left,
+                 rect.bottom - rect.top);
+}
+
+QString rectText(const QRect& rect)
+{
+    return QStringLiteral("[%1,%2 %3x%4]")
+            .arg(rect.x())
+            .arg(rect.y())
+            .arg(rect.width())
+            .arg(rect.height());
+}
+
+bool populateNativeMonitorGeometry(HMONITOR monitor, NativeMonitorGeometry& geometry)
+{
+    if (!monitor) {
+        return false;
+    }
+
+    MONITORINFOEXW monitorInfo = {};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(monitor, reinterpret_cast<MONITORINFO*>(&monitorInfo))) {
+        return false;
+    }
+
+    geometry.handle = monitor;
+    geometry.monitor = fromNativeRect(monitorInfo.rcMonitor);
+    geometry.workArea = fromNativeRect(monitorInfo.rcWork);
+    geometry.name = QString::fromWCharArray(monitorInfo.szDevice);
+    return geometry.isValid();
+}
+
+struct MonitorSearchContext
+{
+    QString name;
+    NativeMonitorGeometry geometry;
+};
+
+BOOL CALLBACK findMonitorByName(HMONITOR monitor, HDC, LPRECT, LPARAM data)
+{
+    auto* context = reinterpret_cast<MonitorSearchContext*>(data);
+    NativeMonitorGeometry candidate;
+    if (populateNativeMonitorGeometry(monitor, candidate) &&
+            candidate.name.compare(context->name, Qt::CaseInsensitive) == 0) {
+        context->geometry = candidate;
+        return FALSE;
+    }
+    return TRUE;
+}
+
+bool nativeMonitorForName(const QString& name, NativeMonitorGeometry& geometry)
+{
+    if (name.isEmpty()) {
+        return false;
+    }
+
+    MonitorSearchContext context { name, {} };
+    EnumDisplayMonitors(nullptr,
+                        nullptr,
+                        findMonitorByName,
+                        reinterpret_cast<LPARAM>(&context));
+    if (context.geometry.isValid()) {
+        geometry = context.geometry;
+        return true;
+    }
+    return false;
+}
+
+bool nativeMonitorForScreen(QScreen* screen, NativeMonitorGeometry& geometry)
+{
+    if (!screen) {
+        return false;
+    }
+
+    if (nativeMonitorForName(screen->name(), geometry)) {
+        return true;
+    }
+
+    const QPoint center = screen->geometry().center();
+    const POINT nativeCenter { center.x(), center.y() };
+    return populateNativeMonitorGeometry(
+            MonitorFromPoint(nativeCenter, MONITOR_DEFAULTTONEAREST), geometry);
+}
+
+bool nativeMonitorForWindow(HWND window, NativeMonitorGeometry& geometry)
+{
+    return window && populateNativeMonitorGeometry(
+            MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST), geometry);
+}
+
+qreal nativeScaleForScreen(const NativeMonitorGeometry& monitor, QScreen* screen)
+{
+    if (screen && screen->geometry().width() > 0 && monitor.monitor.width() > 0) {
+        return static_cast<qreal>(monitor.monitor.width()) / screen->geometry().width();
+    }
+    if (screen && screen->devicePixelRatio() > 0) {
+        return screen->devicePixelRatio();
+    }
+    return 1.0;
+}
+
+QRect relativeLogicalToNative(const QRect& logicalGeometry,
+                              const NativeMonitorGeometry& monitor,
+                              qreal scale)
+{
+    return QRect(monitor.monitor.left() + qRound(logicalGeometry.left() * scale),
+                 monitor.monitor.top() + qRound(logicalGeometry.top() * scale),
+                 qMax(1, qRound(logicalGeometry.width() * scale)),
+                 qMax(1, qRound(logicalGeometry.height() * scale)));
+}
+
+QRect nativeToRelativeLogical(const QRect& nativeGeometry,
+                              const NativeMonitorGeometry& monitor,
+                              qreal scale)
+{
+    if (scale <= 0) {
+        scale = 1.0;
+    }
+
+    return QRect(qRound((nativeGeometry.left() - monitor.monitor.left()) / scale),
+                 qRound((nativeGeometry.top() - monitor.monitor.top()) / scale),
+                 qMax(1, qRound(nativeGeometry.width() / scale)),
+                 qMax(1, qRound(nativeGeometry.height() / scale)));
+}
+#endif
 }
 
 WindowPlacement::WindowPlacement(QObject* parent)
@@ -100,11 +282,25 @@ void WindowPlacement::restore()
 
     QSettings settings;
     const QRect savedGeometry = settings.value(GeometryKey).toRect();
+#ifdef Q_OS_WIN32
+    const QRect savedWindowsGeometry = settings.value(WindowsOuterGeometryKey).toRect();
+    const bool hasSavedWindowsGeometry = m_Enabled && savedWindowsGeometry.isValid();
+#else
     const bool hasSavedGeometry = m_Enabled && savedGeometry.isValid();
+#endif
 
+#ifdef Q_OS_WIN32
+    const bool hasLegacyGeometry = m_Enabled && !hasSavedWindowsGeometry && savedGeometry.isValid();
+    QScreen* screen = hasSavedWindowsGeometry
+            ? screenForName(settings.value(ScreenNameKey).toString())
+            : (hasLegacyGeometry
+                       ? findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry)
+                       : m_Window->screen());
+#else
     QScreen* screen = hasSavedGeometry
             ? findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry)
             : m_Window->screen();
+#endif
     if (!screen) {
         screen = QGuiApplication::primaryScreen();
     }
@@ -113,6 +309,71 @@ void WindowPlacement::restore()
     }
 
     m_Restoring = true;
+#ifdef Q_OS_WIN32
+    const HWND nativeWindow = reinterpret_cast<HWND>(m_Window->winId());
+    NativeMonitorGeometry nativeMonitor;
+    const QString savedNativeScreenName = settings.value(WindowsScreenNameKey).toString();
+    if (!nativeMonitorForName(savedNativeScreenName, nativeMonitor) &&
+            !nativeMonitorForScreen(screen, nativeMonitor)) {
+        nativeMonitorForWindow(nativeWindow, nativeMonitor);
+    }
+
+    RECT currentWindowRect = {};
+    const bool hasCurrentWindowRect = nativeWindow && GetWindowRect(nativeWindow, &currentWindowRect);
+    if (nativeWindow && nativeMonitor.isValid() && hasCurrentWindowRect) {
+        const qreal scale = nativeScaleForScreen(nativeMonitor, screen);
+        QRect requestedNativeGeometry = fromNativeRect(currentWindowRect);
+        QRect logicalGeometry;
+
+        if (hasSavedWindowsGeometry) {
+            logicalGeometry = savedWindowsGeometry;
+            requestedNativeGeometry = relativeLogicalToNative(logicalGeometry, nativeMonitor, scale);
+        }
+        else if (hasLegacyGeometry) {
+            logicalGeometry = savedGeometry.translated(-screen->geometry().topLeft());
+            requestedNativeGeometry = relativeLogicalToNative(logicalGeometry, nativeMonitor, scale);
+        }
+
+        const int nativeInset = qMax(1, qRound(OversizedWindowInset * scale));
+        const QRect constrainedNativeGeometry = constrainedGeometry(
+                requestedNativeGeometry, nativeMonitor.workArea, nativeInset);
+
+        if (!SetWindowPos(nativeWindow,
+                          nullptr,
+                          constrainedNativeGeometry.x(),
+                          constrainedNativeGeometry.y(),
+                          constrainedNativeGeometry.width(),
+                          constrainedNativeGeometry.height(),
+                          SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER)) {
+            qWarning() << "Failed to restore native window geometry:" << GetLastError();
+        }
+
+        RECT restoredWindowRect = {};
+        GetWindowRect(nativeWindow, &restoredWindowRect);
+        qInfo().noquote()
+                << QStringLiteral("Window placement restore screen=%1 saved=%2 requestedNative=%3 "
+                                  "constrainedNative=%4 actualNative=%5 scale=%6")
+                           .arg(nativeMonitor.name,
+                                logicalGeometry.isValid() ? rectText(logicalGeometry)
+                                                          : QStringLiteral("default"),
+                                rectText(requestedNativeGeometry),
+                                rectText(constrainedNativeGeometry),
+                                rectText(fromNativeRect(restoredWindowRect)))
+                           .arg(scale);
+    }
+    else {
+        const QRect availableGeometry = screen->availableGeometry();
+        if (hasLegacyGeometry) {
+            m_Window->setScreen(screen);
+            m_Window->setGeometry(constrainGeometry(savedGeometry, availableGeometry));
+        }
+        else {
+            const QSize requestedSize = m_Window->size();
+            m_Window->resize(constrainedLength(requestedSize.width(), availableGeometry.width()),
+                             constrainedLength(requestedSize.height(), availableGeometry.height()));
+        }
+    }
+#else
     if (hasSavedGeometry) {
         m_Window->setScreen(screen);
         m_Window->setGeometry(constrainGeometry(savedGeometry, screen->availableGeometry()));
@@ -123,6 +384,7 @@ void WindowPlacement::restore()
         m_Window->resize(constrainedLength(requestedSize.width(), availableGeometry.width()),
                          constrainedLength(requestedSize.height(), availableGeometry.height()));
     }
+#endif
     m_Restoring = false;
 }
 
@@ -134,11 +396,8 @@ void WindowPlacement::flush()
 
 QScreen* WindowPlacement::findSavedScreen(const QString& name, const QRect& geometry)
 {
-    const auto screens = QGuiApplication::screens();
-    for (QScreen* screen : screens) {
-        if (screen->name() == name) {
-            return screen;
-        }
+    if (QScreen* screen = screenForName(name)) {
+        return screen;
     }
 
     if (QScreen* screen = QGuiApplication::screenAt(geometry.center())) {
@@ -150,19 +409,7 @@ QScreen* WindowPlacement::findSavedScreen(const QString& name, const QRect& geom
 
 QRect WindowPlacement::constrainGeometry(const QRect& geometry, const QRect& availableGeometry)
 {
-    if (!availableGeometry.isValid()) {
-        return geometry;
-    }
-
-    QRect result = geometry;
-    result.setWidth(constrainedLength(result.width(), availableGeometry.width()));
-    result.setHeight(constrainedLength(result.height(), availableGeometry.height()));
-
-    const int maximumX = availableGeometry.right() - result.width() + 1;
-    const int maximumY = availableGeometry.bottom() - result.height() + 1;
-    result.moveLeft(qBound(availableGeometry.left(), result.left(), maximumX));
-    result.moveTop(qBound(availableGeometry.top(), result.top(), maximumY));
-    return result;
+    return constrainedGeometry(geometry, availableGeometry);
 }
 
 void WindowPlacement::scheduleSave()
@@ -181,15 +428,48 @@ void WindowPlacement::saveNow()
         return;
     }
 
+    QSettings settings;
+#ifdef Q_OS_WIN32
+    const HWND nativeWindow = reinterpret_cast<HWND>(m_Window->winId());
+    if (!nativeWindow || IsIconic(nativeWindow) || IsZoomed(nativeWindow)) {
+        return;
+    }
+
+    RECT nativeWindowRect = {};
+    NativeMonitorGeometry nativeMonitor;
+    if (!GetWindowRect(nativeWindow, &nativeWindowRect) ||
+            !nativeMonitorForWindow(nativeWindow, nativeMonitor)) {
+        return;
+    }
+
+    QScreen* screen = m_Window->screen();
+    if (!screen) {
+        screen = QGuiApplication::screenAt(m_Window->geometry().center());
+    }
+    const qreal scale = nativeScaleForScreen(nativeMonitor, screen);
+    const QRect nativeGeometry = fromNativeRect(nativeWindowRect);
+    const QRect logicalGeometry = nativeToRelativeLogical(
+            nativeGeometry, nativeMonitor, scale);
+
+    settings.setValue(WindowsOuterGeometryKey, logicalGeometry);
+    settings.setValue(WindowsScreenNameKey, nativeMonitor.name);
+    settings.setValue(ScreenNameKey, screen ? screen->name() : nativeMonitor.name);
+    qInfo().noquote()
+            << QStringLiteral("Window placement save screen=%1 native=%2 relativeLogical=%3 scale=%4")
+                       .arg(nativeMonitor.name,
+                            rectText(nativeGeometry),
+                            rectText(logicalGeometry))
+                       .arg(scale);
+#else
     QScreen* screen = QGuiApplication::screenAt(m_Window->geometry().center());
     if (!screen) {
         screen = m_Window->screen();
     }
 
-    QSettings settings;
     settings.setValue(GeometryKey, m_Window->geometry());
     if (screen) {
         settings.setValue(ScreenNameKey, screen->name());
     }
+#endif
     settings.sync();
 }

--- a/app/gui/windowplacement.cpp
+++ b/app/gui/windowplacement.cpp
@@ -1,14 +1,11 @@
 #include "windowplacement.h"
+#include "windowsdisplaygeometry.h"
 
 #include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QSettings>
 #include <QWindow>
-
-#ifdef Q_OS_WIN32
-#include <windows.h>
-#endif
 
 namespace {
 constexpr auto GeometryKey = "mainwindow/geometry";
@@ -51,40 +48,7 @@ QRect constrainedGeometry(const QRect& geometry,
     return result;
 }
 
-QScreen* screenForName(const QString& name)
-{
-    const auto screens = QGuiApplication::screens();
-    for (QScreen* screen : screens) {
-        if (screen->name() == name) {
-            return screen;
-        }
-    }
-
-    return nullptr;
-}
-
 #ifdef Q_OS_WIN32
-struct NativeMonitorGeometry
-{
-    HMONITOR handle = nullptr;
-    QRect monitor;
-    QRect workArea;
-    QString name;
-
-    bool isValid() const
-    {
-        return handle && monitor.isValid() && workArea.isValid();
-    }
-};
-
-QRect fromNativeRect(const RECT& rect)
-{
-    return QRect(rect.left,
-                 rect.top,
-                 rect.right - rect.left,
-                 rect.bottom - rect.top);
-}
-
 QString rectText(const QRect& rect)
 {
     return QStringLiteral("[%1,%2 %3x%4]")
@@ -94,114 +58,26 @@ QString rectText(const QRect& rect)
             .arg(rect.height());
 }
 
-bool populateNativeMonitorGeometry(HMONITOR monitor, NativeMonitorGeometry& geometry)
-{
-    if (!monitor) {
-        return false;
-    }
-
-    MONITORINFOEXW monitorInfo = {};
-    monitorInfo.cbSize = sizeof(monitorInfo);
-    if (!GetMonitorInfoW(monitor, reinterpret_cast<MONITORINFO*>(&monitorInfo))) {
-        return false;
-    }
-
-    geometry.handle = monitor;
-    geometry.monitor = fromNativeRect(monitorInfo.rcMonitor);
-    geometry.workArea = fromNativeRect(monitorInfo.rcWork);
-    geometry.name = QString::fromWCharArray(monitorInfo.szDevice);
-    return geometry.isValid();
-}
-
-struct MonitorSearchContext
-{
-    QString name;
-    NativeMonitorGeometry geometry;
-};
-
-BOOL CALLBACK findMonitorByName(HMONITOR monitor, HDC, LPRECT, LPARAM data)
-{
-    auto* context = reinterpret_cast<MonitorSearchContext*>(data);
-    NativeMonitorGeometry candidate;
-    if (populateNativeMonitorGeometry(monitor, candidate) &&
-            candidate.name.compare(context->name, Qt::CaseInsensitive) == 0) {
-        context->geometry = candidate;
-        return FALSE;
-    }
-    return TRUE;
-}
-
-bool nativeMonitorForName(const QString& name, NativeMonitorGeometry& geometry)
-{
-    if (name.isEmpty()) {
-        return false;
-    }
-
-    MonitorSearchContext context { name, {} };
-    EnumDisplayMonitors(nullptr,
-                        nullptr,
-                        findMonitorByName,
-                        reinterpret_cast<LPARAM>(&context));
-    if (context.geometry.isValid()) {
-        geometry = context.geometry;
-        return true;
-    }
-    return false;
-}
-
-bool nativeMonitorForScreen(QScreen* screen, NativeMonitorGeometry& geometry)
-{
-    if (!screen) {
-        return false;
-    }
-
-    if (nativeMonitorForName(screen->name(), geometry)) {
-        return true;
-    }
-
-    const QPoint center = screen->geometry().center();
-    const POINT nativeCenter { center.x(), center.y() };
-    return populateNativeMonitorGeometry(
-            MonitorFromPoint(nativeCenter, MONITOR_DEFAULTTONEAREST), geometry);
-}
-
-bool nativeMonitorForWindow(HWND window, NativeMonitorGeometry& geometry)
-{
-    return window && populateNativeMonitorGeometry(
-            MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST), geometry);
-}
-
-qreal nativeScaleForScreen(const NativeMonitorGeometry& monitor, QScreen* screen)
-{
-    if (screen && screen->geometry().width() > 0 && monitor.monitor.width() > 0) {
-        return static_cast<qreal>(monitor.monitor.width()) / screen->geometry().width();
-    }
-    if (screen && screen->devicePixelRatio() > 0) {
-        return screen->devicePixelRatio();
-    }
-    return 1.0;
-}
-
 QRect relativeLogicalToNative(const QRect& logicalGeometry,
-                              const NativeMonitorGeometry& monitor,
+                              const WindowsDisplayGeometry::Monitor& monitor,
                               qreal scale)
 {
-    return QRect(monitor.monitor.left() + qRound(logicalGeometry.left() * scale),
-                 monitor.monitor.top() + qRound(logicalGeometry.top() * scale),
+    return QRect(monitor.bounds.left() + qRound(logicalGeometry.left() * scale),
+                 monitor.bounds.top() + qRound(logicalGeometry.top() * scale),
                  qMax(1, qRound(logicalGeometry.width() * scale)),
                  qMax(1, qRound(logicalGeometry.height() * scale)));
 }
 
 QRect nativeToRelativeLogical(const QRect& nativeGeometry,
-                              const NativeMonitorGeometry& monitor,
+                              const WindowsDisplayGeometry::Monitor& monitor,
                               qreal scale)
 {
     if (scale <= 0) {
         scale = 1.0;
     }
 
-    return QRect(qRound((nativeGeometry.left() - monitor.monitor.left()) / scale),
-                 qRound((nativeGeometry.top() - monitor.monitor.top()) / scale),
+    return QRect(qRound((nativeGeometry.left() - monitor.bounds.left()) / scale),
+                 qRound((nativeGeometry.top() - monitor.bounds.top()) / scale),
                  qMax(1, qRound(nativeGeometry.width() / scale)),
                  qMax(1, qRound(nativeGeometry.height() / scale)));
 }
@@ -214,6 +90,11 @@ WindowPlacement::WindowPlacement(QObject* parent)
     m_SaveTimer.setInterval(300);
     m_SaveTimer.setSingleShot(true);
     connect(&m_SaveTimer, &QTimer::timeout, this, &WindowPlacement::saveNow);
+    if (qGuiApp) {
+        connect(qGuiApp, &QGuiApplication::screenRemoved, this, [this](QScreen*) {
+            scheduleSave();
+        });
+    }
 }
 
 QWindow* WindowPlacement::window() const
@@ -291,11 +172,16 @@ void WindowPlacement::restore()
 
 #ifdef Q_OS_WIN32
     const bool hasLegacyGeometry = m_Enabled && !hasSavedWindowsGeometry && savedGeometry.isValid();
-    QScreen* screen = hasSavedWindowsGeometry
-            ? screenForName(settings.value(ScreenNameKey).toString())
-            : (hasLegacyGeometry
-                       ? findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry)
-                       : m_Window->screen());
+    QScreen* screen = m_Window->screen();
+    if (hasSavedWindowsGeometry) {
+        if (QScreen* savedScreen = WindowsDisplayGeometry::screenForName(
+                    settings.value(ScreenNameKey).toString())) {
+            screen = savedScreen;
+        }
+    }
+    else if (hasLegacyGeometry) {
+        screen = findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry);
+    }
 #else
     QScreen* screen = hasSavedGeometry
             ? findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry)
@@ -310,19 +196,21 @@ void WindowPlacement::restore()
 
     m_Restoring = true;
 #ifdef Q_OS_WIN32
-    const HWND nativeWindow = reinterpret_cast<HWND>(m_Window->winId());
-    NativeMonitorGeometry nativeMonitor;
+    WindowsDisplayGeometry::Monitor nativeMonitor;
     const QString savedNativeScreenName = settings.value(WindowsScreenNameKey).toString();
-    if (!nativeMonitorForName(savedNativeScreenName, nativeMonitor) &&
-            !nativeMonitorForScreen(screen, nativeMonitor)) {
-        nativeMonitorForWindow(nativeWindow, nativeMonitor);
+    if (!WindowsDisplayGeometry::monitorForName(savedNativeScreenName, nativeMonitor) &&
+            !WindowsDisplayGeometry::monitorForScreen(screen, nativeMonitor)) {
+        WindowsDisplayGeometry::monitorForWindow(m_Window, nativeMonitor);
     }
 
-    RECT currentWindowRect = {};
-    const bool hasCurrentWindowRect = nativeWindow && GetWindowRect(nativeWindow, &currentWindowRect);
-    if (nativeWindow && nativeMonitor.isValid() && hasCurrentWindowRect) {
-        const qreal scale = nativeScaleForScreen(nativeMonitor, screen);
-        QRect requestedNativeGeometry = fromNativeRect(currentWindowRect);
+    if (QScreen* matchingScreen = WindowsDisplayGeometry::screenForMonitor(nativeMonitor)) {
+        screen = matchingScreen;
+    }
+
+    const QRect currentWindowGeometry = WindowsDisplayGeometry::windowRect(m_Window);
+    if (nativeMonitor.isValid() && currentWindowGeometry.isValid()) {
+        const qreal scale = WindowsDisplayGeometry::scaleFactor(nativeMonitor, screen);
+        QRect requestedNativeGeometry = currentWindowGeometry;
         QRect logicalGeometry;
 
         if (hasSavedWindowsGeometry) {
@@ -338,18 +226,13 @@ void WindowPlacement::restore()
         const QRect constrainedNativeGeometry = constrainedGeometry(
                 requestedNativeGeometry, nativeMonitor.workArea, nativeInset);
 
-        if (!SetWindowPos(nativeWindow,
-                          nullptr,
-                          constrainedNativeGeometry.x(),
-                          constrainedNativeGeometry.y(),
-                          constrainedNativeGeometry.width(),
-                          constrainedNativeGeometry.height(),
-                          SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER)) {
-            qWarning() << "Failed to restore native window geometry:" << GetLastError();
+        quint32 errorCode = 0;
+        if (!WindowsDisplayGeometry::setWindowRect(
+                    m_Window, constrainedNativeGeometry, &errorCode)) {
+            qWarning() << "Failed to restore native window geometry:" << errorCode;
         }
 
-        RECT restoredWindowRect = {};
-        GetWindowRect(nativeWindow, &restoredWindowRect);
+        const QRect restoredWindowGeometry = WindowsDisplayGeometry::windowRect(m_Window);
         qInfo().noquote()
                 << QStringLiteral("Window placement restore screen=%1 saved=%2 requestedNative=%3 "
                                   "constrainedNative=%4 actualNative=%5 scale=%6")
@@ -358,7 +241,7 @@ void WindowPlacement::restore()
                                                           : QStringLiteral("default"),
                                 rectText(requestedNativeGeometry),
                                 rectText(constrainedNativeGeometry),
-                                rectText(fromNativeRect(restoredWindowRect)))
+                                rectText(restoredWindowGeometry))
                            .arg(scale);
     }
     else {
@@ -396,7 +279,7 @@ void WindowPlacement::flush()
 
 QScreen* WindowPlacement::findSavedScreen(const QString& name, const QRect& geometry)
 {
-    if (QScreen* screen = screenForName(name)) {
+    if (QScreen* screen = WindowsDisplayGeometry::screenForName(name)) {
         return screen;
     }
 
@@ -430,30 +313,32 @@ void WindowPlacement::saveNow()
 
     QSettings settings;
 #ifdef Q_OS_WIN32
-    const HWND nativeWindow = reinterpret_cast<HWND>(m_Window->winId());
-    if (!nativeWindow || IsIconic(nativeWindow) || IsZoomed(nativeWindow)) {
+    if (!WindowsDisplayGeometry::isNormalWindow(m_Window)) {
         return;
     }
 
-    RECT nativeWindowRect = {};
-    NativeMonitorGeometry nativeMonitor;
-    if (!GetWindowRect(nativeWindow, &nativeWindowRect) ||
-            !nativeMonitorForWindow(nativeWindow, nativeMonitor)) {
+    const QRect nativeGeometry = WindowsDisplayGeometry::windowRect(m_Window);
+    WindowsDisplayGeometry::Monitor nativeMonitor;
+    if (!nativeGeometry.isValid() ||
+            !WindowsDisplayGeometry::monitorForWindow(m_Window, nativeMonitor)) {
         return;
     }
 
-    QScreen* screen = m_Window->screen();
+    QScreen* screen = WindowsDisplayGeometry::screenForMonitor(nativeMonitor);
+    if (!screen) {
+        screen = m_Window->screen();
+    }
     if (!screen) {
         screen = QGuiApplication::screenAt(m_Window->geometry().center());
     }
-    const qreal scale = nativeScaleForScreen(nativeMonitor, screen);
-    const QRect nativeGeometry = fromNativeRect(nativeWindowRect);
+    const qreal scale = WindowsDisplayGeometry::scaleFactor(nativeMonitor, screen);
     const QRect logicalGeometry = nativeToRelativeLogical(
             nativeGeometry, nativeMonitor, scale);
 
     settings.setValue(WindowsOuterGeometryKey, logicalGeometry);
     settings.setValue(WindowsScreenNameKey, nativeMonitor.name);
     settings.setValue(ScreenNameKey, screen ? screen->name() : nativeMonitor.name);
+    settings.remove(GeometryKey);
     qInfo().noquote()
             << QStringLiteral("Window placement save screen=%1 native=%2 relativeLogical=%3 scale=%4")
                        .arg(nativeMonitor.name,

--- a/app/gui/windowsdisplaygeometry.cpp
+++ b/app/gui/windowsdisplaygeometry.cpp
@@ -219,6 +219,47 @@ QRect windowRect(QWindow* window)
     return {};
 }
 
+bool clientRectForOverlappedWindow(QWindow* referenceWindow,
+                                   const QRect& frameRect,
+                                   QRect& clientRect)
+{
+#if defined(Q_OS_WIN32)
+    const HWND nativeWindow = windowHandle(referenceWindow);
+    if (!nativeWindow || !frameRect.isValid()) {
+        return false;
+    }
+
+    RECT frameAdjustment = {};
+    const UINT dpi = GetDpiForWindow(nativeWindow);
+    if (!AdjustWindowRectExForDpi(&frameAdjustment,
+                                  WS_OVERLAPPEDWINDOW,
+                                  FALSE,
+                                  0,
+                                  dpi ? dpi : USER_DEFAULT_SCREEN_DPI)) {
+        return false;
+    }
+
+    const int frameWidth = frameAdjustment.right - frameAdjustment.left;
+    const int frameHeight = frameAdjustment.bottom - frameAdjustment.top;
+    const int clientWidth = frameRect.width() - frameWidth;
+    const int clientHeight = frameRect.height() - frameHeight;
+    if (clientWidth <= 0 || clientHeight <= 0) {
+        return false;
+    }
+
+    clientRect = QRect(frameRect.x() - frameAdjustment.left,
+                       frameRect.y() - frameAdjustment.top,
+                       clientWidth,
+                       clientHeight);
+    return true;
+#else
+    Q_UNUSED(referenceWindow)
+    Q_UNUSED(frameRect)
+    Q_UNUSED(clientRect)
+    return false;
+#endif
+}
+
 bool setWindowRect(QWindow* window, const QRect& geometry, quint32* errorCode)
 {
     if (errorCode) {

--- a/app/gui/windowsdisplaygeometry.cpp
+++ b/app/gui/windowsdisplaygeometry.cpp
@@ -1,0 +1,294 @@
+#include "windowsdisplaygeometry.h"
+
+#include <QGuiApplication>
+#include <QScreen>
+#include <QWindow>
+
+#if defined(Q_OS_WIN32)
+#include <windows.h>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtGui/qscreen_platform.h>
+#endif
+#endif
+
+namespace WindowsDisplayGeometry {
+
+bool Monitor::isValid() const
+{
+    return bounds.isValid() && workArea.isValid() && !name.isEmpty();
+}
+
+QScreen* screenForName(const QString& name)
+{
+    const auto screens = QGuiApplication::screens();
+    for (QScreen* screen : screens) {
+        if (screen->name().compare(name, Qt::CaseInsensitive) == 0) {
+            return screen;
+        }
+    }
+
+    return nullptr;
+}
+
+#if defined(Q_OS_WIN32)
+namespace {
+QRect fromNativeRect(const RECT& rect)
+{
+    return QRect(rect.left,
+                 rect.top,
+                 rect.right - rect.left,
+                 rect.bottom - rect.top);
+}
+
+bool populateMonitor(HMONITOR nativeMonitor, Monitor& monitor)
+{
+    if (!nativeMonitor) {
+        return false;
+    }
+
+    MONITORINFOEXW monitorInfo = {};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(nativeMonitor, reinterpret_cast<MONITORINFO*>(&monitorInfo))) {
+        return false;
+    }
+
+    Monitor result;
+    result.bounds = fromNativeRect(monitorInfo.rcMonitor);
+    result.workArea = fromNativeRect(monitorInfo.rcWork);
+    result.name = QString::fromWCharArray(monitorInfo.szDevice);
+    if (!result.isValid()) {
+        return false;
+    }
+
+    monitor = result;
+    return true;
+}
+
+struct MonitorSearchContext
+{
+    QString name;
+    Monitor monitor;
+};
+
+BOOL CALLBACK findMonitorByName(HMONITOR nativeMonitor, HDC, LPRECT, LPARAM data)
+{
+    auto* context = reinterpret_cast<MonitorSearchContext*>(data);
+    Monitor candidate;
+    if (populateMonitor(nativeMonitor, candidate) &&
+            candidate.name.compare(context->name, Qt::CaseInsensitive) == 0) {
+        context->monitor = candidate;
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+bool monitorForNameExact(const QString& name, Monitor& monitor)
+{
+    if (name.isEmpty()) {
+        return false;
+    }
+
+    MonitorSearchContext context { name, {} };
+    EnumDisplayMonitors(nullptr,
+                        nullptr,
+                        findMonitorByName,
+                        reinterpret_cast<LPARAM>(&context));
+    if (!context.monitor.isValid()) {
+        return false;
+    }
+
+    monitor = context.monitor;
+    return true;
+}
+
+bool monitorForScreenExact(QScreen* screen, Monitor& monitor)
+{
+    if (!screen) {
+        return false;
+    }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (auto* nativeScreen = screen->nativeInterface<QNativeInterface::QWindowsScreen>()) {
+        if (populateMonitor(nativeScreen->handle(), monitor)) {
+            return true;
+        }
+    }
+#endif
+
+    return monitorForNameExact(screen->name(), monitor);
+}
+
+HWND windowHandle(QWindow* window)
+{
+    return window ? reinterpret_cast<HWND>(window->winId()) : nullptr;
+}
+
+bool sameMonitor(const Monitor& first, const Monitor& second)
+{
+    return first.isValid() && second.isValid() &&
+            (first.name.compare(second.name, Qt::CaseInsensitive) == 0 ||
+             first.bounds == second.bounds);
+}
+} // namespace
+#endif
+
+bool monitorForName(const QString& name, Monitor& monitor)
+{
+#if defined(Q_OS_WIN32)
+    return monitorForNameExact(name, monitor);
+#else
+    Q_UNUSED(name)
+    Q_UNUSED(monitor)
+#endif
+
+    return false;
+}
+
+bool monitorForScreen(QScreen* screen, Monitor& monitor)
+{
+#if defined(Q_OS_WIN32)
+    if (!screen) {
+        return false;
+    }
+
+    if (monitorForScreenExact(screen, monitor)) {
+        return true;
+    }
+
+    const QPoint center = screen->geometry().center();
+    const POINT nativeCenter { center.x(), center.y() };
+    return populateMonitor(
+            MonitorFromPoint(nativeCenter, MONITOR_DEFAULTTONEAREST), monitor);
+#else
+    Q_UNUSED(screen)
+    Q_UNUSED(monitor)
+    return false;
+#endif
+}
+
+bool monitorForWindow(QWindow* window, Monitor& monitor)
+{
+#if defined(Q_OS_WIN32)
+    const HWND nativeWindow = windowHandle(window);
+    return nativeWindow && populateMonitor(
+            MonitorFromWindow(nativeWindow, MONITOR_DEFAULTTONEAREST), monitor);
+#else
+    Q_UNUSED(window)
+    Q_UNUSED(monitor)
+    return false;
+#endif
+}
+
+QScreen* screenForMonitor(const Monitor& monitor)
+{
+    if (!monitor.isValid()) {
+        return nullptr;
+    }
+
+    if (QScreen* screen = screenForName(monitor.name)) {
+        return screen;
+    }
+
+#if defined(Q_OS_WIN32)
+    const auto screens = QGuiApplication::screens();
+    for (QScreen* screen : screens) {
+        Monitor candidate;
+        if (monitorForScreenExact(screen, candidate) && sameMonitor(candidate, monitor)) {
+            return screen;
+        }
+    }
+#endif
+
+    return nullptr;
+}
+
+QRect windowRect(QWindow* window)
+{
+#if defined(Q_OS_WIN32)
+    RECT nativeRect = {};
+    const HWND nativeWindow = windowHandle(window);
+    if (nativeWindow && GetWindowRect(nativeWindow, &nativeRect)) {
+        return fromNativeRect(nativeRect);
+    }
+#else
+    Q_UNUSED(window)
+#endif
+
+    return {};
+}
+
+bool setWindowRect(QWindow* window, const QRect& geometry, quint32* errorCode)
+{
+    if (errorCode) {
+        *errorCode = 0;
+    }
+
+#if defined(Q_OS_WIN32)
+    const HWND nativeWindow = windowHandle(window);
+    if (!nativeWindow || !geometry.isValid()) {
+        if (errorCode) {
+            *errorCode = nativeWindow ? ERROR_INVALID_PARAMETER : ERROR_INVALID_WINDOW_HANDLE;
+        }
+        return false;
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    if (SetWindowPos(nativeWindow,
+                     nullptr,
+                     geometry.x(),
+                     geometry.y(),
+                     geometry.width(),
+                     geometry.height(),
+                     SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOZORDER)) {
+        return true;
+    }
+
+    if (errorCode) {
+        *errorCode = GetLastError();
+    }
+#else
+    Q_UNUSED(window)
+    Q_UNUSED(geometry)
+#endif
+
+    return false;
+}
+
+bool isNormalWindow(QWindow* window)
+{
+#if defined(Q_OS_WIN32)
+    const HWND nativeWindow = windowHandle(window);
+    return nativeWindow && !IsIconic(nativeWindow) && !IsZoomed(nativeWindow);
+#else
+    Q_UNUSED(window)
+    return false;
+#endif
+}
+
+qreal scaleFactor(const Monitor& monitor, QScreen* preferredScreen)
+{
+    if (!monitor.isValid()) {
+        return 1.0;
+    }
+
+#if defined(Q_OS_WIN32)
+    QScreen* screen = preferredScreen;
+    Monitor screenMonitor;
+    if (!screen || !monitorForScreenExact(screen, screenMonitor) ||
+            !sameMonitor(screenMonitor, monitor)) {
+        screen = screenForMonitor(monitor);
+    }
+
+    if (screen && screen->geometry().width() > 0) {
+        return static_cast<qreal>(monitor.bounds.width()) / screen->geometry().width();
+    }
+#else
+    Q_UNUSED(preferredScreen)
+#endif
+
+    return 1.0;
+}
+
+} // namespace WindowsDisplayGeometry

--- a/app/gui/windowsdisplaygeometry.h
+++ b/app/gui/windowsdisplaygeometry.h
@@ -28,6 +28,9 @@ bool monitorForScreen(QScreen* screen, Monitor& monitor);
 bool monitorForWindow(QWindow* window, Monitor& monitor);
 
 QRect windowRect(QWindow* window);
+bool clientRectForOverlappedWindow(QWindow* referenceWindow,
+                                   const QRect& frameRect,
+                                   QRect& clientRect);
 bool setWindowRect(QWindow* window, const QRect& geometry, quint32* errorCode = nullptr);
 bool isNormalWindow(QWindow* window);
 

--- a/app/gui/windowsdisplaygeometry.h
+++ b/app/gui/windowsdisplaygeometry.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QRect>
+#include <QString>
+#include <QtGlobal>
+
+class QScreen;
+class QWindow;
+
+namespace WindowsDisplayGeometry {
+
+// Snapshot in native physical desktop coordinates. Native monitor handles are
+// intentionally not retained because they become invalid after display changes.
+struct Monitor
+{
+    QRect bounds;
+    QRect workArea;
+    QString name;
+
+    bool isValid() const;
+};
+
+QScreen* screenForName(const QString& name);
+QScreen* screenForMonitor(const Monitor& monitor);
+
+bool monitorForName(const QString& name, Monitor& monitor);
+bool monitorForScreen(QScreen* screen, Monitor& monitor);
+bool monitorForWindow(QWindow* window, Monitor& monitor);
+
+QRect windowRect(QWindow* window);
+bool setWindowRect(QWindow* window, const QRect& geometry, quint32* errorCode = nullptr);
+bool isNormalWindow(QWindow* window);
+
+qreal scaleFactor(const Monitor& monitor, QScreen* preferredScreen = nullptr);
+
+} // namespace WindowsDisplayGeometry

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -28,6 +28,7 @@
 #ifdef Q_OS_WIN32
 // Scaling the icon down on Win32 looks dreadful, so render at lower res
 #define ICON_SIZE 32
+#include <windows.h>
 #include <dxgi1_6.h>
 #include <wrl/client.h>
 #else
@@ -68,6 +69,61 @@
 #include <QUrl>
 
 #include <utility>
+
+namespace {
+QRect qtWindowFrameForSdl(QWindow* window)
+{
+    if (!window) {
+        return {};
+    }
+
+#ifdef Q_OS_WIN32
+    RECT nativeRect = {};
+    const HWND nativeWindow = reinterpret_cast<HWND>(window->winId());
+    if (nativeWindow && GetWindowRect(nativeWindow, &nativeRect)) {
+        return QRect(nativeRect.left,
+                     nativeRect.top,
+                     nativeRect.right - nativeRect.left,
+                     nativeRect.bottom - nativeRect.top);
+    }
+#endif
+
+    const QRect frame = window->frameGeometry();
+#ifdef Q_OS_DARWIN
+    return frame;
+#else
+    const qreal scale = window->devicePixelRatio();
+    return QRect(qRound(frame.x() * scale),
+                 qRound(frame.y() * scale),
+                 qMax(1, qRound(frame.width() * scale)),
+                 qMax(1, qRound(frame.height() * scale)));
+#endif
+}
+
+#ifdef Q_OS_WIN32
+bool qtWindowNativeMonitorBounds(QWindow* window, QRect& bounds)
+{
+    if (!window) {
+        return false;
+    }
+
+    const HWND nativeWindow = reinterpret_cast<HWND>(window->winId());
+    const HMONITOR monitor = nativeWindow
+            ? MonitorFromWindow(nativeWindow, MONITOR_DEFAULTTONEAREST)
+            : nullptr;
+    MONITORINFO monitorInfo = { sizeof(monitorInfo) };
+    if (!monitor || !GetMonitorInfoW(monitor, &monitorInfo)) {
+        return false;
+    }
+
+    bounds = QRect(monitorInfo.rcMonitor.left,
+                   monitorInfo.rcMonitor.top,
+                   monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left,
+                   monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top);
+    return bounds.isValid();
+}
+#endif
+}
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QQuickOpenGLUtils>
@@ -1761,17 +1817,39 @@ void Session::getWindowDimensions(int& x, int& y,
         if (m_QtWindow != nullptr) {
             QScreen* screen = m_QtWindow->screen();
             if (screen != nullptr) {
+#ifdef Q_OS_WIN32
+                QRect displayRect;
+                const bool hasNativeDisplayRect =
+                        qtWindowNativeMonitorBounds(m_QtWindow, displayRect);
+                if (!hasNativeDisplayRect) {
+                    displayRect = screen->geometry();
+                }
+#else
                 QRect displayRect = screen->geometry();
+#endif
 
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "Qt UI screen is at (%d,%d)",
-                            displayRect.x(), displayRect.y());
+                            "Qt UI screen is at (%d,%d) %dx%d",
+                            displayRect.x(), displayRect.y(),
+                            displayRect.width(), displayRect.height());
                 for (int i = 0; i < SDL_GetNumVideoDisplays(); i++) {
                     SDL_Rect displayBounds;
 
                     if (SDL_GetDisplayBounds(i, &displayBounds) == 0) {
-                        if (displayBounds.x == displayRect.x() &&
-                            displayBounds.y == displayRect.y()) {
+#ifdef Q_OS_WIN32
+                        const bool matchesDisplay = hasNativeDisplayRect
+                                ? (displayBounds.x == displayRect.x() &&
+                                   displayBounds.y == displayRect.y() &&
+                                   displayBounds.w == displayRect.width() &&
+                                   displayBounds.h == displayRect.height())
+                                : (displayBounds.x == displayRect.x() &&
+                                   displayBounds.y == displayRect.y());
+#else
+                        const bool matchesDisplay =
+                                displayBounds.x == displayRect.x() &&
+                                displayBounds.y == displayRect.y();
+#endif
+                        if (matchesDisplay) {
                             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                                         "SDL found matching display %d",
                                         i);
@@ -3481,17 +3559,12 @@ void Session::exec()
     // 这里只改初始创建；运行中 Ctrl+Alt+Shift+F 退出全屏时走的是 toggleFullscreen()
     // 里的那次 getWindowDimensions()，恢复的仍然是串流分辨率大小。
     if (m_IsFullScreen && m_QtWindow != nullptr) {
-        QRect guiFrame = m_QtWindow->geometry();
+        const QRect guiFrame = qtWindowFrameForSdl(m_QtWindow);
         if (guiFrame.width() > 0 && guiFrame.height() > 0) {
-            qreal scale = 1.0;
-#ifndef Q_OS_DARWIN
-            // macOS 上 SDL 和 Qt 都用点（逻辑坐标）；其他平台 SDL 用物理像素，要折算
-            scale = m_QtWindow->devicePixelRatio();
-#endif
-            x = qRound(guiFrame.x() * scale);
-            y = qRound(guiFrame.y() * scale);
-            width = qRound(guiFrame.width() * scale);
-            height = qRound(guiFrame.height() * scale);
+            x = guiFrame.x();
+            y = guiFrame.y();
+            width = guiFrame.width();
+            height = guiFrame.height();
         }
     }
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -72,7 +72,7 @@
 #include <utility>
 
 namespace {
-QRect qtWindowFrameForSdl(QWindow* window)
+QRect qtWindowCreationGeometryForSdl(QWindow* window)
 {
     if (!window) {
         return {};
@@ -80,20 +80,22 @@ QRect qtWindowFrameForSdl(QWindow* window)
 
 #ifdef Q_OS_WIN32
     const QRect nativeFrame = WindowsDisplayGeometry::windowRect(window);
-    if (nativeFrame.isValid()) {
-        return nativeFrame;
+    QRect nativeClient;
+    if (WindowsDisplayGeometry::clientRectForOverlappedWindow(
+                window, nativeFrame, nativeClient)) {
+        return nativeClient;
     }
 #endif
 
-    const QRect frame = window->frameGeometry();
+    const QRect client = window->geometry();
 #ifdef Q_OS_DARWIN
-    return frame;
+    return client;
 #else
     const qreal scale = window->devicePixelRatio();
-    return QRect(qRound(frame.x() * scale),
-                 qRound(frame.y() * scale),
-                 qMax(1, qRound(frame.width() * scale)),
-                 qMax(1, qRound(frame.height() * scale)));
+    return QRect(qRound(client.x() * scale),
+                 qRound(client.y() * scale),
+                 qMax(1, qRound(client.width() * scale)),
+                 qMax(1, qRound(client.height() * scale)));
 #endif
 }
 
@@ -3545,12 +3547,12 @@ void Session::exec()
     // 这里只改初始创建；运行中 Ctrl+Alt+Shift+F 退出全屏时走的是 toggleFullscreen()
     // 里的那次 getWindowDimensions()，恢复的仍然是串流分辨率大小。
     if (m_IsFullScreen && m_QtWindow != nullptr) {
-        const QRect guiFrame = qtWindowFrameForSdl(m_QtWindow);
-        if (guiFrame.width() > 0 && guiFrame.height() > 0) {
-            x = guiFrame.x();
-            y = guiFrame.y();
-            width = guiFrame.width();
-            height = guiFrame.height();
+        const QRect creationGeometry = qtWindowCreationGeometryForSdl(m_QtWindow);
+        if (creationGeometry.isValid()) {
+            x = creationGeometry.x();
+            y = creationGeometry.y();
+            width = creationGeometry.width();
+            height = creationGeometry.height();
         }
     }
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -9,6 +9,7 @@
 #include "backend/richpresencemanager.h"
 #include "backend/nvhttp.h"
 #include "backend/identitymanager.h"
+#include "gui/windowsdisplaygeometry.h"
 
 #include <Limelight.h>
 #include "SDL_compat.h"
@@ -78,13 +79,9 @@ QRect qtWindowFrameForSdl(QWindow* window)
     }
 
 #ifdef Q_OS_WIN32
-    RECT nativeRect = {};
-    const HWND nativeWindow = reinterpret_cast<HWND>(window->winId());
-    if (nativeWindow && GetWindowRect(nativeWindow, &nativeRect)) {
-        return QRect(nativeRect.left,
-                     nativeRect.top,
-                     nativeRect.right - nativeRect.left,
-                     nativeRect.bottom - nativeRect.top);
+    const QRect nativeFrame = WindowsDisplayGeometry::windowRect(window);
+    if (nativeFrame.isValid()) {
+        return nativeFrame;
     }
 #endif
 
@@ -103,23 +100,12 @@ QRect qtWindowFrameForSdl(QWindow* window)
 #ifdef Q_OS_WIN32
 bool qtWindowNativeMonitorBounds(QWindow* window, QRect& bounds)
 {
-    if (!window) {
+    WindowsDisplayGeometry::Monitor monitor;
+    if (!WindowsDisplayGeometry::monitorForWindow(window, monitor)) {
         return false;
     }
 
-    const HWND nativeWindow = reinterpret_cast<HWND>(window->winId());
-    const HMONITOR monitor = nativeWindow
-            ? MonitorFromWindow(nativeWindow, MONITOR_DEFAULTTONEAREST)
-            : nullptr;
-    MONITORINFO monitorInfo = { sizeof(monitorInfo) };
-    if (!monitor || !GetMonitorInfoW(monitor, &monitorInfo)) {
-        return false;
-    }
-
-    bounds = QRect(monitorInfo.rcMonitor.left,
-                   monitorInfo.rcMonitor.top,
-                   monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left,
-                   monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top);
+    bounds = monitor.bounds;
     return bounds.isValid();
 }
 #endif


### PR DESCRIPTION
## 问题

Windows 自定义标题栏保留了标准窗口样式，同时让客户区覆盖整个外框。之前保存的是 Qt 客户区几何，恢复时 Windows 又按标准窗口框重新计算外框，因此每次关闭重开都会向左上偏移，并逐次变大。

同一处坐标语义混用还会影响串流窗口：Qt 主窗口的客户区坐标被当成实际外框，并用于匹配 SDL 显示器，在高 DPI 或多显示器环境下可能选错位置或显示器。

## 修改

- Windows 先完成原生窗口框初始化，再恢复窗口位置和尺寸。
- 使用 `GetWindowRect()` 保存实际外框，按显示器保存相对逻辑坐标；恢复时根据当前缩放换算回物理坐标，并在工作区内约束。
- 兼容旧版 `mainwindow/geometry`，完成一次有效保存后清理旧键。
- 最大化和最小化状态不覆盖最后一次普通窗口位置。
- Qt 主窗口交给 SDL 时以实际外框为目标；Windows 先按 DPI 换算成 SDL 所需的客户区创建几何，避免 SDL 再次添加窗口框。Windows 使用物理显示器边界匹配 SDL display。
- 将 Windows 原生窗口和显示器几何查询集中到 `WindowsDisplayGeometry`，业务代码不保存或直接操作原生句柄。
- Qt 6 使用 `QScreen` 的 Windows 原生接口确认同一显示器；无法确认时不混用其他屏幕的缩放数据。
- 监听显示器移除事件，在系统完成窗口迁移后通过原有的 300ms single-shot 定时器保存，不增加轮询或高频原生查询。
- 补充保存和恢复日志，记录目标显示器、请求位置、约束结果和最终位置。

## 验证

- Windows x64 Release 完整构建成功，包含翻译、MSI 和便携包；最终修改已重新编译并链接。
- 连续关闭重开 4 次，窗口位置和尺寸保持一致。
- 自定义位置连续重开 3 次无漂移。
- 验证最大化、最小化恢复和工作区边界约束，普通窗口位置未被覆盖。
- 使用 100% 和 125% 缩放往返测试，保存的逻辑位置和尺寸保持一致。
- 使用独立便携配置模拟保存的显示器已移除，程序回退到当前可用显示器并约束到工作区；后续连续启动位置保持一致。
- 使用项目打包的 sdl2-compat/SDL3 创建测试窗口，换算后的客户区最终得到与目标完全一致的 Win32 外框。
- QML 检查和差异格式检查通过。

当前测试环境只识别到一台显示器，多显示器热拔插和从不同显示器启动全屏串流仍需要在真实多屏环境验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window position and size restoration on Windows, including monitor scaling, work areas, and native window frames.
  * Preserved window placement more reliably across monitor changes, display configurations, and screen removal.
  * Improved startup sizing and fullscreen behavior on Windows.
  * Maintained compatibility with existing saved window settings and non-Windows platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->