### PR TITLE
fix(streaming): 优化串流覆盖层事件处理

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,14 @@ jobs:
         release\overlay_button_native_wake.exe
         if errorlevel 1 exit /b %ERRORLEVEL%
         popd
+        pushd tests\overlay_toast_event_state
+        qmake overlay_toast_event_state.pro
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        ..\..\scripts\jom.exe release
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        release\overlay_toast_event_state.exe
+        if errorlevel 1 exit /b %ERRORLEVEL%
+        popd
 
     - name: Install Qt arm64
       uses: jdpurcell/install-qt-action@v5

--- a/app/app.pro
+++ b/app/app.pro
@@ -331,6 +331,7 @@ HEADERS += \
     streaming/video/overlaybuttonposition.h \
     streaming/video/overlayeventwakestate.h \
     streaming/video/overlaymenubutton.h \
+    streaming/video/overlaytoasteventstate.h \
     streaming/video/overlaytoast.h \
     backend/systemproperties.h \
     imageutils.h \

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -2283,9 +2283,6 @@ void Session::showQtOverlayMenu(std::optional<QPoint> pointerGlobalPosition,
         break;
     }
 
-    // Pump Qt events immediately to trigger first paint
-    QCoreApplication::processEvents(QEventLoop::AllEvents);
-
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Qt overlay menu shown at (%d,%d) %dx%d",
                 parentRect.x(), parentRect.y(), parentRect.width(), parentRect.height());
@@ -2335,8 +2332,8 @@ void Session::syncQtOverlayWindowsWithSdlWindowState()
         if (m_MenuButton) {
             m_MenuButton->hideButton();
         }
-        if (m_Toast && m_Toast->isVisible()) {
-            m_Toast->hide();
+        if (m_Toast) {
+            m_Toast->dismissImmediately();
         }
         return;
     }
@@ -2573,7 +2570,6 @@ void Session::showStreamingToast(const QString& message, int durationMs)
     m_Toast->showToast(parentRect.x(), parentRect.y(),
                        parentRect.width(), parentRect.height(),
                        message, durationMs);
-    QCoreApplication::processEvents();
 }
 
 void Session::updateFileMappingMenuState()
@@ -3196,6 +3192,13 @@ bool Session::tryReconnect()
         return false;
     };
 
+    auto processReconnectQtEvents = [this]() {
+        if (m_Toast) {
+            m_Toast->beginEventProcessing();
+        }
+        QCoreApplication::processEvents();
+    };
+
     while (!cancelled && SDL_GetTicks() - startTicks < graceMs) {
         // Update the on-screen indicator (re-shown each attempt so it stays up)
         Uint32 remainingMs = graceMs - (SDL_GetTicks() - startTicks);
@@ -3220,7 +3223,7 @@ bool Session::tryReconnect()
                 // Abort the in-progress connection attempt
                 LiInterruptConnection();
             }
-            QCoreApplication::processEvents();
+            processReconnectQtEvents();
             SDL_Delay(10);
         }
         thread.wait();
@@ -3256,7 +3259,7 @@ bool Session::tryReconnect()
             if (cancelled) {
                 break;
             }
-            QCoreApplication::processEvents();
+            processReconnectQtEvents();
             SDL_Delay(10);
         }
 
@@ -4109,7 +4112,7 @@ void Session::exec()
         // delay input and video processing.
         return (m_MenuPanel && m_MenuPanel->needsEventProcessing()) ||
                (m_MenuButton && m_MenuButton->needsEventProcessing()) ||
-               (m_Toast && m_Toast->isVisible()) ||
+               (m_Toast && m_Toast->needsEventProcessing()) ||
 #ifdef MOONLIGHT_ENABLE_FUNCTION_TESTS
                (m_StylusReplayTest && m_StylusReplayTest->isPanelVisible());
 #else
@@ -4131,6 +4134,9 @@ void Session::exec()
             // Clear before processing so an update requested from inside a Qt
             // handler remains pending and schedules a second pass.
             m_MenuButton->beginEventProcessing();
+        }
+        if (m_Toast) {
+            m_Toast->beginEventProcessing();
         }
         QCoreApplication::processEvents(QEventLoop::AllEvents);
     };
