### PR TITLE
feat(appimage): add metadata to appimage builds

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -12,21 +12,9 @@ on:
         required: false
         default: manual
         type: string
-      appimage_update_tag:
-        description: AppImage update channel
-        required: true
-        default: latest
-        type: choice
-        options:
-          - latest
-          - latest-pre
   workflow_call:
     inputs:
       ci_version:
-        required: true
-        type: string
-      appimage_update_tag:
-        description: AppImage update channel
         required: true
         type: string
 
@@ -34,19 +22,13 @@ jobs:
   build:
     env:
       CI_VERSION: ${{ inputs.ci_version }}
-      APPIMAGE_UPDATE_TAG: ${{ inputs.appimage_update_tag }}
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Validate Inputs
+      - name: Validate Version
         run: |
           if [[ ! "$CI_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::CI_VERSION must contain only letters, numbers, dots, underscores, or hyphens"
-            exit 1
-          fi
-
-          if [[ "$APPIMAGE_UPDATE_TAG" != "latest" && "$APPIMAGE_UPDATE_TAG" != "latest-pre" ]]; then
-            echo "::error::APPIMAGE_UPDATE_TAG must be either 'latest' or 'latest-pre'"
             exit 1
           fi
 

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -25,6 +25,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Validate Version
+        run: |
+          if [[ ! "$CI_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::CI_VERSION must contain only letters, numbers, dots, underscores, or hyphens"
+            exit 1
+          fi
+
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
@@ -167,7 +174,7 @@ jobs:
 
       - name: Verify Binaries
         run: |
-          appimage="build/installer-release/Moonlight-VPlus-${{ env.CI_VERSION }}-x86_64.AppImage"
+          appimage="build/installer-release/Moonlight-VPlus-${CI_VERSION}-x86_64.AppImage"
 
           if [[ ! -s "$appimage" ]]; then
             echo "::error file=$appimage::AppImage is missing or empty"

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -38,10 +38,15 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Validate Version
+      - name: Validate Inputs
         run: |
           if [[ ! "$CI_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::CI_VERSION must contain only letters, numbers, dots, underscores, or hyphens"
+            exit 1
+          fi
+
+          if [[ "$APPIMAGE_UPDATE_TAG" != "latest" && "$APPIMAGE_UPDATE_TAG" != "latest-pre" ]]; then
+            echo "::error::APPIMAGE_UPDATE_TAG must be either 'latest' or 'latest-pre'"
             exit 1
           fi
 

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -12,9 +12,21 @@ on:
         required: false
         default: manual
         type: string
+      appimage_update_tag:
+        description: AppImage update channel
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - latest-pre
   workflow_call:
     inputs:
       ci_version:
+        required: true
+        type: string
+      appimage_update_tag:
+        description: AppImage update channel
         required: true
         type: string
 
@@ -22,6 +34,7 @@ jobs:
   build:
     env:
       CI_VERSION: ${{ inputs.ci_version }}
+      APPIMAGE_UPDATE_TAG: ${{ inputs.appimage_update_tag }}
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -12,9 +12,21 @@ on:
         required: false
         default: manual
         type: string
+      appimage_update_tag:
+        description: AppImage update channel
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - latest-pre
   workflow_call:
     inputs:
       ci_version:
+        required: true
+        type: string
+      appimage_update_tag:
+        description: AppImage update channel
         required: true
         type: string
 
@@ -22,13 +34,19 @@ jobs:
   build:
     env:
       CI_VERSION: ${{ inputs.ci_version }}
+      APPIMAGE_UPDATE_TAG: ${{ inputs.appimage_update_tag }}
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Validate Version
+      - name: Validate Inputs
         run: |
           if [[ ! "$CI_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
             echo "::error::CI_VERSION must contain only letters, numbers, dots, underscores, or hyphens"
+            exit 1
+          fi
+
+          if [[ "$APPIMAGE_UPDATE_TAG" != "latest" && "$APPIMAGE_UPDATE_TAG" != "latest-pre" ]]; then
+            echo "::error::APPIMAGE_UPDATE_TAG must be either 'latest' or 'latest-pre'"
             exit 1
           fi
 

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -169,6 +169,8 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: Moonlight-VPlus-LinuxAppImage-${{ env.CI_VERSION }}
-          path: build/installer-release/Moonlight-VPlus-${{ env.CI_VERSION }}-x86_64.AppImage
+          path: |
+            build/installer-release/Moonlight-VPlus-${{ env.CI_VERSION }}-x86_64.AppImage
+            build/installer-release/Moonlight-VPlus-${{ env.CI_VERSION }}-x86_64.AppImage.zsync
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -36,7 +36,7 @@ jobs:
           wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.4.313-jammy.list https://packages.lunarg.com/vulkan/1.4.313/lunarg-vulkan-1.4.313-jammy.list
           sudo apt update
-          sudo apt install -y qt6-base-dev qt6-declarative-dev libqt6svg6-dev qt6-image-formats-plugins qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-layouts \
+          sudo apt install -y qt6-base-dev qt6-declarative-dev qt6-multimedia-dev libqt6svg6-dev qt6-image-formats-plugins qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-layouts \
             qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qtquick python3-pip nasm libgbm-dev libdrm-dev libfreetype-dev libasound2-dev \
             libdbus-1-dev libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libglu1-mesa-dev libibus-1.0-dev libpulse-dev libudev-dev libx11-dev libxcursor-dev \
             libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev libxss-dev libxt-dev libxv-dev libxxf86vm-dev libxcb-dri3-dev libx11-xcb-dev \

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -165,6 +165,20 @@ jobs:
           sudo ldconfig
           scripts/build-appimage.sh
 
+      - name: Verify Binaries
+        run: |
+          appimage="build/installer-release/Moonlight-VPlus-${VERSION}-${{ matrix.arch }}.AppImage"
+
+          if [[ ! -s "$appimage" ]]; then
+            echo "::error file=$appimage::AppImage is missing or empty"
+            exit 1
+          fi
+
+          if [[ ! -s "${appimage}.zsync" ]]; then
+            echo "::error file=${appimage}.zsync::zsync is missing or empty"
+            exit 1
+          fi
+
       - name: Upload Binaries
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Verify Binaries
         run: |
-          appimage="build/installer-release/Moonlight-VPlus-${VERSION}-${{ matrix.arch }}.AppImage"
+          appimage="build/installer-release/Moonlight-VPlus-${{ env.CI_VERSION }}-x86_64.AppImage"
 
           if [[ ! -s "$appimage" ]]; then
             echo "::error file=$appimage::AppImage is missing or empty"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,16 +125,16 @@ jobs:
       shell: cmd
       run: |
         echo Starting CI-optimized build...
-        
+
         rem Clear any problematic environment variables
         set MAKEFLAGS=
         set _CL_=
-        
+
         rem Build with standard configuration and correct architecture
         echo Building with CI optimizations...
         call scripts\build-arch.bat release x64
         if errorlevel 1 exit /b %ERRORLEVEL%
-        
+
         echo Build Windows x64 completed successfully!
 
     - name: Test DualSense haptics rendering
@@ -266,7 +266,7 @@ jobs:
 
   build-macos:
     runs-on: macos-15
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -479,7 +479,7 @@ jobs:
         git clone --branch $LIBVA_VER --depth 1 https://github.com/intel/libva.git
         cd libva
         ./autogen.sh
-        
+
         # Configure with conditional Wayland support
         echo "Configuring libva..."
         if pkg-config --exists wayland-client; then
@@ -489,7 +489,7 @@ jobs:
           echo "Configuring libva without Wayland support"
           ./configure --enable-x11 --disable-wayland
         fi
-        
+
         make -j$(nproc)
         sudo make install
         sudo ldconfig
@@ -555,7 +555,7 @@ jobs:
       run: |
         # Configure FUSE for AppImage in CI environment
         echo "Setting up FUSE environment for AppImage..."
-        
+
         # Check if FUSE is available
         if [ -f /dev/fuse ]; then
           echo "✅ /dev/fuse is available"
@@ -564,10 +564,10 @@ jobs:
           sudo mknod /dev/fuse c 10 229 || echo "Failed to create /dev/fuse"
           sudo chmod 666 /dev/fuse || echo "Failed to set permissions on /dev/fuse"
         fi
-        
+
         # Check FUSE library
         ldconfig -p | grep fuse || echo "FUSE library not found in ldconfig"
-        
+
         # Set environment variable for AppImage extraction mode if FUSE fails
         echo "APPIMAGE_EXTRACT_AND_RUN=1" >> $GITHUB_ENV
 
@@ -585,14 +585,14 @@ jobs:
         # export QT_SELECT=5
         # export PATH=/usr/lib/qt5/bin:$PATH
         # export QT_QPA_PLATFORM_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins
-        
+
         # Add linuxdeploy to PATH
         export PATH=$PATH:$HOME/bin
-        
+
         echo "Building AppImage with CI-optimized settings..."
         echo "APPIMAGE_EXTRACT_AND_RUN=$APPIMAGE_EXTRACT_AND_RUN"
         echo "PATH includes: $HOME/bin"
-        
+
         # Run the build script
         scripts/build-appimage.sh
 
@@ -600,11 +600,14 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Moonlight-VPlus-r${{ env.BUILD_NUMBER }}-${{ matrix.arch }}.AppImage
-        path: build/installer-release/Moonlight-VPlus-*-${{ matrix.arch }}.AppImage
+        path: |
+          build/installer-release/Moonlight-VPlus-*-${{ matrix.arch }}.AppImage
+          build/installer-release/Moonlight-VPlus-*-${{ matrix.arch }}.AppImage.zsync
+
 
   build-steamlink:
     runs-on: ubuntu-22.04
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -642,7 +645,7 @@ jobs:
     if: github.event_name == 'release'
     needs: [qml-lint, build-windows, build-macos, build-linux, build-steamlink]
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Download all artifacts
       uses: actions/download-artifact@v4
@@ -655,5 +658,6 @@ jobs:
           **/*.zip
           **/*.dmg
           **/*.AppImage
+          **/*/AppImage.zsync
       env:
         GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,20 @@ jobs:
     - name: Check QML type resolution
       run: scripts/qmllint-check.sh
 
+  version-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Test version derivation
+      run: python3 -m unittest discover -s tests/derive_version -p 'test_*.py'
+
   build-windows:
     runs-on: windows-2022
     steps:
@@ -314,6 +328,8 @@ jobs:
     # 得等 trixie。想再往下压只能自己编 Qt，不值。
     name: build-linux (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    env:
+      APPIMAGE_UPDATE_TAG: ${{ github.event_name == 'release' && github.event.release.prerelease && 'latest-pre' || 'latest' }}
 
     strategy:
       # 一边挂了不要连累另一边，方便单独看是哪个架构的问题。
@@ -658,7 +674,7 @@ jobs:
 
   release:
     if: github.event_name == 'release'
-    needs: [qml-lint, build-windows, build-macos, build-linux, build-steamlink]
+    needs: [qml-lint, version-tests, build-windows, build-macos, build-linux, build-steamlink]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -596,6 +596,20 @@ jobs:
         # Run the build script
         scripts/build-appimage.sh
 
+    - name: Verify AppImage
+      run: |
+        appimage="build/installer-release/Moonlight-VPlus-${VERSION}-${{ matrix.arch }}.AppImage"
+
+        if [[ ! -s "$appimage" ]]; then
+          echo "::error file=$appimage::AppImage is missing or empty"
+          exit 1
+        fi
+
+        if [[ ! -s "${appimage}.zsync" ]]; then
+          echo "::error file=${appimage}.zsync::zsync is missing or empty"
+          exit 1
+        fi
+
     - name: Upload AppImage artifact
       uses: actions/upload-artifact@v4
       with:
@@ -603,6 +617,7 @@ jobs:
         path: |
           build/installer-release/Moonlight-VPlus-*-${{ matrix.arch }}.AppImage
           build/installer-release/Moonlight-VPlus-*-${{ matrix.arch }}.AppImage.zsync
+        if-no-files-found: error
 
 
   build-steamlink:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -658,6 +658,6 @@ jobs:
           **/*.zip
           **/*.dmg
           **/*.AppImage
-          **/*/AppImage.zsync
+          **/*.AppImage.zsync
       env:
         GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,6 +314,8 @@ jobs:
     # 得等 trixie。想再往下压只能自己编 Qt，不值。
     name: build-linux (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    env:
+      APPIMAGE_UPDATE_TAG: ${{ github.event_name == 'release' && github.event.release.prerelease && 'latest-pre' || 'latest' }}
 
     strategy:
       # 一边挂了不要连累另一边，方便单独看是哪个架构的问题。

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,8 +314,6 @@ jobs:
     # 得等 trixie。想再往下压只能自己编 Qt，不值。
     name: build-linux (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    env:
-      APPIMAGE_UPDATE_TAG: ${{ github.event_name == 'release' && github.event.release.prerelease && 'latest-pre' || 'latest' }}
 
     strategy:
       # 一边挂了不要连累另一边，方便单独看是哪个架构的问题。

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -86,12 +86,34 @@ if [ -n "$QT_PLUGIN_PATH" ] && [ -d "$QT_PLUGIN_PATH/multimedia" ]; then
   echo "Removing GStreamer multimedia backend..."
   rm -f "$QT_PLUGIN_PATH/multimedia/libgstreamermediaplugin.so"
 fi
+
+APPIMAGE_PATH="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage"
+APPIMAGE_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|latest|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync"
+
 pushd $INSTALLER_FOLDER
-LDAI_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|latest|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync" \
-LDAI_OUTPUT="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage" \
+LDAI_UPDATE_INFORMATION="$APPIMAGE_UPDATE_INFORMATION" \
+LDAI_OUTPUT="$APPIMAGE_PATH" \
   VERSION=$VERSION $LINUXDEPLOY --appdir $DEPLOY_FOLDER \
   --library=/usr/local/lib/libSDL3.so.0 \
   --plugin qt --output appimage || fail "linuxdeploy failed!"
 popd
+
+echo Verifying AppImage update metadata
+[ -s "$APPIMAGE_PATH" ] || fail "AppImage is missing or empty: $APPIMAGE_PATH"
+
+ZSYNC_PATH="${APPIMAGE_PATH}.zsync"
+[ -s "$ZSYNC_PATH" ] || fail "zsync metadata is missing or empty: $ZSYNC_PATH"
+
+ACTUAL_UPDATE_INFORMATION=$(env -u APPIMAGE_EXTRACT_AND_RUN \
+  "$APPIMAGE_PATH" --appimage-updateinformation) || \
+  fail "Unable to read AppImage update information"
+[ "$ACTUAL_UPDATE_INFORMATION" = "$APPIMAGE_UPDATE_INFORMATION" ] || \
+  fail "Unexpected AppImage update information: $ACTUAL_UPDATE_INFORMATION"
+
+APPIMAGE_FILENAME=$(basename "$APPIMAGE_PATH")
+grep -Fqx "Filename: $APPIMAGE_FILENAME" "$ZSYNC_PATH" || \
+  fail "zsync Filename does not match $APPIMAGE_FILENAME"
+grep -Fqx "URL: $APPIMAGE_FILENAME" "$ZSYNC_PATH" || \
+  fail "zsync URL does not match $APPIMAGE_FILENAME"
 
 echo Build successful

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -15,6 +15,12 @@ INSTALLER_FOLDER=$BUILD_ROOT/installer-$BUILD_CONFIG
 VERSION=$(python3 "$SOURCE_ROOT/scripts/derive-version.py" --source-root "$SOURCE_ROOT" --field artifact)
 APPIMAGE_ARCH=$(uname -m)
 LINUXDEPLOY=linuxdeploy-$APPIMAGE_ARCH.AppImage
+APPIMAGE_UPDATE_TAG="${APPIMAGE_UPDATE_TAG:-latest}"
+
+case "$APPIMAGE_UPDATE_TAG" in
+	latest|latest-pre) ;;
+	*) fail "Invalid APPIMAGE_UPDATE_TAG: $APPIMAGE_UPDATE_TAG"
+esac
 
 command -v qmake6 >/dev/null 2>&1 || fail "Unable to find 'qmake6' in your PATH!"
 command -v $LINUXDEPLOY >/dev/null 2>&1 || fail "Unable to find '$LINUXDEPLOY' in your PATH!"
@@ -88,7 +94,7 @@ if [ -n "$QT_PLUGIN_PATH" ] && [ -d "$QT_PLUGIN_PATH/multimedia" ]; then
 fi
 
 APPIMAGE_PATH="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage"
-APPIMAGE_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|latest|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync"
+APPIMAGE_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|$APPIMAGE_UPDATE_TAG|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync"
 
 pushd "$INSTALLER_FOLDER" || fail "Unable to enter install folder: $INSTALLER_FOLDER"
 LDAI_UPDATE_INFORMATION="$APPIMAGE_UPDATE_INFORMATION" \

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -90,13 +90,13 @@ fi
 APPIMAGE_PATH="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage"
 APPIMAGE_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|latest|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync"
 
-pushd $INSTALLER_FOLDER
+pushd "$INSTALLER_FOLDER" || fail "Unable to enter install folder: $INSTALLER_FOLDER"
 LDAI_UPDATE_INFORMATION="$APPIMAGE_UPDATE_INFORMATION" \
 LDAI_OUTPUT="$APPIMAGE_PATH" \
-  VERSION=$VERSION $LINUXDEPLOY --appdir $DEPLOY_FOLDER \
+  VERSION="$VERSION" "$LINUXDEPLOY" --appdir "$DEPLOY_FOLDER" \
   --library=/usr/local/lib/libSDL3.so.0 \
   --plugin qt --output appimage || fail "linuxdeploy failed!"
-popd
+popd || fail "Unable to leave install folder"
 
 echo Verifying AppImage update metadata
 [ -s "$APPIMAGE_PATH" ] || fail "AppImage is missing or empty: $APPIMAGE_PATH"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -87,7 +87,8 @@ if [ -n "$QT_PLUGIN_PATH" ] && [ -d "$QT_PLUGIN_PATH/multimedia" ]; then
   rm -f "$QT_PLUGIN_PATH/multimedia/libgstreamermediaplugin.so"
 fi
 pushd $INSTALLER_FOLDER
-OUTPUT="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage" \
+LDAI_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|latest|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync" \
+LDAI_OUTPUT="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage" \
   VERSION=$VERSION $LINUXDEPLOY --appdir $DEPLOY_FOLDER \
   --library=/usr/local/lib/libSDL3.so.0 \
   --plugin qt --output appimage || fail "linuxdeploy failed!"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -15,12 +15,6 @@ INSTALLER_FOLDER=$BUILD_ROOT/installer-$BUILD_CONFIG
 VERSION=$(python3 "$SOURCE_ROOT/scripts/derive-version.py" --source-root "$SOURCE_ROOT" --field artifact)
 APPIMAGE_ARCH=$(uname -m)
 LINUXDEPLOY=linuxdeploy-$APPIMAGE_ARCH.AppImage
-APPIMAGE_UPDATE_TAG="${APPIMAGE_UPDATE_TAG:-latest}"
-
-case "$APPIMAGE_UPDATE_TAG" in
-	latest|latest-pre) ;;
-	*) fail "Invalid APPIMAGE_UPDATE_TAG: $APPIMAGE_UPDATE_TAG"
-esac
 
 command -v qmake6 >/dev/null 2>&1 || fail "Unable to find 'qmake6' in your PATH!"
 command -v $LINUXDEPLOY >/dev/null 2>&1 || fail "Unable to find '$LINUXDEPLOY' in your PATH!"
@@ -94,7 +88,7 @@ if [ -n "$QT_PLUGIN_PATH" ] && [ -d "$QT_PLUGIN_PATH/multimedia" ]; then
 fi
 
 APPIMAGE_PATH="$INSTALLER_FOLDER/Moonlight-VPlus-$VERSION-$APPIMAGE_ARCH.AppImage"
-APPIMAGE_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|$APPIMAGE_UPDATE_TAG|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync"
+APPIMAGE_UPDATE_INFORMATION="gh-releases-zsync|qiin2333|moonlight-qt|latest|Moonlight-VPlus-*-${APPIMAGE_ARCH}.AppImage.zsync"
 
 pushd "$INSTALLER_FOLDER" || fail "Unable to enter install folder: $INSTALLER_FOLDER"
 LDAI_UPDATE_INFORMATION="$APPIMAGE_UPDATE_INFORMATION" \

--- a/scripts/derive-version.py
+++ b/scripts/derive-version.py
@@ -20,9 +20,10 @@ import subprocess
 from pathlib import Path
 
 
-SEMVER_RE = re.compile(
+GIT_DESCRIBE_RE = re.compile(
     r"^v?(?P<base>\d+\.\d+\.\d+)"
-    r"(?:-(?P<count>\d+)-g(?P<sha>[0-9a-fA-F]+))?"
+    r"(?P<prerelease>(?:[.-][0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?)"
+    r"-(?P<count>\d+)-g(?P<sha>[0-9a-fA-F]+)"
     r"(?P<dirty>-dirty)?$"
 )
 
@@ -58,17 +59,24 @@ def clamp_u16(value: int) -> int:
     return max(0, min(value, 65535))
 
 
+def normalize_explicit_version(version: str) -> str:
+    if re.match(r"^v\d", version):
+        return version[1:]
+    return version
+
+
 def derive(source_root: Path) -> dict[str, str]:
     ci_version = os.environ.get("CI_VERSION", "").strip()
     fallback = read_fallback_version(source_root)
 
     if ci_version:
-        base = ".".join(str(part) for part in split_numeric_base(ci_version))
+        display = normalize_explicit_version(ci_version)
+        base = ".".join(str(part) for part in split_numeric_base(display))
         major, minor, patch = split_numeric_base(base)
         return {
             "base": base,
-            "display": ci_version,
-            "artifact": ci_version.replace("+", "-"),
+            "display": display,
+            "artifact": display.replace("+", "-"),
             "numeric": f"{major}.{minor}.{patch}.0",
             "describe": ci_version,
             "commit": run_git(source_root, "rev-parse", "--short=8", "HEAD") or "unknown",
@@ -88,18 +96,19 @@ def derive(source_root: Path) -> dict[str, str]:
     commit = run_git(source_root, "rev-parse", "--short=8", "HEAD") or "unknown"
 
     if describe:
-        match = SEMVER_RE.match(describe)
+        match = GIT_DESCRIBE_RE.fullmatch(describe)
         if match:
             base = match.group("base")
-            count = int(match.group("count") or 0)
-            sha = match.group("sha") or commit
+            version = base + (match.group("prerelease") or "")
+            count = int(match.group("count"))
+            sha = match.group("sha")
             dirty = bool(match.group("dirty"))
             major, minor, patch = split_numeric_base(base)
 
             if count == 0 and not dirty:
-                display = base
+                display = version
             else:
-                display = f"{base}+{count}.g{sha[:8]}"
+                display = f"{version}+{count}.g{sha[:8]}"
                 if dirty:
                     display += ".dirty"
 

--- a/tests/derive_version/test_derive_version.py
+++ b/tests/derive_version/test_derive_version.py
@@ -1,0 +1,83 @@
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "derive-version.py"
+SPEC = importlib.util.spec_from_file_location("derive_version", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+derive_version = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(derive_version)
+
+
+class DeriveVersionTests(unittest.TestCase):
+    def derive_from_git(self, describe: str) -> dict[str, str]:
+        def run_git(_source_root: Path, *args: str) -> str:
+            if args and args[0] == "describe":
+                return describe
+            if args == ("rev-parse", "--short=8", "HEAD"):
+                return "feedface"
+            raise AssertionError(f"Unexpected git command: {args}")
+
+        with (
+            mock.patch.dict(os.environ, {"CI_VERSION": ""}),
+            mock.patch.object(derive_version, "run_git", side_effect=run_git),
+            mock.patch.object(
+                derive_version, "read_fallback_version", return_value="6.2.84"
+            ),
+        ):
+            return derive_version.derive(Path("."))
+
+    def test_exact_stable_tag(self) -> None:
+        result = self.derive_from_git("v6.3.13-0-g12345678")
+
+        self.assertEqual(result["display"], "6.3.13")
+        self.assertEqual(result["artifact"], "6.3.13")
+        self.assertEqual(result["numeric"], "6.3.13.0")
+
+    def test_exact_legacy_dot_prerelease_tag(self) -> None:
+        result = self.derive_from_git("v6.3.10.beta-0-g4af38f30")
+
+        self.assertEqual(result["display"], "6.3.10.beta")
+        self.assertEqual(result["artifact"], "6.3.10.beta")
+        self.assertEqual(result["numeric"], "6.3.10.0")
+
+    def test_exact_semver_prerelease_tag(self) -> None:
+        result = self.derive_from_git("v6.3.14-beta.1-0-gabcdef12")
+
+        self.assertEqual(result["display"], "6.3.14-beta.1")
+        self.assertEqual(result["artifact"], "6.3.14-beta.1")
+        self.assertEqual(result["numeric"], "6.3.14.0")
+
+    def test_commits_after_prerelease_tag_keep_git_metadata(self) -> None:
+        result = self.derive_from_git(
+            "v6.3.14-beta.1-3-gabcdef123456-dirty"
+        )
+
+        self.assertEqual(
+            result["display"], "6.3.14-beta.1+3.gabcdef12.dirty"
+        )
+        self.assertEqual(
+            result["artifact"], "6.3.14-beta.1-3.gabcdef12.dirty"
+        )
+        self.assertEqual(result["numeric"], "6.3.14.3")
+
+    def test_explicit_version_strips_tag_prefix(self) -> None:
+        with (
+            mock.patch.dict(os.environ, {"CI_VERSION": "v6.3.15-rc.1"}),
+            mock.patch.object(derive_version, "run_git", return_value="feedface"),
+            mock.patch.object(
+                derive_version, "read_fallback_version", return_value="6.2.84"
+            ),
+        ):
+            result = derive_version.derive(Path("."))
+
+        self.assertEqual(result["display"], "6.3.15-rc.1")
+        self.assertEqual(result["artifact"], "6.3.15-rc.1")
+        self.assertEqual(result["numeric"], "6.3.15.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Allows appimage update helpers to automatically update appimages for the user instead of them having to manually download the new version each time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Linux AppImage releases now include `.zsync` update metadata alongside the application image.
  - Release packages provide both the AppImage and its corresponding update metadata.

- **Bug Fixes**
  - Added safeguards to prevent incomplete or missing AppImage files from being published.
  - Verified that update information and metadata reference the correct release files.

- **Chores**
  - Improved Linux build configuration with multimedia support.
  - Added validation for supported release version formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->