### PR TITLE
fix(streaming): stop polling Qt for idle overlay button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,28 @@ jobs:
         if errorlevel 1 exit /b %ERRORLEVEL%
         popd
 
+    - name: Test overlay event wakeups
+      shell: cmd
+      run: |
+        for /f "usebackq delims=" %%i in (`scripts\vswhere.exe -latest -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvarsall.bat" AMD64
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        pushd tests\overlay_event_wake_state
+        qmake overlay_event_wake_state.pro
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        ..\..\scripts\jom.exe release
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        release\overlay_event_wake_state.exe
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        popd
+        pushd tests\overlay_button_native_wake
+        qmake overlay_button_native_wake.pro
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        ..\..\scripts\jom.exe release
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        release\overlay_button_native_wake.exe
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        popd
+
     - name: Install Qt arm64
       uses: jdpurcell/install-qt-action@v5
       with:

--- a/app/app.pro
+++ b/app/app.pro
@@ -329,6 +329,7 @@ HEADERS += \
     streaming/video/overlaymanager.h \
     streaming/video/overlaymenupanel.h \
     streaming/video/overlaybuttonposition.h \
+    streaming/video/overlayeventwakestate.h \
     streaming/video/overlaymenubutton.h \
     streaming/video/overlaytoast.h \
     backend/systemproperties.h \

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -48,6 +48,9 @@
 #define SDL_CODE_FLUSH_TOUCHPAD_FRAME 106
 #define SDL_CODE_CURSOR_UPDATE 107
 #define SDL_CODE_FLUSH_CURSOR_VISIBILITY 108
+#ifdef Q_OS_WIN32
+#define SDL_CODE_PROCESS_QT_OVERLAY_EVENTS 109
+#endif
 
 #include <openssl/rand.h>
 
@@ -4069,6 +4072,14 @@ void Session::exec()
     // Keep a hidden button ready so placement can switch during a stream
     // without creating a window from inside an input callback.
     m_MenuButton = new OverlayMenuButton();
+#ifdef Q_OS_WIN32
+    m_MenuButton->setEventWakeCallback([]() {
+        SDL_Event wakeEvent = {};
+        wakeEvent.type = SDL_USEREVENT;
+        wakeEvent.user.code = SDL_CODE_PROCESS_QT_OVERLAY_EVENTS;
+        SDL_PushEvent(&wakeEvent);
+    });
+#endif
     m_MenuButton->setClickCallback([this](const QPoint& globalPosition,
                                           bool closeWhenPointerOutside) {
         showQtOverlayMenu(globalPosition, closeWhenPointerOutside);
@@ -4097,6 +4108,7 @@ void Session::exec()
         // all Qt events every 10 ms even while the button is idle, which can
         // delay input and video processing.
         return (m_MenuPanel && m_MenuPanel->needsEventProcessing()) ||
+               (m_MenuButton && m_MenuButton->needsEventProcessing()) ||
                (m_Toast && m_Toast->isVisible()) ||
 #ifdef MOONLIGHT_ENABLE_FUNCTION_TESTS
                (m_StylusReplayTest && m_StylusReplayTest->isPanelVisible());
@@ -4104,7 +4116,7 @@ void Session::exec()
                false;
 #endif
     };
-    auto processQtEventsDuringStream = [&lastQtEventPumpTicks,
+    auto processQtEventsDuringStream = [this, &lastQtEventPumpTicks,
                                         &qtUiNeedsEventProcessing](bool force = false) {
         if (!qtUiNeedsEventProcessing()) {
             return;
@@ -4115,6 +4127,11 @@ void Session::exec()
             return;
         }
         lastQtEventPumpTicks = now;
+        if (m_MenuButton) {
+            // Clear before processing so an update requested from inside a Qt
+            // handler remains pending and schedules a second pass.
+            m_MenuButton->beginEventProcessing();
+        }
         QCoreApplication::processEvents(QEventLoop::AllEvents);
     };
 
@@ -4305,6 +4322,13 @@ void Session::exec()
                 }
                 break;
             }
+#ifdef Q_OS_WIN32
+            case SDL_CODE_PROCESS_QT_OVERLAY_EVENTS:
+                // The actual Qt processing happens after SDL dispatch below.
+                // Keeping this event side-effect free also coalesces bursts of
+                // native button messages without re-entering Qt from Win32.
+                break;
+#endif
             default:
                 SDL_assert(false);
             }
@@ -4763,6 +4787,9 @@ DispatchDeferredCleanup:
 
     // Destroy the Qt overlay menu button
     if (m_MenuButton) {
+#ifdef Q_OS_WIN32
+        m_MenuButton->setEventWakeCallback({});
+#endif
         m_MenuButton->hideButton();
         delete m_MenuButton;
         m_MenuButton = nullptr;

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -4086,14 +4086,17 @@ void Session::exec()
     // Switch to async logging mode when we enter the SDL loop
     StreamUtils::enterAsyncLoggingMode();
 
-    // Hijack this thread to be the SDL main thread. Pump Qt only for visible
-    // streaming UI; clipboard sync runs in a helper process with its own Qt
-    // event loop and is serviced via pipe polling below.
+    // Hijack this thread to be the SDL main thread. Pump Qt periodically only
+    // while transient streaming UI is active; clipboard sync runs in a helper
+    // process with its own Qt event loop and is serviced via pipe polling below.
     constexpr Uint32 QT_UI_EVENT_PUMP_INTERVAL_MS = 10;
     Uint32 lastQtEventPumpTicks = 0;
     auto qtUiNeedsEventProcessing = [this]() {
+        // The floating button remains visible for the entire stream. Treating
+        // visibility as active Qt work forces this SDL loop to wake and drain
+        // all Qt events every 10 ms even while the button is idle, which can
+        // delay input and video processing.
         return (m_MenuPanel && m_MenuPanel->needsEventProcessing()) ||
-               (m_MenuButton && m_MenuButton->isButtonVisible()) ||
                (m_Toast && m_Toast->isVisible()) ||
 #ifdef MOONLIGHT_ENABLE_FUNCTION_TESTS
                (m_StylusReplayTest && m_StylusReplayTest->isPanelVisible());

--- a/app/streaming/video/overlayeventwakestate.h
+++ b/app/streaming/video/overlayeventwakestate.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomic>
+
+// Coalesces repeated overlay wake requests while preserving the first edge.
+// The SDL loop consumes the pending edge immediately before pumping Qt so a
+// request raised during event processing remains pending for the next pass.
+class OverlayEventWakeState
+{
+public:
+    bool request()
+    {
+        bool expected = false;
+        return m_Pending.compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel);
+    }
+
+    bool isPending() const
+    {
+        return m_Pending.load(std::memory_order_acquire);
+    }
+
+    bool take()
+    {
+        return m_Pending.exchange(false, std::memory_order_acq_rel);
+    }
+
+    void clear()
+    {
+        m_Pending.store(false, std::memory_order_release);
+    }
+
+private:
+    std::atomic_bool m_Pending{false};
+};

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -8,6 +8,11 @@
 #include <QInputDevice>
 #endif
 
+#ifdef Q_OS_WIN32
+#include <windows.h>
+#include <commctrl.h>
+#endif
+
 namespace {
 QPoint globalMousePosition(QMouseEvent* event)
 {
@@ -28,6 +33,132 @@ bool mouseEventComesFromTouch(QMouseEvent* event)
 #endif
 }
 }
+
+#ifdef Q_OS_WIN32
+struct OverlayMenuButton::NativeEventMonitor
+{
+    using SetWindowSubclassFn = BOOL (WINAPI *)(HWND, SUBCLASSPROC, UINT_PTR, DWORD_PTR);
+    using RemoveWindowSubclassFn = BOOL (WINAPI *)(HWND, SUBCLASSPROC, UINT_PTR);
+    using DefSubclassProcFn = LRESULT (WINAPI *)(HWND, UINT, WPARAM, LPARAM);
+
+    struct SubclassApis
+    {
+        SubclassApis()
+        {
+            module = LoadLibraryW(L"comctl32.dll");
+            if (!module) {
+                return;
+            }
+            setWindowSubclass = reinterpret_cast<SetWindowSubclassFn>(
+                    GetProcAddress(module, "SetWindowSubclass"));
+            removeWindowSubclass = reinterpret_cast<RemoveWindowSubclassFn>(
+                    GetProcAddress(module, "RemoveWindowSubclass"));
+            defSubclassProc = reinterpret_cast<DefSubclassProcFn>(
+                    GetProcAddress(module, "DefSubclassProc"));
+        }
+
+        bool available() const
+        {
+            return setWindowSubclass && removeWindowSubclass && defSubclassProc;
+        }
+
+        HMODULE module = nullptr;
+        SetWindowSubclassFn setWindowSubclass = nullptr;
+        RemoveWindowSubclassFn removeWindowSubclass = nullptr;
+        DefSubclassProcFn defSubclassProc = nullptr;
+    };
+
+    explicit NativeEventMonitor(OverlayMenuButton* owner) : owner(owner) {}
+
+    ~NativeEventMonitor()
+    {
+        detach();
+    }
+
+    static SubclassApis& apis()
+    {
+        static SubclassApis value;
+        return value;
+    }
+
+    static bool shouldWakeForMessage(UINT message)
+    {
+        if ((message >= WM_MOUSEFIRST && message <= WM_MOUSELAST) ||
+                (message >= 0x0241 && message <= 0x0253)) {
+            return true;
+        }
+
+        switch (message) {
+        case WM_MOUSEHOVER:
+        case WM_MOUSELEAVE:
+        case WM_NCMOUSEMOVE:
+        case WM_NCMOUSEHOVER:
+        case WM_NCMOUSELEAVE:
+        case WM_CAPTURECHANGED:
+        case WM_TOUCH:
+        case WM_GESTURE:
+        case WM_GESTURENOTIFY:
+        case WM_PAINT:
+        case WM_SHOWWINDOW:
+        case WM_WINDOWPOSCHANGED:
+        case WM_DPICHANGED:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    static LRESULT CALLBACK subclassProc(HWND hwnd, UINT message,
+                                         WPARAM wParam, LPARAM lParam,
+                                         UINT_PTR, DWORD_PTR refData)
+    {
+        auto* monitor = reinterpret_cast<NativeEventMonitor*>(refData);
+        if (monitor && monitor->owner && shouldWakeForMessage(message)) {
+            monitor->owner->requestEventProcessing();
+        }
+
+        if (message == WM_NCDESTROY && monitor) {
+            monitor->hwnd = nullptr;
+        }
+
+        return apis().defSubclassProc(hwnd, message, wParam, lParam);
+    }
+
+    bool attach(HWND newHwnd)
+    {
+        if (hwnd == newHwnd && hwnd != nullptr) {
+            return true;
+        }
+
+        detach();
+        if (!newHwnd || !apis().available()) {
+            return false;
+        }
+
+        if (!apis().setWindowSubclass(newHwnd, subclassProc, kSubclassId,
+                                      reinterpret_cast<DWORD_PTR>(this))) {
+            return false;
+        }
+
+        hwnd = newHwnd;
+        return true;
+    }
+
+    void detach()
+    {
+        if (hwnd && apis().available()) {
+            apis().removeWindowSubclass(hwnd, subclassProc, kSubclassId);
+        }
+        hwnd = nullptr;
+    }
+
+    bool isAttached() const { return hwnd != nullptr; }
+
+    static constexpr UINT_PTR kSubclassId = 0x4D4C4F42; // "MLOB"
+    OverlayMenuButton* owner;
+    HWND hwnd = nullptr;
+};
+#endif
 
 OverlayMenuButton::OverlayMenuButton(QWindow* parent)
     : QRasterWindow(parent),
@@ -50,7 +181,61 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
 
 OverlayMenuButton::~OverlayMenuButton()
 {
+#ifdef Q_OS_WIN32
+    m_NativeEventMonitor.reset();
+#endif
 }
+
+bool OverlayMenuButton::needsEventProcessing() const
+{
+    if (!m_ButtonVisible) {
+        return false;
+    }
+
+#ifdef Q_OS_WIN32
+    // If native monitoring is unavailable, retain the old continuous-pump
+    // behavior so the button never becomes unusable on an unusual system.
+    return !m_NativeEventMonitor || !m_NativeEventMonitor->isAttached() ||
+           m_EventWakeState.isPending();
+#else
+    return true;
+#endif
+}
+
+void OverlayMenuButton::beginEventProcessing()
+{
+    m_EventWakeState.take();
+}
+
+void OverlayMenuButton::requestEventProcessing()
+{
+    if (!m_ButtonVisible) {
+        return;
+    }
+
+    if (m_EventWakeState.request() && m_EventWakeCallback) {
+        m_EventWakeCallback();
+    }
+}
+
+void OverlayMenuButton::requestButtonUpdate()
+{
+    requestEventProcessing();
+    requestUpdate();
+}
+
+#ifdef Q_OS_WIN32
+void OverlayMenuButton::ensureNativeEventMonitor()
+{
+    if (!m_NativeEventMonitor) {
+        m_NativeEventMonitor = std::make_unique<NativeEventMonitor>(this);
+    }
+
+    if (!m_NativeEventMonitor->attach(reinterpret_cast<HWND>(winId()))) {
+        qWarning("Failed to monitor native overlay button events; using continuous Qt event processing");
+    }
+}
+#endif
 
 void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int parentH)
 {
@@ -86,6 +271,9 @@ void OverlayMenuButton::repositionTo(int parentX, int parentY, int parentW, int 
     }
 
     setGeometry(QRect(clampToParent(newPosition), QSize(kButtonSize, kButtonSize)));
+    if (m_ButtonVisible) {
+        requestEventProcessing();
+    }
 }
 
 void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int parentH)
@@ -93,14 +281,18 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
     repositionTo(parentX, parentY, parentW, parentH);
     m_ButtonVisible = true;
     show();
+#ifdef Q_OS_WIN32
+    ensureNativeEventMonitor();
+#endif
     raise();
-    requestUpdate();
+    requestButtonUpdate();
 }
 
 void OverlayMenuButton::hideButton()
 {
     cancelInteraction();
     m_ButtonVisible = false;
+    m_EventWakeState.clear();
     unsetCursor();
     hide();
 }
@@ -182,7 +374,7 @@ void OverlayMenuButton::cancelInteraction()
         // Touch input has no hover state after the finger is released.
         m_Hovered = false;
         setOpacity(0.35);
-        requestUpdate();
+        requestButtonUpdate();
     }
 
     if (m_Hovered) {
@@ -258,7 +450,7 @@ void OverlayMenuButton::mouseMoveEvent(QMouseEvent* event)
     if (!m_Hovered) {
         m_Hovered = true;
         setOpacity(0.95);
-        requestUpdate();
+        requestButtonUpdate();
     }
 
     if (m_InputSource == InputSource::None) {
@@ -383,7 +575,7 @@ bool OverlayMenuButton::event(QEvent* ev)
     if (ev->type() == QEvent::Leave) {
         m_Hovered = false;
         setOpacity(0.35);
-        requestUpdate();
+        requestButtonUpdate();
     }
     else if (ev->type() == QEvent::UngrabMouse && m_InputSource == InputSource::Mouse) {
         cancelInteraction();

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -6,9 +6,11 @@
 #include <QSurfaceFormat>
 #include <QTouchEvent>
 #include <functional>
+#include <memory>
 #include <optional>
 
 #include "overlaybuttonposition.h"
+#include "overlayeventwakestate.h"
 
 /**
  * OverlayMenuButton - A small floating button rendered by the OS compositor,
@@ -26,11 +28,13 @@ class OverlayMenuButton : public QRasterWindow {
 public:
     using ClickCallback = std::function<void(const QPoint& globalPosition,
                                              bool closeWhenPointerOutside)>;
+    using EventWakeCallback = std::function<void()>;
 
     explicit OverlayMenuButton(QWindow* parent = nullptr);
     ~OverlayMenuButton() override;
 
     void setClickCallback(ClickCallback cb) { m_ClickCallback = std::move(cb); }
+    void setEventWakeCallback(EventWakeCallback cb) { m_EventWakeCallback = std::move(cb); }
 
     /**
      * Reposition the button relative to the given Qt logical parent rect,
@@ -50,6 +54,11 @@ public:
 
     bool isButtonVisible() const { return m_ButtonVisible; }
 
+    // Windows can wake the SDL loop from the button's native window procedure,
+    // so an idle visible button does not need a continuous Qt event pump.
+    bool needsEventProcessing() const;
+    void beginEventProcessing();
+
 protected:
     void paintEvent(QPaintEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
@@ -59,6 +68,10 @@ protected:
     bool event(QEvent* event) override;
 
 private:
+#ifdef Q_OS_WIN32
+    struct NativeEventMonitor;
+#endif
+
     enum class InputSource { None, Mouse, Touch };
 
     void drawCrescentMoon(QPainter& p, qreal cx, qreal cy, qreal radius);
@@ -67,8 +80,15 @@ private:
     void updateInteraction(const QPoint& globalPosition);
     void finishInteraction(const QPoint& globalPosition);
     void cancelInteraction();
+    void requestEventProcessing();
+    void requestButtonUpdate();
+#ifdef Q_OS_WIN32
+    void ensureNativeEventMonitor();
+#endif
 
     ClickCallback m_ClickCallback;
+    EventWakeCallback m_EventWakeCallback;
+    OverlayEventWakeState m_EventWakeState;
     bool m_Hovered;
     bool m_ButtonVisible;
     bool m_Dragging;
@@ -79,6 +99,9 @@ private:
     QRect m_ParentGeometry;
     OverlayButtonPositionStore m_PositionStore;
     std::optional<QPointF> m_NormalizedPosition;
+#ifdef Q_OS_WIN32
+    std::unique_ptr<NativeEventMonitor> m_NativeEventMonitor;
+#endif
 
     // Button size (logical pixels)
     static constexpr int kButtonSize = 36;

--- a/tests/overlay_button_native_wake/main.cpp
+++ b/tests/overlay_button_native_wake/main.cpp
@@ -80,8 +80,8 @@ int main(int argc, char* argv[])
 
     require(button.needsEventProcessing(),
             "native button input must request Qt event processing");
-    require(wakeCount > settledWakeCount,
-            "native button input must wake the owner loop");
+    require(wakeCount - settledWakeCount >= nativeMessageCount / 1000,
+            "each consumed native input burst must wake the owner loop");
 
     // A burst is represented by a bounded number of wake edges instead of one
     // SDL wake event per native message.

--- a/tests/overlay_button_native_wake/main.cpp
+++ b/tests/overlay_button_native_wake/main.cpp
@@ -1,0 +1,88 @@
+#include "streaming/video/overlaymenubutton.h"
+
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QTemporaryDir>
+#include <QtGlobal>
+
+#ifdef Q_OS_WIN32
+#include <windows.h>
+#endif
+
+namespace {
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        qFatal("%s", message);
+    }
+}
+
+void settleQtEvents(OverlayMenuButton& button)
+{
+    for (int pass = 0; pass < 16 && button.needsEventProcessing(); ++pass) {
+        button.beginEventProcessing();
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+    }
+    require(!button.needsEventProcessing(),
+            "overlay button event processing must settle");
+}
+}
+
+int main(int argc, char* argv[])
+{
+#ifndef Q_OS_WIN32
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+    return 0;
+#else
+    QTemporaryDir settingsDirectory;
+    require(settingsDirectory.isValid(), "temporary settings directory must be available");
+    qputenv("MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR",
+            settingsDirectory.path().toLocal8Bit());
+
+    QGuiApplication app(argc, argv);
+    OverlayMenuButton button;
+    int wakeCount = 0;
+    button.setEventWakeCallback([&wakeCount]() { wakeCount++; });
+    button.showButton(100, 100, 800, 600);
+    settleQtEvents(button);
+
+    const int settledWakeCount = wakeCount;
+    HWND hwnd = reinterpret_cast<HWND>(button.winId());
+    require(hwnd != nullptr, "overlay button must have a native window");
+
+    constexpr int nativeMessageCount = 100000;
+    for (int i = 0; i < nativeMessageCount; ++i) {
+        require(PostMessageW(hwnd, WM_MOUSEMOVE, 0, MAKELPARAM(i % 32, i % 32)) != FALSE,
+                "native pointer pressure message must be queued");
+
+        // Keep the Windows thread queue below its PostMessage limit while still
+        // presenting large bursts to the wake coalescer.
+        if ((i + 1) % 1000 == 0) {
+            MSG message;
+            while (PeekMessageW(&message, hwnd, 0, 0, PM_REMOVE)) {
+                TranslateMessage(&message);
+                DispatchMessageW(&message);
+            }
+        }
+    }
+
+    require(button.needsEventProcessing(),
+            "native button input must request Qt event processing");
+    require(wakeCount > settledWakeCount,
+            "native button input must wake the owner loop");
+
+    // A burst is represented by a bounded number of wake edges instead of one
+    // SDL wake event per native message.
+    require(wakeCount - settledWakeCount < nativeMessageCount / 100,
+            "native input wakeups must be coalesced under pressure");
+
+    settleQtEvents(button);
+    button.hideButton();
+    require(!button.needsEventProcessing(),
+            "hidden button must not keep the Qt event pump active");
+
+    qunsetenv("MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR");
+    return 0;
+#endif
+}

--- a/tests/overlay_button_native_wake/main.cpp
+++ b/tests/overlay_button_native_wake/main.cpp
@@ -64,7 +64,18 @@ int main(int argc, char* argv[])
                 TranslateMessage(&message);
                 DispatchMessageW(&message);
             }
+            // Match the production loop: consume the wake edge and dispatch
+            // the Qt events before accepting the next native-message burst.
+            settleQtEvents(button);
         }
+    }
+
+    require(PostMessageW(hwnd, WM_MOUSEMOVE, 0, MAKELPARAM(1, 1)) != FALSE,
+            "final pointer message must be queued");
+    MSG finalMessage;
+    while (PeekMessageW(&finalMessage, hwnd, 0, 0, PM_REMOVE)) {
+        TranslateMessage(&finalMessage);
+        DispatchMessageW(&finalMessage);
     }
 
     require(button.needsEventProcessing(),

--- a/tests/overlay_button_native_wake/overlay_button_native_wake.pro
+++ b/tests/overlay_button_native_wake/overlay_button_native_wake.pro
@@ -1,0 +1,19 @@
+QT += core gui
+CONFIG += console c++17
+CONFIG -= app_bundle
+
+win32: LIBS += user32.lib
+
+INCLUDEPATH += ../../app
+
+SOURCES += \
+    main.cpp \
+    ../../app/settings/devicelocalsettings.cpp \
+    ../../app/streaming/video/overlaybuttonposition.cpp \
+    ../../app/streaming/video/overlaymenubutton.cpp
+
+HEADERS += \
+    ../../app/settings/devicelocalsettings.h \
+    ../../app/streaming/video/overlaybuttonposition.h \
+    ../../app/streaming/video/overlayeventwakestate.h \
+    ../../app/streaming/video/overlaymenubutton.h

--- a/tests/overlay_event_wake_state/main.cpp
+++ b/tests/overlay_event_wake_state/main.cpp
@@ -1,0 +1,78 @@
+#include "streaming/video/overlayeventwakestate.h"
+
+#include <QCoreApplication>
+#include <QtGlobal>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace {
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        qFatal("%s", message);
+    }
+}
+}
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    OverlayEventWakeState state;
+    constexpr int keyPairs = 1000000;
+
+    // An idle visible button must not create work while keyboard events pass
+    // through the SDL loop. This is the regression that caused continuous Qt
+    // pumping after v6.3.7.
+    for (int i = 0; i < keyPairs; ++i) {
+        require(!state.isPending(),
+                "idle overlay state must remain quiet during keyboard pressure");
+    }
+
+    require(state.request(), "first request must schedule a wakeup");
+    require(!state.request(), "repeated requests must be coalesced");
+    require(state.take(), "pending request must be consumed");
+    require(!state.take(), "consumed state must remain clear");
+
+    constexpr int producerCount = 4;
+    constexpr int requestsPerProducer = 250000;
+    std::atomic_int activeProducers{producerCount};
+    std::atomic_int scheduledWakeups{0};
+    std::atomic_int consumedWakeups{0};
+    std::vector<std::thread> producers;
+    producers.reserve(producerCount);
+
+    for (int producer = 0; producer < producerCount; ++producer) {
+        producers.emplace_back([&]() {
+            for (int i = 0; i < requestsPerProducer; ++i) {
+                if (state.request()) {
+                    scheduledWakeups.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+            activeProducers.fetch_sub(1, std::memory_order_release);
+        });
+    }
+
+    while (activeProducers.load(std::memory_order_acquire) != 0 ||
+           state.isPending()) {
+        if (state.take()) {
+            consumedWakeups.fetch_add(1, std::memory_order_relaxed);
+        }
+        std::this_thread::yield();
+    }
+
+    for (auto& producer : producers) {
+        producer.join();
+    }
+    if (state.take()) {
+        consumedWakeups.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    require(scheduledWakeups.load() == consumedWakeups.load(),
+            "every scheduled wakeup edge must be consumable");
+    require(!state.isPending(), "stress test must finish with a clear state");
+
+    return 0;
+}

--- a/tests/overlay_event_wake_state/overlay_event_wake_state.pro
+++ b/tests/overlay_event_wake_state/overlay_event_wake_state.pro
@@ -1,0 +1,9 @@
+QT += core
+CONFIG += console c++17
+CONFIG -= app_bundle
+
+INCLUDEPATH += ../../app
+
+SOURCES += main.cpp
+
+HEADERS += ../../app/streaming/video/overlayeventwakestate.h


### PR DESCRIPTION
## 问题

悬浮按钮在整个串流期间一直可见。此前这会让主循环每 10 ms 运行一次 Qt 全量事件处理，即使用户没有操作按钮，也会持续参与 Windows 消息队列的处理。现场对照测试中，禁用悬浮按钮后，快速打字漏字符的问题随即消失。

直接停止处理 Qt 事件也不完整，因为悬浮按钮的点击、触摸和拖动都依赖 Qt 事件分发，按钮会因此失去交互能力。

## 修改

- Windows 下监听悬浮按钮自身的原生窗口消息；只有按钮收到鼠标、触摸、指针或绘制请求时，才唤醒 SDL 主循环处理 Qt 事件。
- 同一批原生消息会合并为一次唤醒，按钮空闲时不再持续运行 Qt 事件泵。
- 菜单、提示和功能测试面板打开时，继续使用原来的 10 ms 刷新周期。
- 原生监听不可用时保留原有处理方式，避免悬浮按钮失效。
- 不修改键盘映射、输入协议或 `moonlight-common-c`。

## 验证

- 一百万轮空闲键盘路径检查，以及四线程共一百万次唤醒竞争测试通过。
- 向悬浮按钮原生窗口连续投递十万条指针消息，确认唤醒能够合并，点击和拖动所需的事件处理路径仍然存在。
- Windows x64 Release 完整构建、翻译生成和便携包打包通过。

仍需要在真实串流中复测快速连续输入，以及悬浮按钮的鼠标点击、拖动和触摸操作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows streaming UI responsiveness by processing overlay interactions only when needed.
  * Reduced unnecessary background event processing while the floating overlay button remains idle.
  * Improved reliability when responding to mouse, touch, hover, and window events.
  * Prevented redundant event wakeups during heavy input activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->