### PR TITLE
feat(ui): 优化记住窗口状态与悬浮按钮位置

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -230,6 +230,7 @@ SOURCES += \
     cli/quitstream.cpp \
     cli/startstream.cpp \
     settings/compatfetcher.cpp \
+    settings/devicelocalsettings.cpp \
     settings/mappingfetcher.cpp \
     settings/streamingpreferences.cpp \
     streaming/input/abstouch.cpp \
@@ -265,6 +266,7 @@ SOURCES += \
     gui/windowswindowchrome.cpp \
     streaming/video/overlaymanager.cpp \
     streaming/video/overlaymenupanel.cpp \
+    streaming/video/overlaybuttonposition.cpp \
     streaming/video/overlaymenubutton.cpp \
     streaming/video/overlaytoast.cpp \
     backend/systemproperties.cpp \
@@ -278,6 +280,7 @@ HEADERS += \
     backend/nvapp.h \
     cli/pair.h \
     settings/compatfetcher.h \
+    settings/devicelocalsettings.h \
     settings/mappingfetcher.h \
     streaming/video/videoenhancement.h \
     utils.h \
@@ -325,6 +328,7 @@ HEADERS += \
     gui/windowswindowchrome.h \
     streaming/video/overlaymanager.h \
     streaming/video/overlaymenupanel.h \
