### PR TITLE
fix(clipboard): preserve local file clipboard during sync

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -88,6 +88,49 @@ ClipboardSync::~ClipboardSync()
     stop();
 }
 
+bool ClipboardSync::hasFileReferences(const QMimeData* mime)
+{
+    if (mime == nullptr) {
+        return false;
+    }
+
+    // Qt normalizes ordinary Finder and Explorer file copies to local URLs.
+    // Do not treat remote web URLs as file clipboard data: browsers commonly
+    // attach those to otherwise valid copied images.
+    if (mime->hasUrls()) {
+        const QList<QUrl> urls = mime->urls();
+        for (const QUrl& url : urls) {
+            if (url.isLocalFile()) {
+                return true;
+            }
+        }
+    }
+
+    // Some native and promised-file providers expose only a platform format,
+    // without a URL that QMimeData can normalize. Match the identifying part
+    // so this also covers Qt's application/x-qt-*-mime wrappers.
+    static const QStringList fileFormatMarkers {
+        QStringLiteral("public.file-url"),
+        QStringLiteral("NSFilenamesPboardType"),
+        QStringLiteral("promised-file"),
+        QStringLiteral("FileNameW"),
+        QStringLiteral("FileGroupDescriptor"),
+        QStringLiteral("FileContents"),
+        QStringLiteral("Shell IDList Array")
+    };
+
+    const QStringList formats = mime->formats();
+    for (const QString& format : formats) {
+        for (const QString& marker : fileFormatMarkers) {
+            if (format.contains(marker, Qt::CaseInsensitive)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 void ClipboardSync::setHostContext(const ClipboardSyncHostContext& hostContext)
 {
     m_HostContext = hostContext;
@@ -269,6 +312,11 @@ void ClipboardSync::applyInboundText(const QByteArray& payload)
         return;
     }
 
+    if (hasFileReferences(cb->mimeData())) {
+        ClipboardLog::debug("ClipboardSync: preserving local file clipboard; inbound text ignored");
+        return;
+    }
+
     // Record hash *before* writing so the dataChanged echo we're about to
     // trigger is suppressed.
     uint64_t hash = hashBytes(payload);
@@ -288,6 +336,11 @@ void ClipboardSync::applyInboundPng(const QByteArray& payload)
 
     QClipboard* cb = QGuiApplication::clipboard();
     if (cb == nullptr) {
+        return;
+    }
+
+    if (hasFileReferences(cb->mimeData())) {
+        ClipboardLog::debug("ClipboardSync: preserving local file clipboard; inbound PNG ignored");
         return;
     }
 
@@ -623,6 +676,14 @@ void ClipboardSync::onLocalClipboardChanged()
     }
 
     const QMimeData* mime = cb->mimeData();
+
+    // Finder and Explorer file copies may include icon/thumbnail image data.
+    // The protocol cannot carry file references, and sending that fallback
+    // image allows the host echo to replace the original local file clipboard.
+    if (hasFileReferences(mime)) {
+        ClipboardLog::debug("ClipboardSync: local file clipboard detected; sync skipped");
+        return;
+    }
 
     // Image takes precedence — some applications attach a fallback text label
     // (file path, alt text) alongside the bitmap; we want the picture, not the

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -82,6 +82,11 @@ public:
         return payloadBytes >= INLINE_THRESHOLD;
     }
 
+    // File copy/paste is not part of the clipboard sync protocol. Native file
+    // clipboards often also expose a thumbnail or application icon as an image,
+    // so callers must reject file references before considering image formats.
+    static bool hasFileReferences(const QMimeData* mime);
+
     explicit ClipboardSync(const ClipboardSyncHostContext& hostContext = ClipboardSyncHostContext(),
                            QObject* parent = nullptr);
     ~ClipboardSync() override;

--- a/tests/clipboard_payload_routing/clipboard_payload_routing.pro
+++ b/tests/clipboard_payload_routing/clipboard_payload_routing.pro
@@ -1,4 +1,4 @@
-QT += core network
+QT += core gui network
 CONFIG += c++17 console
 CONFIG -= app_bundle
 
@@ -9,4 +9,11 @@ INCLUDEPATH += \
     $$PWD/../../app
 
 SOURCES += \
-    main.cpp
+    main.cpp \
+    ../../app/streaming/clipboardsync.cpp
+
+macx:SOURCES += ../../clipboard-helper/macos.mm
+
+HEADERS += \
+    ../../app/streaming/clipboardlogging.h \
+    ../../app/streaming/clipboardsync.h

--- a/tests/clipboard_payload_routing/main.cpp
+++ b/tests/clipboard_payload_routing/main.cpp
@@ -1,7 +1,9 @@
 #include "streaming/clipboardsync.h"
 
 #include <QCoreApplication>
+#include <QMimeData>
 #include <QTextStream>
+#include <QUrl>
 
 namespace {
 bool require(bool condition, const QString& message, QTextStream& err)
@@ -28,6 +30,41 @@ int main(int argc, char* argv[])
                   QStringLiteral("70 KiB payload did not use blob transfer"), err);
     ok &= require(ClipboardSync::MAX_BLOB_BYTES == 64LL * 1024 * 1024,
                   QStringLiteral("blob size cap changed unexpectedly"), err);
+
+    QMimeData localFile;
+    localFile.setUrls({QUrl::fromLocalFile(QStringLiteral("/tmp/report.tex"))});
+    localFile.setData(QStringLiteral("image/tiff"), QByteArrayLiteral("finder-icon"));
+    ok &= require(ClipboardSync::hasFileReferences(&localFile),
+                  QStringLiteral("local file URL with image fallback was not protected"), err);
+
+    QMimeData macFile;
+    macFile.setData(QStringLiteral("application/x-qt-mac-pasteboard-mime;value=\"public.file-url\""),
+                    QByteArrayLiteral("file:///tmp/report.tex"));
+    ok &= require(ClipboardSync::hasFileReferences(&macFile),
+                  QStringLiteral("macOS public.file-url format was not protected"), err);
+
+    QMimeData promisedFile;
+    promisedFile.setData(QStringLiteral("com.apple.pasteboard.promised-file-url"),
+                         QByteArrayLiteral("file:///tmp/future-file"));
+    ok &= require(ClipboardSync::hasFileReferences(&promisedFile),
+                  QStringLiteral("macOS promised file format was not protected"), err);
+
+    QMimeData windowsFile;
+    windowsFile.setData(QStringLiteral("application/x-qt-windows-mime;value=\"FileGroupDescriptorW\""),
+                        QByteArrayLiteral("descriptor"));
+    ok &= require(ClipboardSync::hasFileReferences(&windowsFile),
+                  QStringLiteral("Windows file descriptor format was not protected"), err);
+
+    QMimeData webImage;
+    webImage.setUrls({QUrl(QStringLiteral("https://example.com/image.png"))});
+    webImage.setData(QStringLiteral("image/png"), QByteArrayLiteral("png"));
+    ok &= require(!ClipboardSync::hasFileReferences(&webImage),
+                  QStringLiteral("remote image URL was misclassified as a file clipboard"), err);
+
+    QMimeData plainImage;
+    plainImage.setData(QStringLiteral("image/png"), QByteArrayLiteral("png"));
+    ok &= require(!ClipboardSync::hasFileReferences(&plainImage),
+                  QStringLiteral("plain image clipboard was misclassified as a file clipboard"), err);
 
     if (!ok) {
         return 1;


### PR DESCRIPTION
## 改了啥呀

- 识别本地文件 URL、macOS `public.file-url` / promised-file 和 Windows 文件描述符格式
- 文件剪贴板事件不再被当作图片外发
- 本地剪贴板仍含文件引用时，拒绝远端文本或 PNG 覆盖
- 给文件格式识别补上回归测试，普通 PNG 和网页图片 URL 继续正常同步

## 为啥要改

Finder 复制文件时会顺手附带图标或缩略图。原先“图片优先”的逻辑把这份杂鱼图标当成普通图片同步，远端回写后就把真正的文件引用覆盖掉了，于是本机粘贴消失，甚至落盘成 TIFF。

协议本来就不支持跨端文件剪贴板传输，但不支持归不支持，可不能把用户本机的文件剪贴板也吃掉呀。

## 验证

- `qmake ../../tests/clipboard_payload_routing/clipboard_payload_routing.pro && nmake`
- `release/clipboard_payload_routing.exe` → `clipboard_payload_routing=passed`
- `git diff --check`

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved local file references in the clipboard when synced text or images are received.
  * Prevented local file clipboards from being overwritten or sent as outbound clipboard updates.
  * Correctly distinguished local file references from remote URLs and regular images.

* **Tests**
  * Added coverage for file references across supported macOS and Windows clipboard formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->