@@ -4192,6 +4198,13 @@ void Session::exec()
         int waitTimeoutMs = (m_ClipboardHelper != nullptr && m_ClipboardHelper->isRunning()) ? 100 : 1000;
         if (qtUiNeedsEventProcessing()) {
             waitTimeoutMs = qMin(waitTimeoutMs, static_cast<int>(QT_UI_EVENT_PUMP_INTERVAL_MS));
+        }
+        if (const int toastDelayMs = m_Toast ? m_Toast->nextEventDelayMs() : -1;
+                toastDelayMs >= 0) {
+            // Avoid relying on platform-specific zero-timeout behavior. Once
+            // due, a 1 ms wake is sufficient and prevents a busy loop if the
+            // native dispatcher needs one more turn to deliver the update.
+            waitTimeoutMs = qMin(waitTimeoutMs, qMax(toastDelayMs, 1));
         }
 #ifdef MOONLIGHT_ENABLE_FUNCTION_TESTS
         if (const int replayDelayMs = m_StylusReplayTest ?
@@ -4797,7 +4810,7 @@ DispatchDeferredCleanup:
 
     // Destroy the Qt overlay toast
     if (m_Toast) {
-        m_Toast->close();
+        m_Toast->dismissImmediately();
         delete m_Toast;
         m_Toast = nullptr;
     }

--- a/app/streaming/video/overlaytoast.cpp
+++ b/app/streaming/video/overlaytoast.cpp
@@ -42,9 +42,6 @@ OverlayToast::OverlayToast(QWindow* parent)
     m_Font.setWeight(QFont::DemiBold);
     m_Font.setStyleHint(QFont::SansSerif);
 
-    m_DismissTimer.setSingleShot(true);
-    connect(&m_DismissTimer, &QTimer::timeout, this, &OverlayToast::startFadeOut);
-
     m_FadeAnimation = new QPropertyAnimation(this, "opacity", this);
     // 淡出跟着 Theme 的动效时长走：这套风格的动效更短更机械
     m_FadeAnimation->setDuration(240);
@@ -52,10 +49,38 @@ OverlayToast::OverlayToast(QWindow* parent)
     m_FadeAnimation->setEndValue(0.0);
     connect(m_FadeAnimation, &QPropertyAnimation::finished,
             this, &OverlayToast::onFadeFinished);
+
+    m_Clock.start();
 }
 
 OverlayToast::~OverlayToast()
 {
+    dismissImmediately();
+}
+
+bool OverlayToast::needsEventProcessing() const
+{
+    return m_EventState.needsEventProcessing(m_Clock.elapsed());
+}
+
+int OverlayToast::nextEventDelayMs() const
+{
+    return m_EventState.nextEventDelayMs(m_Clock.elapsed());
+}
+
+void OverlayToast::beginEventProcessing()
+{
+    if (m_EventState.beginEventProcessing(m_Clock.elapsed())) {
+        startFadeOut();
+    }
+}
+
+void OverlayToast::dismissImmediately()
+{
+    m_FadeAnimation->stop();
+    m_EventState.cancel();
+    hide();
+    setOpacity(1.0);
 }
 
 void OverlayToast::showToast(int parentX, int parentY, int parentW, int parentH,
@@ -63,9 +88,10 @@ void OverlayToast::showToast(int parentX, int parentY, int parentW, int parentH,
 {
     m_Message = message;
 
-    // Stop any ongoing fade / dismiss
-    m_DismissTimer.stop();
+    // Stop any ongoing fade before replacing the toast. The state deadline is
+    // reset below, so an expired older toast cannot dismiss the new message.
     m_FadeAnimation->stop();
+    m_EventState.show(m_Clock.elapsed(), durationMs);
     setOpacity(1.0);
 
     // Calculate dimensions
@@ -93,17 +119,19 @@ void OverlayToast::showToast(int parentX, int parentY, int parentW, int parentH,
     show();
     raise();
     requestUpdate();
-
-    m_DismissTimer.start(durationMs);
 }
 
 void OverlayToast::startFadeOut()
 {
+    if (!m_EventState.isFading()) {
+        return;
+    }
     m_FadeAnimation->start();
 }
 
 void OverlayToast::onFadeFinished()
 {
+    m_EventState.finishFade();
     hide();
     setOpacity(1.0);
 }

--- a/app/streaming/video/overlaytoast.h
+++ b/app/streaming/video/overlaytoast.h
@@ -3,9 +3,11 @@
 #include <QRasterWindow>
 #include <QPainter>
 #include <QFont>
-#include <QTimer>
+#include <QElapsedTimer>
 #include <QSurfaceFormat>
 #include <QPropertyAnimation>
+
+#include "overlaytoasteventstate.h"
 
 /**
  * OverlayToast - lightweight, auto-dismissing toast notification
@@ -31,6 +33,14 @@ public:
     void showToast(int parentX, int parentY, int parentW, int parentH,
                    const QString& message, int durationMs = 2000);
 
+    // Static toast contents do not require a continuously running Qt event
+    // loop. Session uses these methods to wake only for initial paint,
+    // dismissal deadline, and the short fade animation.
+    bool needsEventProcessing() const;
+    int nextEventDelayMs() const;
+    void beginEventProcessing();
+    void dismissImmediately();
+
 protected:
     void paintEvent(QPaintEvent* event) override;
 
@@ -41,7 +51,8 @@ private slots:
 private:
     QString m_Message;
     QFont   m_Font;
-    QTimer  m_DismissTimer;
+    QElapsedTimer m_Clock;
+    OverlayToastEventState m_EventState;
     QPropertyAnimation* m_FadeAnimation;
     int m_ToastHeight;
     int m_HorizPadding;

--- a/app/streaming/video/overlaytoasteventstate.h
+++ b/app/streaming/video/overlaytoasteventstate.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <climits>
+#include <cstdint>
+
+// Tracks only the scheduling state for OverlayToast. Keeping this separate
+// from QRasterWindow makes the idle/deadline behavior deterministic and easy
+// to test without running a platform GUI event loop.
+class OverlayToastEventState
+{
+public:
+    enum class Phase {
+        Hidden,
+        Static,
+        Fading,
+    };
+
+    void show(std::int64_t nowMs, int durationMs)
+    {
+        m_Phase = Phase::Static;
+        m_DeadlineMs = nowMs + (durationMs > 0 ? durationMs : 0);
+        m_Pending = true;
+    }
+
+    void cancel()
+    {
+        m_Phase = Phase::Hidden;
+        m_DeadlineMs = 0;
+        m_Pending = false;
+    }
+
+    bool needsEventProcessing(std::int64_t nowMs) const
+    {
+        return m_Pending ||
+                m_Phase == Phase::Fading ||
+                (m_Phase == Phase::Static && nowMs >= m_DeadlineMs);
+    }
+
+    int nextEventDelayMs(std::int64_t nowMs) const
+    {
+        if (m_Phase != Phase::Static || m_Pending) {
+            return -1;
+        }
+
+        const std::int64_t remainingMs = m_DeadlineMs - nowMs;
+        if (remainingMs <= 0) {
+            return 0;
+        }
+        if (remainingMs > INT_MAX) {
+            return INT_MAX;
+        }
+        return static_cast<int>(remainingMs);
+    }
+
+    // Consumes the current pending edge and transitions an expired static
+    // toast into its fade phase. Returns true only when fading should start.
+    bool beginEventProcessing(std::int64_t nowMs)
+    {
+        m_Pending = false;
+        if (m_Phase == Phase::Static && nowMs >= m_DeadlineMs) {
+            m_Phase = Phase::Fading;
+            return true;
+        }
+        return false;
+    }
+
+    void finishFade()
+    {
+        cancel();
+    }
+
+    bool isVisible() const { return m_Phase != Phase::Hidden; }
+    bool isFading() const { return m_Phase == Phase::Fading; }
+
+private:
+    Phase m_Phase = Phase::Hidden;
+    std::int64_t m_DeadlineMs = 0;
+    bool m_Pending = false;
+};

--- a/tests/overlay_toast_event_state/main.cpp
+++ b/tests/overlay_toast_event_state/main.cpp
@@ -1,0 +1,89 @@
+#include "streaming/video/overlaytoasteventstate.h"
+
+#include <QCoreApplication>
+#include <QtGlobal>
+
+#include <limits>
+
+namespace {
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        qFatal("%s", message);
+    }
+}
+}
+
+int main(int argc, char* argv[])
+{
+    QCoreApplication app(argc, argv);
+    OverlayToastEventState state;
+
+    require(!state.isVisible(), "new toast state must be hidden");
+    require(!state.needsEventProcessing(0), "hidden toast must remain idle");
+    require(state.nextEventDelayMs(0) == -1, "hidden toast must have no deadline");
+
+    state.show(100, 2000);
+    require(state.isVisible(), "shown toast must be visible");
+    require(state.needsEventProcessing(100), "new toast must request initial processing");
+    require(state.nextEventDelayMs(100) == -1,
+            "pending initial paint must take precedence over the deadline");
+
+    require(!state.beginEventProcessing(100), "initial processing must not start fading");
+    require(!state.needsEventProcessing(100), "static toast must become idle after painting");
+    require(state.nextEventDelayMs(100) == 2000, "static toast must expose its deadline");
+    require(!state.beginEventProcessing(500),
+            "unrelated Qt work must not start the toast fade early");
+    require(state.nextEventDelayMs(500) == 1600,
+            "unrelated Qt work must preserve the toast deadline");
+
+    constexpr int idleChecks = 1000000;
+    for (int i = 0; i < idleChecks; ++i) {
+        require(!state.needsEventProcessing(1000),
+                "static toast must not request continuous event pumping");
+    }
+
+    require(state.nextEventDelayMs(2099) == 1, "deadline must retain millisecond precision");
+    require(state.needsEventProcessing(2100), "expired toast must request processing");
+    require(state.beginEventProcessing(2100), "expired toast must enter fade phase");
+    require(state.isFading(), "toast must report an active fade");
+    require(state.needsEventProcessing(2100), "fade animation must keep processing events");
+    require(state.nextEventDelayMs(2100) == -1, "fade phase must not retain a deadline");
+
+    state.finishFade();
+    require(!state.isVisible(), "finished fade must hide the toast");
+    require(!state.needsEventProcessing(2100), "finished fade must return to idle");
+
+    state.show(3000, 1000);
+    state.beginEventProcessing(3000);
+    state.show(3200, 4000);
+    require(state.needsEventProcessing(3200), "replacement toast must request a fresh paint");
+    require(!state.beginEventProcessing(3200), "replacement must not inherit the old deadline");
+    require(state.nextEventDelayMs(3200) == 4000,
+            "replacement toast must own a new dismissal deadline");
+    require(!state.needsEventProcessing(4000),
+            "the replaced toast deadline must not dismiss the new toast");
+
+    require(state.beginEventProcessing(7200), "replacement toast must eventually fade");
+    state.show(7300, 500);
+    require(!state.isFading(), "a toast replacing an active fade must return to static phase");
+    require(!state.beginEventProcessing(7300),
+            "replacement during fade must receive a full display interval");
+    require(state.nextEventDelayMs(7300) == 500,
+            "replacement during fade must own its new deadline");
+
+    state.cancel();
+    require(!state.isVisible(), "cancel must hide the toast");
+    require(state.nextEventDelayMs(4000) == -1, "cancel must clear the deadline");
+
+    state.show(0, std::numeric_limits<int>::max());
+    state.beginEventProcessing(0);
+    require(state.nextEventDelayMs(0) == std::numeric_limits<int>::max(),
+            "large valid deadlines must remain representable");
+
+    state.show(5000, -1);
+    require(state.beginEventProcessing(5000),
+            "negative durations must be clamped to an immediate fade");
+
+    return 0;
+}

--- a/tests/overlay_toast_event_state/overlay_toast_event_state.pro
+++ b/tests/overlay_toast_event_state/overlay_toast_event_state.pro
@@ -1,0 +1,9 @@
+QT += core
+CONFIG += console c++17
+CONFIG -= app_bundle
+
+INCLUDEPATH += ../../app
+
+SOURCES += main.cpp
+
+HEADERS += ../../app/streaming/video/overlaytoasteventstate.h


### PR DESCRIPTION
## 问题

#194 已经解决了 Windows 悬浮按钮空闲时持续处理 Qt 事件的问题，但串流覆盖层还有两条相近路径：

- 打开悬浮菜单和显示 Toast 时会直接调用 `processEvents()`。这些函数可能由 Qt 鼠标事件触发，因此会在当前 Qt 事件处理过程中再次进入事件循环。
- Toast 静止显示的 1.5～4.5 秒内，Session 仍会每 10 ms 处理一次 Qt 全量事件。此时远程输入可能已经恢复，仍有短时间干扰输入的风险。

## 修改

- 删除菜单和 Toast 内部的同步 `processEvents()`，统一回到 Session 事件分发结束后的安全位置处理。
- 将 Toast 拆分为首次绘制、静止等待、到期淡出和隐藏状态。
- 静止显示时只把消失截止时间交给 `SDL_WaitEventTimeout()`，不再持续运行 Qt 事件泵；首次绘制和 240 ms 淡出动画期间才处理 Qt 事件。
- 重连循环也会推进 Toast 状态，保证重连提示仍能按时显示和淡出。
- 连续显示新 Toast 会重置截止时间，不会被旧提示提前关闭。

## 验证

新增状态测试覆盖空闲压力、截止时间、淡出、取消、连续替换和淡出期间替换，并加入 Windows CI。Windows x64 Release、翻译和便携包构建已通过。

这次没有修改键盘映射、输入协议或 `moonlight-common-c`。macOS 和 Linux 悬浮按钮的空闲唤醒机制仍需要结合各自窗口系统单独处理，不包含在本 PR 中。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay toast timing and dismissal behavior during streaming and reconnects.
  * Toasts now dismiss immediately when the streaming window is hidden or cleaned up.
  * Reduced unnecessary event processing while preserving smooth fade-out animations.

* **Tests**
  * Added coverage for toast display, expiration, fading, cancellation, replacement, and edge-case durations.
  * Windows builds now run the new overlay toast state tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->