+    streaming/video/overlaybuttonposition.h \
     streaming/video/overlaymenubutton.h \
     streaming/video/overlaytoast.h \
     backend/systemproperties.h \

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -46,7 +46,9 @@ ApplicationWindow {
     WindowPlacement {
         id: windowPlacement
         window: window
-        enabled: StreamingPreferences.rememberWindowPosition
+        enabled: StreamingPreferences.rememberWindowPosition &&
+                 SystemProperties.hasDesktopEnvironment &&
+                 (!SystemProperties.isRunningWayland || SystemProperties.isRunningXWayland)
     }
 
     WindowsWindowChrome {
@@ -127,23 +129,24 @@ ApplicationWindow {
     }
 
     Component.onCompleted: {
-        // Always fit the initial window to the current screen. If the user opted
-        // in, restore the last normal window geometry before showing it.
+        // Always fit the initial window to the current screen. When the preference
+        // is enabled, restore the last normal window geometry before showing it.
         windowsWindowChrome.activate()
-        windowPlacement.restore()
+        var startMaximized = windowPlacement.restore(
+                    StreamingPreferences.uiDisplayMode === StreamingPreferences.UI_MAXIMIZED)
 
         // Show the window according to the user's preferences
         if (SystemProperties.hasDesktopEnvironment) {
-            if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_MAXIMIZED) {
+            if (StreamingPreferences.uiDisplayMode === StreamingPreferences.UI_FULLSCREEN) {
+                window.showFullScreen()
+            }
+            else if (startMaximized) {
                 if (Qt.platform.os === "windows") {
                     window.opacity = 0
                     window.revealAfterFirstFrame = true
                     revealFallbackTimer.start()
                 }
                 window.showMaximized()
-            }
-            else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) {
-                window.showFullScreen()
             }
             else {
                 window.show()

--- a/app/gui/windowplacement.cpp
+++ b/app/gui/windowplacement.cpp
@@ -1,10 +1,12 @@
 #include "windowplacement.h"
 #include "windowsdisplaygeometry.h"
+#include "settings/devicelocalsettings.h"
 
 #include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QSettings>
+#include <QStringList>
 #include <QWindow>
 
 namespace {
@@ -12,34 +14,104 @@ constexpr auto GeometryKey = "mainwindow/geometry";
 constexpr auto WindowsOuterGeometryKey = "mainwindow/windowsOuterGeometry";
 constexpr auto WindowsScreenNameKey = "mainwindow/windowsScreen";
 constexpr auto ScreenNameKey = "mainwindow/screen";
-constexpr int OversizedWindowInset = 32;
+constexpr auto MaximizedKey = "mainwindow/maximized";
+constexpr auto LocalStateVersionKey = "meta/version";
+constexpr auto LocalStateFileName = "window-placement.ini";
+constexpr int LocalStateVersion = 1;
 
-int constrainedLength(int requested, int available, int oversizedInset = OversizedWindowInset)
+const QStringList& placementStateKeys()
+{
+    static const QStringList keys {
+        QLatin1String(GeometryKey),
+        QLatin1String(WindowsOuterGeometryKey),
+        QLatin1String(WindowsScreenNameKey),
+        QLatin1String(ScreenNameKey),
+        QLatin1String(MaximizedKey),
+    };
+    return keys;
+}
+
+void migrateLegacyPlacementSettings(QSettings& localSettings)
+{
+    if (localSettings.value(QLatin1String(LocalStateVersionKey), 0).toInt() >=
+            LocalStateVersion) {
+        return;
+    }
+
+    QSettings globalSettings;
+    bool hasLegacyState = false;
+    for (const QString& key : placementStateKeys()) {
+        if (!globalSettings.contains(key)) {
+            continue;
+        }
+
+        hasLegacyState = true;
+        if (!localSettings.contains(key)) {
+            localSettings.setValue(key, globalSettings.value(key));
+        }
+    }
+
+    localSettings.sync();
+    if (localSettings.status() != QSettings::NoError) {
+        qWarning() << "Failed to migrate device-local window placement state";
+        return;
+    }
+
+    if (hasLegacyState) {
+        for (const QString& key : placementStateKeys()) {
+            globalSettings.remove(key);
+        }
+        globalSettings.sync();
+        if (globalSettings.status() != QSettings::NoError) {
+            qWarning() << "Failed to remove migrated window placement state from main settings";
+            return;
+        }
+        qInfo() << "Migrated window placement state to device-local storage";
+    }
+
+    localSettings.setValue(QLatin1String(LocalStateVersionKey), LocalStateVersion);
+    localSettings.sync();
+    if (localSettings.status() != QSettings::NoError) {
+        qWarning() << "Failed to finalize the device-local window placement migration";
+    }
+}
+
+const char* visibilityName(QWindow::Visibility visibility)
+{
+    switch (visibility) {
+    case QWindow::Hidden: return "hidden";
+    case QWindow::AutomaticVisibility: return "automatic";
+    case QWindow::Windowed: return "windowed";
+    case QWindow::Minimized: return "minimized";
+    case QWindow::Maximized: return "maximized";
+    case QWindow::FullScreen: return "fullscreen";
+    }
+    return "unknown";
+}
+
+int constrainedLength(int requested, int available)
 {
     if (available <= 0) {
         return qMax(1, requested);
     }
 
-    if (requested >= available) {
-        return qMax(1, available > oversizedInset
-                           ? available - oversizedInset
-                           : available);
+    if (requested > available) {
+        return available;
     }
 
     return qMax(1, requested);
 }
 
 QRect constrainedGeometry(const QRect& geometry,
-                          const QRect& availableGeometry,
-                          int oversizedInset = OversizedWindowInset)
+                          const QRect& availableGeometry)
 {
     if (!availableGeometry.isValid()) {
         return geometry;
     }
 
     QRect result = geometry;
-    result.setWidth(constrainedLength(result.width(), availableGeometry.width(), oversizedInset));
-    result.setHeight(constrainedLength(result.height(), availableGeometry.height(), oversizedInset));
+    result.setWidth(constrainedLength(result.width(), availableGeometry.width()));
+    result.setHeight(constrainedLength(result.height(), availableGeometry.height()));
 
     const int maximumX = availableGeometry.right() - result.width() + 1;
     const int maximumY = availableGeometry.bottom() - result.height() + 1;
@@ -85,8 +157,13 @@ QRect nativeToRelativeLogical(const QRect& nativeGeometry,
 }
 
 WindowPlacement::WindowPlacement(QObject* parent)
-    : QObject(parent)
+    : QObject(parent),
+      m_PlacementSettings(DeviceLocalSettings::filePath(
+                                  QLatin1String(LocalStateFileName),
+                                  "MOONLIGHT_WINDOW_PLACEMENT_DIR"),
+                          QSettings::IniFormat)
 {
+    migrateLegacyPlacementSettings(m_PlacementSettings);
     m_SaveTimer.setInterval(300);
     m_SaveTimer.setSingleShot(true);
     connect(&m_SaveTimer, &QTimer::timeout, this, &WindowPlacement::saveNow);
@@ -127,6 +204,7 @@ void WindowPlacement::setWindow(QWindow* window)
             else {
                 m_SaveTimer.stop();
             }
+            saveWindowState(visibility);
         });
     }
 
@@ -147,6 +225,9 @@ void WindowPlacement::setEnabled(bool enabled)
     m_Enabled = enabled;
     if (m_Enabled) {
         scheduleSave();
+        if (m_Window) {
+            saveWindowState(m_Window->visibility());
+        }
     }
     else {
         m_SaveTimer.stop();
@@ -155,16 +236,33 @@ void WindowPlacement::setEnabled(bool enabled)
     emit enabledChanged();
 }
 
-void WindowPlacement::restore()
+bool WindowPlacement::restore(bool defaultMaximized)
 {
+    const bool hasSavedMaximized = m_Enabled &&
+            m_PlacementSettings.contains(QLatin1String(MaximizedKey));
+    const bool savedMaximized = hasSavedMaximized &&
+            m_PlacementSettings.value(QLatin1String(MaximizedKey)).toBool();
+    const bool selectedMaximized = defaultMaximized || savedMaximized;
+
+    qInfo().noquote()
+            << QStringLiteral("Window placement state restore saved=%1 fallbackMaximized=%2 "
+                              "selectedMaximized=%3")
+                       .arg(hasSavedMaximized
+                                    ? (savedMaximized ? QStringLiteral("maximized")
+                                                      : QStringLiteral("windowed"))
+                                    : QStringLiteral("none"))
+                       .arg(defaultMaximized ? 1 : 0)
+                       .arg(selectedMaximized ? 1 : 0);
+
     if (!m_Window) {
-        return;
+        return selectedMaximized;
     }
 
-    QSettings settings;
-    const QRect savedGeometry = settings.value(GeometryKey).toRect();
+    const QRect savedGeometry = m_PlacementSettings.value(
+            QLatin1String(GeometryKey)).toRect();
 #ifdef Q_OS_WIN32
-    const QRect savedWindowsGeometry = settings.value(WindowsOuterGeometryKey).toRect();
+    const QRect savedWindowsGeometry = m_PlacementSettings.value(
+            QLatin1String(WindowsOuterGeometryKey)).toRect();
     const bool hasSavedWindowsGeometry = m_Enabled && savedWindowsGeometry.isValid();
 #else
     const bool hasSavedGeometry = m_Enabled && savedGeometry.isValid();
@@ -175,29 +273,34 @@ void WindowPlacement::restore()
     QScreen* screen = m_Window->screen();
     if (hasSavedWindowsGeometry) {
         if (QScreen* savedScreen = WindowsDisplayGeometry::screenForName(
-                    settings.value(ScreenNameKey).toString())) {
+                    m_PlacementSettings.value(QLatin1String(ScreenNameKey)).toString())) {
             screen = savedScreen;
         }
     }
     else if (hasLegacyGeometry) {
-        screen = findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry);
+        screen = findSavedScreen(m_PlacementSettings.value(
+                                     QLatin1String(ScreenNameKey)).toString(),
+                                 savedGeometry);
     }
 #else
     QScreen* screen = hasSavedGeometry
-            ? findSavedScreen(settings.value(ScreenNameKey).toString(), savedGeometry)
+            ? findSavedScreen(m_PlacementSettings.value(
+                                  QLatin1String(ScreenNameKey)).toString(),
+                              savedGeometry)
             : m_Window->screen();
 #endif
     if (!screen) {
         screen = QGuiApplication::primaryScreen();
     }
     if (!screen) {
-        return;
+        return selectedMaximized;
     }
 
     m_Restoring = true;
 #ifdef Q_OS_WIN32
     WindowsDisplayGeometry::Monitor nativeMonitor;
-    const QString savedNativeScreenName = settings.value(WindowsScreenNameKey).toString();
+    const QString savedNativeScreenName = m_PlacementSettings.value(
+            QLatin1String(WindowsScreenNameKey)).toString();
     if (!WindowsDisplayGeometry::monitorForName(savedNativeScreenName, nativeMonitor) &&
             !WindowsDisplayGeometry::monitorForScreen(screen, nativeMonitor)) {
         WindowsDisplayGeometry::monitorForWindow(m_Window, nativeMonitor);
@@ -222,9 +325,8 @@ void WindowPlacement::restore()
             requestedNativeGeometry = relativeLogicalToNative(logicalGeometry, nativeMonitor, scale);
         }
 
-        const int nativeInset = qMax(1, qRound(OversizedWindowInset * scale));
         const QRect constrainedNativeGeometry = constrainedGeometry(
-                requestedNativeGeometry, nativeMonitor.workArea, nativeInset);
+                requestedNativeGeometry, nativeMonitor.workArea);
 
         quint32 errorCode = 0;
         if (!WindowsDisplayGeometry::setWindowRect(
@@ -269,11 +371,15 @@ void WindowPlacement::restore()
     }
 #endif
     m_Restoring = false;
+    return selectedMaximized;
 }
 
 void WindowPlacement::flush()
 {
     m_SaveTimer.stop();
+    if (m_Window) {
+        saveWindowState(m_Window->visibility());
+    }
     saveNow();
 }
 
@@ -303,6 +409,41 @@ void WindowPlacement::scheduleSave()
     }
 }
 
+void WindowPlacement::saveWindowState(QWindow::Visibility visibility)
+{
+    if (!m_Enabled || m_Restoring || !m_Window) {
+        return;
+    }
+
+    bool maximized;
+    if (visibility == QWindow::Windowed) {
+        maximized = false;
+    }
+    else if (visibility == QWindow::Maximized) {
+        maximized = true;
+    }
+    else {
+        // Minimized, fullscreen, hidden, and startup transitions are not stable
+        // restore targets. Keep the last normal/maximized state instead.
+        return;
+    }
+
+    if (m_PlacementSettings.contains(QLatin1String(MaximizedKey)) &&
+            m_PlacementSettings.value(QLatin1String(MaximizedKey)).toBool() == maximized) {
+        return;
+    }
+    m_PlacementSettings.setValue(QLatin1String(MaximizedKey), maximized);
+    m_PlacementSettings.sync();
+    if (m_PlacementSettings.status() != QSettings::NoError) {
+        qWarning() << "Failed to save device-local window state";
+        return;
+    }
+    qInfo().noquote()
+            << QStringLiteral("Window placement state save maximized=%1 visibility=%2")
+                       .arg(maximized ? 1 : 0)
+                       .arg(QString::fromLatin1(visibilityName(visibility)));
+}
+
 void WindowPlacement::saveNow()
 {
     if (!m_Enabled || m_Restoring || !m_Window ||
@@ -311,7 +452,6 @@ void WindowPlacement::saveNow()
         return;
     }
 
-    QSettings settings;
 #ifdef Q_OS_WIN32
     if (!WindowsDisplayGeometry::isNormalWindow(m_Window)) {
         return;
@@ -335,10 +475,11 @@ void WindowPlacement::saveNow()
     const QRect logicalGeometry = nativeToRelativeLogical(
             nativeGeometry, nativeMonitor, scale);
 
-    settings.setValue(WindowsOuterGeometryKey, logicalGeometry);
-    settings.setValue(WindowsScreenNameKey, nativeMonitor.name);
-    settings.setValue(ScreenNameKey, screen ? screen->name() : nativeMonitor.name);
-    settings.remove(GeometryKey);
+    m_PlacementSettings.setValue(QLatin1String(WindowsOuterGeometryKey), logicalGeometry);
+    m_PlacementSettings.setValue(QLatin1String(WindowsScreenNameKey), nativeMonitor.name);
+    m_PlacementSettings.setValue(QLatin1String(ScreenNameKey),
+                                 screen ? screen->name() : nativeMonitor.name);
+    m_PlacementSettings.remove(QLatin1String(GeometryKey));
     qInfo().noquote()
             << QStringLiteral("Window placement save screen=%1 native=%2 relativeLogical=%3 scale=%4")
                        .arg(nativeMonitor.name,
@@ -351,10 +492,13 @@ void WindowPlacement::saveNow()
         screen = m_Window->screen();
     }
 
-    settings.setValue(GeometryKey, m_Window->geometry());
+    m_PlacementSettings.setValue(QLatin1String(GeometryKey), m_Window->geometry());
     if (screen) {
-        settings.setValue(ScreenNameKey, screen->name());
+        m_PlacementSettings.setValue(QLatin1String(ScreenNameKey), screen->name());
     }
 #endif
-    settings.sync();
+    m_PlacementSettings.sync();
+    if (m_PlacementSettings.status() != QSettings::NoError) {
+        qWarning() << "Failed to save device-local window geometry";
+    }
 }

--- a/app/gui/windowplacement.cpp
+++ b/app/gui/windowplacement.cpp
@@ -242,7 +242,9 @@ bool WindowPlacement::restore(bool defaultMaximized)
             m_PlacementSettings.contains(QLatin1String(MaximizedKey));
     const bool savedMaximized = hasSavedMaximized &&
             m_PlacementSettings.value(QLatin1String(MaximizedKey)).toBool();
-    const bool selectedMaximized = defaultMaximized || savedMaximized;
+    const bool selectedMaximized = hasSavedMaximized
+            ? savedMaximized
+            : defaultMaximized;
 
     qInfo().noquote()
             << QStringLiteral("Window placement state restore saved=%1 fallbackMaximized=%2 "

--- a/app/gui/windowplacement.h
+++ b/app/gui/windowplacement.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QRect>
+#include <QSettings>
 #include <QTimer>
 #include <QWindow>
 
@@ -23,7 +24,7 @@ public:
     bool isEnabled() const;
     void setEnabled(bool enabled);
 
-    Q_INVOKABLE void restore();
+    Q_INVOKABLE bool restore(bool defaultMaximized);
     Q_INVOKABLE void flush();
 
 signals:
@@ -35,8 +36,10 @@ private:
     static QRect constrainGeometry(const QRect& geometry, const QRect& availableGeometry);
 
     void scheduleSave();
+    void saveWindowState(QWindow::Visibility visibility);
     void saveNow();
 
+    QSettings m_PlacementSettings;
     QPointer<QWindow> m_Window;
     QTimer m_SaveTimer;
     bool m_Enabled = false;

--- a/app/gui/windowswindowchrome.cpp
+++ b/app/gui/windowswindowchrome.cpp
@@ -3,6 +3,9 @@
 #include <QCoreApplication>
 #include <QScreen>
 #include <QTimer>
+#include <QtMath>
+
+#include <limits>
 
 #ifdef Q_OS_WIN32
 #include <windows.h>
@@ -38,6 +41,55 @@ QString qtRectText(const QRect& rect)
             .arg(rect.y())
             .arg(rect.width())
             .arg(rect.height());
+}
+
+LONG nativeMaximumTrackLength(int logicalMaximum, qreal scale)
+{
+    const qint64 nativeMaximum = qCeil(qMax(1, logicalMaximum) * scale);
+    return static_cast<LONG>(qMin<qint64>(
+            nativeMaximum, (std::numeric_limits<LONG>::max)()));
+}
+
+void constrainMaximizedDragRestoreSize(HWND window)
+{
+    WINDOWPLACEMENT placement = { sizeof(placement) };
+    if (!GetWindowPlacement(window, &placement)) {
+        return;
+    }
+
+    const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitorInfo = { sizeof(monitorInfo) };
+    if (!monitor || !GetMonitorInfoW(monitor, &monitorInfo)) {
+        return;
+    }
+
+    const LONG workWidth = monitorInfo.rcWork.right - monitorInfo.rcWork.left;
+    const LONG workHeight = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top;
+    const LONG normalWidth = placement.rcNormalPosition.right -
+                             placement.rcNormalPosition.left;
+    const LONG normalHeight = placement.rcNormalPosition.bottom -
+                              placement.rcNormalPosition.top;
+    if (workWidth <= 0 || workHeight <= 0 || normalWidth <= 0 || normalHeight <= 0) {
+        return;
+    }
+    const LONG restoredWidth = qMin(normalWidth, workWidth);
+    const LONG restoredHeight = qMin(normalHeight, workHeight);
+    if (restoredWidth == normalWidth && restoredHeight == normalHeight) {
+        return;
+    }
+
+    const RECT previousNormalPosition = placement.rcNormalPosition;
+    placement.rcNormalPosition.right = placement.rcNormalPosition.left + restoredWidth;
+    placement.rcNormalPosition.bottom = placement.rcNormalPosition.top + restoredHeight;
+    if (!SetWindowPlacement(window, &placement)) {
+        qWarning() << "Failed to constrain the maximized drag restore size:" << GetLastError();
+        return;
+    }
+
+    qInfo().noquote()
+            << QStringLiteral("Window drag restore constrained normal size from %1 to %2")
+                       .arg(nativeRectText(previousNormalPosition),
+                            nativeRectText(placement.rcNormalPosition));
 }
 }
 #endif
@@ -326,9 +378,28 @@ bool WindowsWindowChrome::nativeEventFilter(const QByteArray& eventType,
             minMaxInfo->ptMaxPosition.y = monitorInfo.rcWork.top - monitorInfo.rcMonitor.top;
             minMaxInfo->ptMaxSize.x = monitorInfo.rcWork.right - monitorInfo.rcWork.left;
             minMaxInfo->ptMaxSize.y = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top;
+            // Keep maximize constrained to the monitor work area, but don't
+            // inherit Windows' screen-sized tracking cap for manual resizing.
+            // Startup restoration applies its own safety constraints when a
+            // saved window no longer fits the current display.
+            const qreal scale = m_Window->devicePixelRatio();
+            minMaxInfo->ptMaxTrackSize.x = nativeMaximumTrackLength(
+                    m_Window->maximumWidth(), scale);
+            minMaxInfo->ptMaxTrackSize.y = nativeMaximumTrackLength(
+                    m_Window->maximumHeight(), scale);
             *result = 0;
             return true;
         }
+    }
+
+    if (nativeMessage->message == WM_NCLBUTTONDOWN &&
+            nativeMessage->wParam == HTCAPTION &&
+            IsZoomed(nativeMessage->hwnd)) {
+        // Windows restores rcNormalPosition before beginning a caption drag.
+        // Keep explicit restore-button behavior intact, but prevent a normal
+        // rectangle larger than the current display from reappearing during
+        // drag-to-restore.
+        constrainMaximizedDragRestoreSize(nativeMessage->hwnd);
     }
 
     if (nativeMessage->message != WM_NCHITTEST ||

--- a/app/settings/devicelocalsettings.cpp
+++ b/app/settings/devicelocalsettings.cpp
@@ -1,0 +1,39 @@
+#include "devicelocalsettings.h"
+
+#include <QDir>
+#include <QStandardPaths>
+
+namespace {
+QString stateDirectory(const char* featureOverrideVariable)
+{
+    if (featureOverrideVariable && *featureOverrideVariable) {
+        const QString featureOverride = qEnvironmentVariable(featureOverrideVariable);
+        if (!featureOverride.isEmpty()) {
+            return QDir::cleanPath(featureOverride);
+        }
+    }
+
+    const QString sharedOverride = qEnvironmentVariable(
+            "MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR");
+    if (!sharedOverride.isEmpty()) {
+        return QDir::cleanPath(sharedOverride);
+    }
+
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+}
+}
+
+QString DeviceLocalSettings::filePath(const QString& fileName,
+                                      const char* featureOverrideVariable)
+{
+    QDir directory(stateDirectory(featureOverrideVariable));
+    if (!directory.path().isEmpty() &&
+            (directory.exists() || directory.mkpath(QStringLiteral(".")))) {
+        return directory.filePath(fileName);
+    }
+
+    QDir fallbackDirectory(QDir::temp().filePath(QStringLiteral("Moonlight")));
+    fallbackDirectory.mkpath(QStringLiteral("."));
+    qWarning("Failed to create the device-local settings directory; using temporary storage");
+    return fallbackDirectory.filePath(fileName);
+}

--- a/app/settings/devicelocalsettings.h
+++ b/app/settings/devicelocalsettings.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QString>
+
+namespace DeviceLocalSettings {
+
+/**
+ * Returns a writable path for state that belongs to this device and must not
+ * be included in Moonlight's normal or portable configuration.
+ */
+QString filePath(const QString& fileName, const char* featureOverrideVariable = nullptr);
+
+}

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -324,7 +324,7 @@ void StreamingPreferences::reload()
     uiDisplayMode = static_cast<UIDisplayMode>(settings.value(SER_UIDISPLAYMODE,
                                                static_cast<int>(settings.value(SER_STARTWINDOWED, true).toBool() ? UIDisplayMode::UI_WINDOWED
                                                                                                                  : UIDisplayMode::UI_MAXIMIZED)).toInt());
-    rememberWindowPosition = settings.value(SER_REMEMBERWINDOWPOSITION, false).toBool();
+    rememberWindowPosition = settings.value(SER_REMEMBERWINDOWPOSITION, true).toBool();
     language = static_cast<Language>(settings.value(SER_LANGUAGE,
                                                     static_cast<int>(Language::LANG_AUTO)).toInt());
     const auto defaultBackgroundSource = defaultVer > 0 ? BGS_ANIME : BGS_PHOTOGRAPHY;

--- a/app/streaming/video/overlaybuttonposition.cpp
+++ b/app/streaming/video/overlaybuttonposition.cpp
@@ -1,0 +1,160 @@
+#include "overlaybuttonposition.h"
+
+#include "settings/devicelocalsettings.h"
+
+#include <QtGlobal>
+
+namespace {
+constexpr auto LocalStateFileName = "overlay-button-placement.ini";
+constexpr auto LocalStateVersionKey = "meta/version";
+constexpr auto NormalizedXKey = "position/normalizedX";
+constexpr auto NormalizedYKey = "position/normalizedY";
+constexpr int LocalStateVersion = 1;
+
+struct AxisBounds
+{
+    int start;
+    int end;
+};
+
+AxisBounds axisBounds(int origin, int parentLength, int buttonLength, int margin)
+{
+    const int movableLength = qMax(0, parentLength - buttonLength);
+    const int safeMargin = qMin(qMax(0, margin), movableLength / 2);
+    return {origin + safeMargin, origin + movableLength - safeMargin};
+}
+
+int resolveAxis(qreal normalized, const AxisBounds& bounds)
+{
+    const qreal safeNormalized = qIsFinite(normalized)
+            ? qBound<qreal>(0.0, normalized, 1.0)
+            : 0.5;
+    return qRound(bounds.start + (bounds.end - bounds.start) * safeNormalized);
+}
+
+qreal normalizeAxis(int position, const AxisBounds& bounds)
+{
+    const int length = bounds.end - bounds.start;
+    if (length <= 0) {
+        return 0.5;
+    }
+    return qBound<qreal>(0.0,
+                         static_cast<qreal>(position - bounds.start) / length,
+                         1.0);
+}
+}
+
+QPoint OverlayButtonPlacement::defaultPosition(const QRect& parentGeometry,
+                                               const QSize& buttonSize,
+                                               int margin)
+{
+    return resolve(QPointF(1.0, 0.0), parentGeometry, buttonSize, margin);
+}
+
+QPoint OverlayButtonPlacement::clamp(const QPoint& position,
+                                     const QRect& parentGeometry,
+                                     const QSize& buttonSize,
+                                     int margin)
+{
+    if (!parentGeometry.isValid() || !buttonSize.isValid()) {
+        return position;
+    }
+
+    const AxisBounds horizontal = axisBounds(parentGeometry.x(),
+                                             parentGeometry.width(),
+                                             buttonSize.width(),
+                                             margin);
+    const AxisBounds vertical = axisBounds(parentGeometry.y(),
+                                           parentGeometry.height(),
+                                           buttonSize.height(),
+                                           margin);
+    return QPoint(qBound(horizontal.start, position.x(), horizontal.end),
+                  qBound(vertical.start, position.y(), vertical.end));
+}
+
+QPoint OverlayButtonPlacement::resolve(const QPointF& normalizedPosition,
+                                       const QRect& parentGeometry,
+                                       const QSize& buttonSize,
+                                       int margin)
+{
+    if (!parentGeometry.isValid() || !buttonSize.isValid()) {
+        return parentGeometry.topLeft();
+    }
+
+    const AxisBounds horizontal = axisBounds(parentGeometry.x(),
+                                             parentGeometry.width(),
+                                             buttonSize.width(),
+                                             margin);
+    const AxisBounds vertical = axisBounds(parentGeometry.y(),
+                                           parentGeometry.height(),
+                                           buttonSize.height(),
+                                           margin);
+    return QPoint(resolveAxis(normalizedPosition.x(), horizontal),
+                  resolveAxis(normalizedPosition.y(), vertical));
+}
+
+QPointF OverlayButtonPlacement::normalize(const QPoint& position,
+                                          const QRect& parentGeometry,
+                                          const QSize& buttonSize,
+                                          int margin)
+{
+    if (!parentGeometry.isValid() || !buttonSize.isValid()) {
+        return QPointF(0.5, 0.5);
+    }
+
+    const AxisBounds horizontal = axisBounds(parentGeometry.x(),
+                                             parentGeometry.width(),
+                                             buttonSize.width(),
+                                             margin);
+    const AxisBounds vertical = axisBounds(parentGeometry.y(),
+                                           parentGeometry.height(),
+                                           buttonSize.height(),
+                                           margin);
+    const QPoint constrained = clamp(position, parentGeometry, buttonSize, margin);
+    return QPointF(normalizeAxis(constrained.x(), horizontal),
+                   normalizeAxis(constrained.y(), vertical));
+}
+
+OverlayButtonPositionStore::OverlayButtonPositionStore(const QString& settingsPath)
+    : m_Settings(settingsPath.isEmpty()
+                         ? DeviceLocalSettings::filePath(
+                                   QLatin1String(LocalStateFileName),
+                                   "MOONLIGHT_OVERLAY_BUTTON_PLACEMENT_DIR")
+                         : settingsPath,
+                 QSettings::IniFormat)
+{
+}
+
+std::optional<QPointF> OverlayButtonPositionStore::load() const
+{
+    if (m_Settings.value(QLatin1String(LocalStateVersionKey), 0).toInt() !=
+            LocalStateVersion) {
+        return std::nullopt;
+    }
+
+    bool xValid = false;
+    bool yValid = false;
+    const qreal x = m_Settings.value(QLatin1String(NormalizedXKey)).toDouble(&xValid);
+    const qreal y = m_Settings.value(QLatin1String(NormalizedYKey)).toDouble(&yValid);
+    if (!xValid || !yValid || !qIsFinite(x) || !qIsFinite(y)) {
+        return std::nullopt;
+    }
+
+    return QPointF(qBound<qreal>(0.0, x, 1.0),
+                   qBound<qreal>(0.0, y, 1.0));
+}
+
+bool OverlayButtonPositionStore::save(const QPointF& normalizedPosition)
+{
+    if (!qIsFinite(normalizedPosition.x()) || !qIsFinite(normalizedPosition.y())) {
+        return false;
+    }
+
+    m_Settings.setValue(QLatin1String(LocalStateVersionKey), LocalStateVersion);
+    m_Settings.setValue(QLatin1String(NormalizedXKey),
+                        qBound<qreal>(0.0, normalizedPosition.x(), 1.0));
+    m_Settings.setValue(QLatin1String(NormalizedYKey),
+                        qBound<qreal>(0.0, normalizedPosition.y(), 1.0));
+    m_Settings.sync();
+    return m_Settings.status() == QSettings::NoError;
+}

--- a/app/streaming/video/overlaybuttonposition.h
+++ b/app/streaming/video/overlaybuttonposition.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QPoint>
+#include <QPointF>
+#include <QRect>
+#include <QSettings>
+#include <QSize>
+
+#include <optional>
+
+class OverlayButtonPlacement
+{
+public:
+    static QPoint defaultPosition(const QRect& parentGeometry,
+                                  const QSize& buttonSize,
+                                  int margin);
+    static QPoint clamp(const QPoint& position,
+                        const QRect& parentGeometry,
+                        const QSize& buttonSize,
+                        int margin);
+    static QPoint resolve(const QPointF& normalizedPosition,
+                          const QRect& parentGeometry,
+                          const QSize& buttonSize,
+                          int margin);
+    static QPointF normalize(const QPoint& position,
+                             const QRect& parentGeometry,
+                             const QSize& buttonSize,
+                             int margin);
+};
+
+/** Device-local exact position; intentionally excluded from configuration sync. */
+class OverlayButtonPositionStore
+{
+public:
+    explicit OverlayButtonPositionStore(const QString& settingsPath = QString());
+
+    std::optional<QPointF> load() const;
+    bool save(const QPointF& normalizedPosition);
+
+private:
+    QSettings m_Settings;
+};

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -35,7 +35,8 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
       m_ButtonVisible(false),
       m_Dragging(false),
       m_InputSource(InputSource::None),
-      m_TouchPointId(-1)
+      m_TouchPointId(-1),
+      m_NormalizedPosition(m_PositionStore.load())
 {
     setFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint
              | Qt::WindowDoesNotAcceptFocus);
@@ -54,18 +55,36 @@ OverlayMenuButton::~OverlayMenuButton()
 void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int parentH)
 {
     const QRect newParentGeometry(parentX, parentY, parentW, parentH);
-    QPoint newPosition;
+    const QRect previousParentGeometry = m_ParentGeometry;
+    const QPoint previousPosition = position();
+    m_ParentGeometry = newParentGeometry;
 
-    if (m_ParentGeometry.isValid()) {
-        // Preserve the button's offset when the streaming window moves or resizes.
-        newPosition = newParentGeometry.topLeft() + (position() - m_ParentGeometry.topLeft());
+    QPoint newPosition;
+    if (m_InputSource != InputSource::None) {
+        const QPoint parentTranslation = previousParentGeometry.isValid()
+                ? m_ParentGeometry.topLeft() - previousParentGeometry.topLeft()
+                : QPoint();
+        newPosition = OverlayButtonPlacement::clamp(
+                previousPosition + parentTranslation,
+                m_ParentGeometry,
+                QSize(kButtonSize, kButtonSize),
+                kMargin);
+        // Keep the active drag origin aligned with any parent movement or
+        // resize so the next pointer event cannot jump back to stale bounds.
+        m_WindowPositionAtPress += newPosition - previousPosition;
+    }
+    else if (m_NormalizedPosition) {
+        newPosition = OverlayButtonPlacement::resolve(
+                *m_NormalizedPosition,
+                m_ParentGeometry,
+                QSize(kButtonSize, kButtonSize),
+                kMargin);
     }
     else {
-        newPosition = QPoint(newParentGeometry.right() - kButtonSize - kMargin + 1,
-                             newParentGeometry.top() + kMargin);
+        newPosition = OverlayButtonPlacement::defaultPosition(
+                m_ParentGeometry, QSize(kButtonSize, kButtonSize), kMargin);
     }
 
-    m_ParentGeometry = newParentGeometry;
     setGeometry(QRect(clampToParent(newPosition), QSize(kButtonSize, kButtonSize)));
 }
 
@@ -88,16 +107,8 @@ void OverlayMenuButton::hideButton()
 
 QPoint OverlayMenuButton::clampToParent(const QPoint& position) const
 {
-    if (!m_ParentGeometry.isValid()) {
-        return position;
-    }
-
-    const int minX = m_ParentGeometry.left() + kMargin;
-    const int minY = m_ParentGeometry.top() + kMargin;
-    const int maxX = qMax(minX, m_ParentGeometry.right() - kButtonSize - kMargin + 1);
-    const int maxY = qMax(minY, m_ParentGeometry.bottom() - kButtonSize - kMargin + 1);
-    return QPoint(qBound(minX, position.x(), maxX),
-                  qBound(minY, position.y(), maxY));
+    return OverlayButtonPlacement::clamp(
+            position, m_ParentGeometry, QSize(kButtonSize, kButtonSize), kMargin);
 }
 
 void OverlayMenuButton::beginInteraction(InputSource source, const QPoint& globalPosition)
@@ -140,7 +151,17 @@ void OverlayMenuButton::finishInteraction(const QPoint& globalPosition)
     }
 
     const InputSource source = m_InputSource;
+    const bool dragged = m_Dragging;
     const bool activate = !m_Dragging;
+
+    if (dragged && m_ParentGeometry.isValid()) {
+        m_NormalizedPosition = OverlayButtonPlacement::normalize(
+                position(), m_ParentGeometry, QSize(kButtonSize, kButtonSize), kMargin);
+        if (!m_PositionStore.save(*m_NormalizedPosition)) {
+            qWarning("Failed to save the device-local overlay button position");
+        }
+    }
+
     cancelInteraction();
 
     if (activate && m_ClickCallback) {

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -6,10 +6,14 @@
 #include <QSurfaceFormat>
 #include <QTouchEvent>
 #include <functional>
+#include <optional>
+
+#include "overlaybuttonposition.h"
 
 /**
  * OverlayMenuButton - A small floating button rendered by the OS compositor,
- * positioned at the top-right corner of the streaming window.
+ * positioned inside the streaming window. It defaults to the top-right and
+ * remembers a device-local relative position after the user drags it.
  *
  * When clicked, triggers a callback to open the overlay menu.
  * Semi-transparent when idle, fully opaque on hover.
@@ -29,13 +33,13 @@ public:
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
 
     /**
-     * Reposition the button relative to the given Qt logical parent rect.
-     * Places the button at the top-right corner of the streaming window.
+     * Reposition the button relative to the given Qt logical parent rect,
+     * resolving a remembered relative position against the latest bounds.
      */
     void repositionTo(int parentX, int parentY, int parentW, int parentH);
 
     /**
-     * Show the button at the top-right corner of the given parent rect.
+     * Show the button inside the given parent rect.
      */
     void showButton(int parentX, int parentY, int parentW, int parentH);
 
@@ -73,6 +77,8 @@ private:
     QPoint m_PressGlobalPosition;
     QPoint m_WindowPositionAtPress;
     QRect m_ParentGeometry;
+    OverlayButtonPositionStore m_PositionStore;
+    std::optional<QPointF> m_NormalizedPosition;
 
     // Button size (logical pixels)
     static constexpr int kButtonSize = 36;

--- a/tests/overlay_button_position/main.cpp
+++ b/tests/overlay_button_position/main.cpp
@@ -1,0 +1,110 @@
+#include "streaming/video/overlaybuttonposition.h"
+#include "settings/devicelocalsettings.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <QtGlobal>
+
+#include <cmath>
+
+namespace {
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        qFatal("%s", message);
+    }
+}
+
+bool nearlyEqual(qreal lhs, qreal rhs)
+{
+    return std::abs(lhs - rhs) < 0.0001;
+}
+}
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    const QRect landscape(100, 200, 1000, 600);
+    const QSize button(36, 36);
+    constexpr int margin = 10;
+
+    require(OverlayButtonPlacement::defaultPosition(landscape, button, margin) ==
+                    QPoint(1054, 210),
+            "default position must remain at the top-right corner");
+
+    const QPoint dragged(777, 500);
+    const QPointF normalized = OverlayButtonPlacement::normalize(
+            dragged, landscape, button, margin);
+    require(OverlayButtonPlacement::resolve(normalized, landscape, button, margin) == dragged,
+            "normalized position must round-trip in the same viewport");
+
+    const QRect portrait(-300, 40, 600, 1000);
+    const QPoint portraitPosition = OverlayButtonPlacement::resolve(
+            normalized, portrait, button, margin);
+    require(portrait.contains(QRect(portraitPosition, button)),
+            "restored position must remain inside a resized viewport");
+    const QPointF portraitNormalized = OverlayButtonPlacement::normalize(
+            portraitPosition, portrait, button, margin);
+    require(std::abs(portraitNormalized.x() - normalized.x()) < 0.002 &&
+                    std::abs(portraitNormalized.y() - normalized.y()) < 0.002,
+            "resizing must preserve the relative position within pixel rounding");
+
+    const QRect narrow(20, 30, 24, 18);
+    require(OverlayButtonPlacement::clamp(QPoint(900, 900), narrow, button, margin) ==
+                    narrow.topLeft(),
+            "narrow viewports must not produce inverted bounds");
+
+    QTemporaryDir temporaryDirectory;
+    require(temporaryDirectory.isValid(), "temporary settings directory must be available");
+
+    qputenv("MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR",
+            temporaryDirectory.path().toLocal8Bit());
+    const QString sharedLocalPath = DeviceLocalSettings::filePath(
+            QStringLiteral("shared.ini"));
+    require(QFileInfo(sharedLocalPath).absolutePath() ==
+                    QDir(temporaryDirectory.path()).absolutePath(),
+            "shared override must isolate device-local settings");
+
+    const QString featureDirectory = temporaryDirectory.filePath(QStringLiteral("feature"));
+    qputenv("MOONLIGHT_TEST_FEATURE_STATE_DIR", featureDirectory.toLocal8Bit());
+    const QString featureLocalPath = DeviceLocalSettings::filePath(
+            QStringLiteral("feature.ini"), "MOONLIGHT_TEST_FEATURE_STATE_DIR");
+    require(QFileInfo(featureLocalPath).absolutePath() == QDir(featureDirectory).absolutePath(),
+            "feature override must take precedence over the shared override");
+    qunsetenv("MOONLIGHT_TEST_FEATURE_STATE_DIR");
+    qunsetenv("MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR");
+
+    const QString settingsPath = temporaryDirectory.filePath(QStringLiteral("position.ini"));
+
+    OverlayButtonPositionStore store(settingsPath);
+    require(!store.load().has_value(), "empty store must not return a custom position");
+    require(store.save(normalized), "valid position must be saved");
+
+    OverlayButtonPositionStore restoredStore(settingsPath);
+    const auto restored = restoredStore.load();
+    require(restored.has_value(), "saved position must be restored");
+    require(nearlyEqual(restored->x(), normalized.x()) &&
+                    nearlyEqual(restored->y(), normalized.y()),
+            "stored normalized coordinates must be preserved");
+
+    require(store.save(QPointF(-2.0, 4.0)),
+            "out-of-range finite positions must be accepted and constrained");
+    const auto constrained = store.load();
+    require(constrained.has_value() && constrained->x() == 0.0 && constrained->y() == 1.0,
+            "stored positions must be constrained to the normalized range");
+    require(!store.save(QPointF(qInf(), 0.5)),
+            "non-finite positions must be rejected");
+
+    QSettings corruptSettings(settingsPath, QSettings::IniFormat);
+    corruptSettings.setValue(QStringLiteral("meta/version"), 99);
+    corruptSettings.sync();
+    OverlayButtonPositionStore corruptStore(settingsPath);
+    require(!corruptStore.load().has_value(),
+            "unsupported position versions must safely fall back");
+
+    return 0;
+}

--- a/tests/overlay_button_position/overlay_button_position.pro
+++ b/tests/overlay_button_position/overlay_button_position.pro
@@ -1,0 +1,14 @@
+QT += core gui
+CONFIG += console c++17
+CONFIG -= app_bundle
+
+INCLUDEPATH += ../../app
+
+SOURCES += \
+    main.cpp \
+    ../../app/settings/devicelocalsettings.cpp \
+    ../../app/streaming/video/overlaybuttonposition.cpp
+
+HEADERS += \
+    ../../app/settings/devicelocalsettings.h \
+    ../../app/streaming/video/overlaybuttonposition.h


### PR DESCRIPTION
## 改动内容

- “记住窗口位置和大小”改为默认开启，并同时记录普通窗口几何与关闭时的最大化状态。
- 窗口精确位置迁移到设备本地文件，避免便携配置或跨设备同步携带显示器坐标；已有配置会在首次启动时迁移。
- 启动时根据当前显示器、工作区和 DPI 恢复窗口。保存尺寸超过当前工作区时收回到完整工作区，等于工作区时保持原尺寸。
- Windows 普通窗口允许用户主动调整到超过屏幕大小；最大化仍使用当前工作区。从最大化标题栏拖动还原时，会先处理已经超过当前屏幕的普通窗口尺寸，避免恢复出不可操作的大窗口。
- 悬浮按钮拖动位置改用设备本地归一化坐标保存，窗口化、最大化、全屏、换屏或 DPI 变化后按当前串流窗口重新计算。鼠标和触摸只在拖动结束时写入一次。

## 状态规则

- 普通窗口和最大化是可恢复状态。
- 最小化、全屏和隐藏不会覆盖最后一次稳定状态。
- 用户明确选择全屏时仍优先全屏；关闭位置记忆后继续服从窗口显示模式。
- 悬浮菜单模式保留在正常配置中，按钮的精确坐标不参与配置同步。

## 验证

- 完成 Windows x64 发布构建及便携包生成。
- 位置测试覆盖默认位置、窗口尺寸变化、负坐标、窄窗口边界、设备本地存储、越界值和损坏版本回退。
- macOS、Linux、Steam Link 的编译和平台窗口行为交由 CI 与后续实机验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Window positions and maximized state are now remembered by default.
  * Window restoration adapts better across desktop, Wayland, and multi-monitor setups.
  * Overlay menu buttons now remember their position after being dragged.
  * Device-local preferences keep window and overlay positions separate from synced settings.

* **Bug Fixes**
  * Prevented oversized or invalid window and overlay positions from being restored.
  * Windows users benefit from improved resizing limits and safer drag-to-restore behavior.

* **Tests**
  * Added coverage for overlay positioning, resizing, persistence, and invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->