### PR TITLE
feat(input): add native macOS DualSense haptics

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -313,6 +313,7 @@ HEADERS += \
     streaming/audio/renderers/renderer.h \
     streaming/audio/dualsensehaptics.h \
     streaming/audio/dualsensehapticscalibration.h \
+    streaming/audio/dualsensehapticsrouting.h \
     streaming/audio/dualsensehapticsstream.h \
     streaming/audio/renderers/sdl.h \
     gui/computermodel.h \

--- a/app/app.pro
+++ b/app/app.pro
@@ -204,7 +204,10 @@ macx {
         CONFIG += discord-rpc libplacebo
     }
 
-    LIBS += -lobjc -framework VideoToolbox -framework AVFoundation -framework CoreVideo -framework CoreGraphics -framework CoreMedia -framework AppKit -framework UniformTypeIdentifiers -framework Metal -framework MetalFx -framework QuartzCore
+    LIBS += -lobjc -framework VideoToolbox -framework AVFoundation -framework CoreVideo -framework CoreGraphics -framework CoreMedia -framework AppKit -framework UniformTypeIdentifiers -framework Metal -framework MetalFx -framework QuartzCore -framework GameController -framework CoreHaptics
+
+    SOURCES += streaming/audio/dualsensehapticsmac.mm
+    HEADERS += streaming/audio/dualsensehapticsmac.h
 
     # For libsoundio
     LIBS += -framework CoreAudio -framework AudioUnit

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -472,12 +472,37 @@ void DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_PCM_FRAME& frame)
 #endif
 }
 
-bool DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+void DualSenseHapticsRenderer::setControllerTarget(int controllerNumber)
 {
 #ifdef Q_OS_MACOS
-    return m_Impl->macRenderer != nullptr && m_Impl->macRenderer->submit(frame);
+    if (m_Impl->macRenderer != nullptr) {
+        m_Impl->macRenderer->setControllerTarget(controllerNumber);
+    }
+#else
+    (void)controllerNumber;
+#endif
+}
+
+void DualSenseHapticsRenderer::reset()
+{
+#ifdef Q_OS_MACOS
+    if (m_Impl->macRenderer != nullptr) {
+        m_Impl->macRenderer->reset();
+    }
+#endif
+}
+
+bool DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame,
+                                      bool* startedNative)
+{
+#ifdef Q_OS_MACOS
+    return m_Impl->macRenderer != nullptr &&
+           m_Impl->macRenderer->submit(frame, startedNative);
 #else
     (void)frame;
+    if (startedNative != nullptr) {
+        *startedNative = false;
+    }
     return false;
 #endif
 }

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -493,16 +493,14 @@ void DualSenseHapticsRenderer::reset()
 }
 
 bool DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame,
-                                      bool* startedNative)
+                                      bool& startedNative)
 {
 #ifdef Q_OS_MACOS
     return m_Impl->macRenderer != nullptr &&
            m_Impl->macRenderer->submit(frame, startedNative);
 #else
     (void)frame;
-    if (startedNative != nullptr) {
-        *startedNative = false;
-    }
+    startedNative = false;
     return false;
 #endif
 }

--- a/app/streaming/audio/dualsensehaptics.cpp
+++ b/app/streaming/audio/dualsensehaptics.cpp
@@ -33,6 +33,8 @@
 #include <QString>
 
 using Microsoft::WRL::ComPtr;
+#elif defined(Q_OS_MACOS)
+#include "dualsensehapticsmac.h"
 #endif
 
 namespace {
@@ -364,8 +366,17 @@ struct DualSenseHapticsRenderer::Impl
         CoUninitialize();
     }
 #else
-    Impl() = default;
+    Impl()
+    {
+#ifdef Q_OS_MACOS
+        macRenderer = std::make_unique<MacDualSenseHapticsRenderer>();
+#endif
+    }
     ~Impl() = default;
+
+#ifdef Q_OS_MACOS
+    std::unique_ptr<MacDualSenseHapticsRenderer> macRenderer;
+#endif
 #endif
 };
 
@@ -458,5 +469,15 @@ void DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_PCM_FRAME& frame)
     m_Impl->condition.notify_one();
 #else
     (void)frame;
+#endif
+}
+
+bool DualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+{
+#ifdef Q_OS_MACOS
+    return m_Impl->macRenderer != nullptr && m_Impl->macRenderer->submit(frame);
+#else
+    (void)frame;
+    return false;
 #endif
 }

--- a/app/streaming/audio/dualsensehaptics.h
+++ b/app/streaming/audio/dualsensehaptics.h
@@ -17,7 +17,7 @@ public:
     void submit(const LI_DS5_HAPTICS_PCM_FRAME& frame);
     void setControllerTarget(int controllerNumber);
     void reset();
-    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool* startedNative);
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool& startedNative);
 
 private:
     struct Impl;

--- a/app/streaming/audio/dualsensehaptics.h
+++ b/app/streaming/audio/dualsensehaptics.h
@@ -15,7 +15,9 @@ public:
 
     static bool isAvailable();
     void submit(const LI_DS5_HAPTICS_PCM_FRAME& frame);
-    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame);
+    void setControllerTarget(int controllerNumber);
+    void reset();
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool* startedNative);
 
 private:
     struct Impl;

--- a/app/streaming/audio/dualsensehaptics.h
+++ b/app/streaming/audio/dualsensehaptics.h
@@ -15,6 +15,7 @@ public:
 
     static bool isAvailable();
     void submit(const LI_DS5_HAPTICS_PCM_FRAME& frame);
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame);
 
 private:
     struct Impl;

--- a/app/streaming/audio/dualsensehapticscalibration.h
+++ b/app/streaming/audio/dualsensehapticscalibration.h
@@ -51,7 +51,8 @@ inline NativeHapticOutput renderIrV2Native(const LI_DS5_HAPTICS_IR_FRAME_V2& fra
 
 inline RumbleOutput renderIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
 {
-    if (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) {
+    if (frame.flags & (LI_DS5_HAPTICS_IR_FLAG_STREAM_END |
+                       LI_DS5_HAPTICS_IR_FLAG_SILENT)) {
         return {0, 0};
     }
 

--- a/app/streaming/audio/dualsensehapticscalibration.h
+++ b/app/streaming/audio/dualsensehapticscalibration.h
@@ -13,6 +13,42 @@ struct RumbleOutput
     std::uint16_t highFrequency;
 };
 
+struct NativeHapticLaneOutput
+{
+    float intensity;
+    float sharpness;
+};
+
+struct NativeHapticOutput
+{
+    NativeHapticLaneOutput left;
+    NativeHapticLaneOutput right;
+};
+
+inline NativeHapticLaneOutput renderNativeLane(const LI_DS5_HAPTICS_IR_LANE_V2& lane)
+{
+    // Core Haptics intensity is perceptual, so use a square-root response to
+    // preserve authored detail at low amplitudes. Spectral balance maps
+    // naturally to sharpness, while transients add a short high-frequency edge.
+    const float energy = std::clamp(lane.rmsAmplitude + lane.transientStrength * 0.25f,
+                                    0.0f, 1.0f);
+    return {
+        std::sqrt(energy),
+        std::clamp(1.0f - lane.lowBandRatio + lane.transientStrength * 0.20f,
+                   0.0f, 1.0f),
+    };
+}
+
+inline NativeHapticOutput renderIrV2Native(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+{
+    if (frame.flags & (LI_DS5_HAPTICS_IR_FLAG_STREAM_END |
+                       LI_DS5_HAPTICS_IR_FLAG_SILENT)) {
+        return {};
+    }
+
+    return {renderNativeLane(frame.lanes[0]), renderNativeLane(frame.lanes[1])};
+}
+
 inline RumbleOutput renderIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
 {
     if (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) {

--- a/app/streaming/audio/dualsensehapticsmac.h
+++ b/app/streaming/audio/dualsensehapticsmac.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include <Limelight.h>
+
+class MacDualSenseHapticsRenderer
+{
+public:
+    MacDualSenseHapticsRenderer();
+    ~MacDualSenseHapticsRenderer();
+
+    MacDualSenseHapticsRenderer(const MacDualSenseHapticsRenderer&) = delete;
+    MacDualSenseHapticsRenderer& operator=(const MacDualSenseHapticsRenderer&) = delete;
+
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_Impl;
+};

--- a/app/streaming/audio/dualsensehapticsmac.h
+++ b/app/streaming/audio/dualsensehapticsmac.h
@@ -16,7 +16,7 @@ public:
 
     void setControllerTarget(int controllerNumber);
     void reset();
-    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool* startedNative);
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool& startedNative);
 
 private:
     struct Impl;

--- a/app/streaming/audio/dualsensehapticsmac.h
+++ b/app/streaming/audio/dualsensehapticsmac.h
@@ -14,7 +14,9 @@ public:
     MacDualSenseHapticsRenderer(const MacDualSenseHapticsRenderer&) = delete;
     MacDualSenseHapticsRenderer& operator=(const MacDualSenseHapticsRenderer&) = delete;
 
-    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame);
+    void setControllerTarget(int controllerNumber);
+    void reset();
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool* startedNative);
 
 private:
     struct Impl;

--- a/app/streaming/audio/dualsensehapticsmac.mm
+++ b/app/streaming/audio/dualsensehapticsmac.mm
@@ -6,8 +6,10 @@
 #include "SDL_compat.h"
 
 #include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #import <CoreHaptics/CoreHaptics.h>
@@ -186,7 +188,7 @@ MoonlightDualSenseHapticState* createState(GCController* controller,
     SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO,
                 "macOS native DualSense haptics ready for player %d",
                 static_cast<int>(controllerNumber));
-    return [state autorelease];
+    return state;
 }
 
 bool updatePlayer(id<CHHapticPatternPlayer> player,
@@ -234,13 +236,19 @@ void stopState(MoonlightDualSenseHapticState* state)
 
 struct MacDualSenseHapticsRenderer::Impl
 {
+    using Clock = std::chrono::steady_clock;
+    // IR arrives every 5 ms, so this tolerates packet loss while bounding an
+    // infinite Core Haptics player if the final silent/end frame is dropped.
+    static constexpr std::chrono::milliseconds StateLeaseTimeout{250};
+
     std::mutex mutex;
     std::condition_variable watchdogWake;
-    NSMutableDictionary<NSNumber*, MoonlightDualSenseHapticState*>* states =
-        [[NSMutableDictionary alloc] init];
+    // Conservative routing admits at most one native controller at a time.
+    MoonlightDualSenseHapticState* state = nil;
     dualsense_haptics::IrBackendLatch backendLatch;
-    dualsense_haptics::NativeStateLeaseTracker stateLeases;
     int selectedLocalController = -1;
+    int stateController = -1;
+    std::optional<Clock::time_point> leaseDeadline;
     bool watchdogStopping = false;
     std::thread watchdog;
 
@@ -254,76 +262,59 @@ struct MacDualSenseHapticsRenderer::Impl
         {
             std::lock_guard lock(mutex);
             watchdogStopping = true;
-            watchdogWake.notify_all();
+            watchdogWake.notify_one();
         }
         watchdog.join();
 
         @autoreleasepool {
             std::lock_guard lock(mutex);
-            stopAll(false);
-            [states release];
+            clearState(false);
         }
     }
 
-    void stopAll(bool latchFallback)
+    void clearState(bool latchFallback)
     {
-        for (NSNumber* key in states) {
+        leaseDeadline.reset();
+        if (state != nil) {
             if (latchFallback) {
-                backendLatch.useFallback(key.unsignedShortValue);
+                backendLatch.useFallback(static_cast<std::uint16_t>(stateController));
             }
-            stopState(states[key]);
+            stopState(state);
+            [state release];
+            state = nil;
+            stateController = -1;
         }
-        [states removeAllObjects];
-        stateLeases.clear();
-        watchdogWake.notify_all();
-    }
-
-    void removeState(NSNumber* key, bool latchFallback)
-    {
-        MoonlightDualSenseHapticState* state = states[key];
-        if (state == nil) {
-            return;
-        }
-
-        const std::uint16_t controllerNumber = key.unsignedShortValue;
-        if (latchFallback) {
-            backendLatch.useFallback(controllerNumber);
-        }
-        stopState(state);
-        [states removeObjectForKey:key];
-        stateLeases.remove(controllerNumber);
-        watchdogWake.notify_all();
+        watchdogWake.notify_one();
     }
 
     void runWatchdog()
     {
         std::unique_lock lock(mutex);
         while (!watchdogStopping) {
-            const auto deadline = stateLeases.nextDeadline();
-            if (!deadline.has_value()) {
-                watchdogWake.wait(lock);
+            if (!leaseDeadline.has_value()) {
+                watchdogWake.wait(lock, [this] {
+                    return watchdogStopping || leaseDeadline.has_value();
+                });
                 continue;
             }
 
-            if (watchdogWake.wait_until(lock, *deadline) != std::cv_status::timeout) {
+            const auto observedDeadline = *leaseDeadline;
+            if (watchdogWake.wait_until(lock, observedDeadline, [this, observedDeadline] {
+                    return watchdogStopping || !leaseDeadline.has_value() ||
+                           *leaseDeadline != observedDeadline;
+                })) {
                 continue;
             }
 
-            const auto expiredControllers = stateLeases.takeExpired();
+            if (!leaseDeadline.has_value() || Clock::now() < *leaseDeadline) {
+                continue;
+            }
+
             @autoreleasepool {
-                for (std::uint16_t controllerNumber : expiredControllers) {
-                    NSNumber* key = @(controllerNumber);
-                    MoonlightDualSenseHapticState* state = states[key];
-                    if (state == nil) {
-                        continue;
-                    }
-
-                    SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
-                                "macOS native DualSense haptics timed out for controller %u",
-                                static_cast<unsigned>(controllerNumber));
-                    stopState(state);
-                    [states removeObjectForKey:key];
-                }
+                SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                            "macOS native DualSense haptics timed out for controller %d",
+                            stateController);
+                clearState(false);
             }
         }
     }
@@ -334,51 +325,50 @@ struct MacDualSenseHapticsRenderer::Impl
         if (selectedLocalController == controllerNumber) {
             return;
         }
-        stopAll(true);
+        clearState(true);
         selectedLocalController = controllerNumber;
     }
 
     void reset()
     {
         std::lock_guard lock(mutex);
-        stopAll(false);
+        clearState(false);
         backendLatch.reset();
+        selectedLocalController = -1;
     }
 
-    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool* startedNative)
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool& startedNative)
     {
         std::lock_guard lock(mutex);
-        if (startedNative != nullptr) {
-            *startedNative = false;
-        }
+        startedNative = false;
 
         const auto selection = findDualSenseSelection();
-        for (NSNumber* activeKey in states.allKeys) {
-            MoonlightDualSenseHapticState* activeState = states[activeKey];
-            const bool valid = !activeState.invalidationToken.isInvalidated &&
-                dualsense_haptics::canKeepNativeState(
-                    activeKey.unsignedShortValue,
+        if (state != nil) {
+            const bool valid = stateController >= 0 &&
+                !state.invalidationToken.isInvalidated &&
+                dualsense_haptics::canUseNativeController(
+                    static_cast<std::uint16_t>(stateController),
                     selectedLocalController,
-                    selection.count,
-                    activeState.controller == selection.controller);
+                    selection.count) &&
+                state.controller == selection.controller;
             if (!valid) {
-                removeState(activeKey, true);
+                clearState(true);
             }
         }
 
-        NSNumber* key = @(frame.controllerNumber);
-        MoonlightDualSenseHapticState* state = states[key];
+        MoonlightDualSenseHapticState* frameState =
+            stateController == frame.controllerNumber ? state : nil;
 
         const bool streamEnd = (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) != 0;
         if (!backendLatch.shouldAttemptNative(frame.controllerNumber, streamEnd)) {
-            if (state != nil) {
-                removeState(key, false);
+            if (frameState != nil) {
+                clearState(false);
             }
             return false;
         }
 
         const bool silent = (frame.flags & LI_DS5_HAPTICS_IR_FLAG_SILENT) != 0;
-        if (silent && state == nil) {
+        if (silent && frameState == nil) {
             return false;
         }
 
@@ -387,35 +377,34 @@ struct MacDualSenseHapticsRenderer::Impl
                 selection.controller : nil;
 
         bool createdState = false;
-        if (state == nil) {
+        if (frameState == nil) {
             if (controller == nil) {
                 backendLatch.useFallback(frame.controllerNumber);
                 return false;
             }
-            state = createState(controller, frame.controllerNumber);
-            if (state == nil) {
+            frameState = createState(controller, frame.controllerNumber);
+            if (frameState == nil) {
                 backendLatch.useFallback(frame.controllerNumber);
                 return false;
             }
-            states[key] = state;
+            state = frameState;
+            stateController = frame.controllerNumber;
             createdState = true;
         }
 
         const auto output = dualsense_haptics::renderIrV2Native(frame);
         NSError* error = nil;
-        if (!updatePlayer(state.leftPlayer, output.left, &error) ||
-            !updatePlayer(state.rightPlayer, output.right, &error)) {
+        if (!updatePlayer(frameState.leftPlayer, output.left, &error) ||
+            !updatePlayer(frameState.rightPlayer, output.right, &error)) {
             SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
                         "Unable to update macOS DualSense haptics: %s",
                         error.localizedDescription.UTF8String ?: "unknown error");
-            removeState(key, true);
+            clearState(true);
             return false;
         }
-        stateLeases.renew(frame.controllerNumber);
-        watchdogWake.notify_all();
-        if (startedNative != nullptr) {
-            *startedNative = createdState;
-        }
+        leaseDeadline = Clock::now() + StateLeaseTimeout;
+        watchdogWake.notify_one();
+        startedNative = createdState;
         return true;
     }
 };
@@ -442,7 +431,7 @@ void MacDualSenseHapticsRenderer::reset()
 }
 
 bool MacDualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame,
-                                         bool* startedNative)
+                                         bool& startedNative)
 {
     @autoreleasepool {
         return m_Impl->submit(frame, startedNative);

--- a/app/streaming/audio/dualsensehapticsmac.mm
+++ b/app/streaming/audio/dualsensehapticsmac.mm
@@ -1,14 +1,24 @@
 #include "dualsensehapticsmac.h"
 
 #include "dualsensehapticscalibration.h"
+#include "dualsensehapticsrouting.h"
 
 #include "SDL_compat.h"
 
 #include <algorithm>
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 
 #import <CoreHaptics/CoreHaptics.h>
 #import <GameController/GameController.h>
+
+@interface MoonlightHapticInvalidationToken : NSObject
+@property(atomic, assign, getter=isInvalidated) BOOL invalidated;
+@end
+
+@implementation MoonlightHapticInvalidationToken
+@end
 
 @interface MoonlightDualSenseHapticState : NSObject
 @property(nonatomic, strong) GCController* controller;
@@ -16,6 +26,7 @@
 @property(nonatomic, strong) CHHapticEngine* rightEngine;
 @property(nonatomic, strong) id<CHHapticPatternPlayer> leftPlayer;
 @property(nonatomic, strong) id<CHHapticPatternPlayer> rightPlayer;
+@property(nonatomic, strong) MoonlightHapticInvalidationToken* invalidationToken;
 @end
 
 @implementation MoonlightDualSenseHapticState
@@ -26,6 +37,7 @@
     [_rightEngine release];
     [_leftPlayer release];
     [_rightPlayer release];
+    [_invalidationToken release];
     [super dealloc];
 }
 @end
@@ -38,28 +50,25 @@ bool isDualSenseController(GCController* controller)
            [controller.extendedGamepad isKindOfClass:[GCDualSenseGamepad class]];
 }
 
-GCController* findDualSense(std::uint16_t controllerNumber)
+struct DualSenseSelection
 {
-    NSMutableArray<GCController*>* fallbackControllers = [NSMutableArray array];
+    GCController* controller;
+    std::size_t count;
+};
+
+DualSenseSelection findDualSenseSelection()
+{
+    GCController* candidate = nil;
+    std::size_t candidateCount = 0;
     for (GCController* controller in GCController.controllers) {
         if (!isDualSenseController(controller)) {
             continue;
         }
-
-        if (controller.playerIndex != GCControllerPlayerIndexUnset &&
-            static_cast<NSInteger>(controller.playerIndex) == controllerNumber) {
-            return controller;
-        }
-        [fallbackControllers addObject:controller];
+        candidate = controller;
+        candidateCount++;
     }
 
-    // SDL and GameController share the player index on macOS. Some controllers
-    // remain unassigned until input begins, so retain a deterministic fallback
-    // for the common single-controller case and for initially unassigned pads.
-    if (controllerNumber < fallbackControllers.count) {
-        return fallbackControllers[controllerNumber];
-    }
-    return nil;
+    return {candidate, candidateCount};
 }
 
 id<CHHapticPatternPlayer> createPlayer(CHHapticEngine* engine, NSError** error)
@@ -75,12 +84,18 @@ id<CHHapticPatternPlayer> createPlayer(CHHapticEngine* engine, NSError** error)
                                      parameters:@[intensity, sharpness]
                                    relativeTime:0
                                        duration:GCHapticDurationInfinite];
+    CHHapticDynamicParameter* initialIntensity =
+        [[CHHapticDynamicParameter alloc]
+            initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl
+                           value:0.0f
+                    relativeTime:0];
     CHHapticPattern* pattern = [[CHHapticPattern alloc] initWithEvents:@[event]
-                                                            parameters:@[]
+                                                            parameters:@[initialIntensity]
                                                                  error:error];
     [intensity release];
     [sharpness release];
     [event release];
+    [initialIntensity release];
     if (pattern == nil) {
         return nil;
     }
@@ -94,6 +109,7 @@ id<CHHapticPatternPlayer> createPlayer(CHHapticEngine* engine, NSError** error)
 }
 
 bool startHandle(GCDeviceHaptics* haptics, GCHapticsLocality locality,
+                 MoonlightHapticInvalidationToken* invalidationToken,
                  CHHapticEngine** engineOut, id<CHHapticPatternPlayer>* playerOut)
 {
     if (![haptics.supportedLocalities containsObject:locality]) {
@@ -102,6 +118,14 @@ bool startHandle(GCDeviceHaptics* haptics, GCHapticsLocality locality,
 
     CHHapticEngine* engine = [haptics createEngineWithLocality:locality];
     NSError* error = nil;
+    engine.playsHapticsOnly = YES;
+    engine.stoppedHandler = ^(CHHapticEngineStoppedReason reason) {
+        (void)reason;
+        invalidationToken.invalidated = YES;
+    };
+    engine.resetHandler = ^{
+        invalidationToken.invalidated = YES;
+    };
     if (engine == nil || ![engine startAndReturnError:&error]) {
         SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
                     "Unable to start macOS DualSense haptic engine: %s",
@@ -123,7 +147,8 @@ bool startHandle(GCDeviceHaptics* haptics, GCHapticsLocality locality,
     return true;
 }
 
-MoonlightDualSenseHapticState* createState(GCController* controller)
+MoonlightDualSenseHapticState* createState(GCController* controller,
+                                           std::uint16_t controllerNumber)
 {
     GCDeviceHaptics* haptics = controller.haptics;
     if (haptics == nil) {
@@ -132,16 +157,20 @@ MoonlightDualSenseHapticState* createState(GCController* controller)
 
     MoonlightDualSenseHapticState* state = [[MoonlightDualSenseHapticState alloc] init];
     state.controller = controller;
+    MoonlightHapticInvalidationToken* invalidationToken =
+        [[MoonlightHapticInvalidationToken alloc] init];
+    state.invalidationToken = invalidationToken;
+    [invalidationToken release];
     CHHapticEngine* leftEngine = nil;
     CHHapticEngine* rightEngine = nil;
     id<CHHapticPatternPlayer> leftPlayer = nil;
     id<CHHapticPatternPlayer> rightPlayer = nil;
-    if (!startHandle(haptics, GCHapticsLocalityLeftHandle,
+    if (!startHandle(haptics, GCHapticsLocalityLeftHandle, state.invalidationToken,
                      &leftEngine, &leftPlayer)) {
         [state release];
         return nil;
     }
-    if (!startHandle(haptics, GCHapticsLocalityRightHandle,
+    if (!startHandle(haptics, GCHapticsLocalityRightHandle, state.invalidationToken,
                      &rightEngine, &rightPlayer)) {
         NSError* error = nil;
         [leftPlayer stopAtTime:CHHapticTimeImmediate error:&error];
@@ -156,7 +185,7 @@ MoonlightDualSenseHapticState* createState(GCController* controller)
 
     SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO,
                 "macOS native DualSense haptics ready for player %d",
-                static_cast<int>(controller.playerIndex));
+                static_cast<int>(controllerNumber));
     return [state autorelease];
 }
 
@@ -184,6 +213,15 @@ bool updatePlayer(id<CHHapticPatternPlayer> player,
 
 void stopState(MoonlightDualSenseHapticState* state)
 {
+    state.leftEngine.stoppedHandler = ^(CHHapticEngineStoppedReason reason) {
+        (void)reason;
+    };
+    state.leftEngine.resetHandler = ^{};
+    state.rightEngine.stoppedHandler = ^(CHHapticEngineStoppedReason reason) {
+        (void)reason;
+    };
+    state.rightEngine.resetHandler = ^{};
+
     NSError* error = nil;
     [state.leftPlayer stopAtTime:CHHapticTimeImmediate error:&error];
     error = nil;
@@ -197,48 +235,170 @@ void stopState(MoonlightDualSenseHapticState* state)
 struct MacDualSenseHapticsRenderer::Impl
 {
     std::mutex mutex;
+    std::condition_variable watchdogWake;
     NSMutableDictionary<NSNumber*, MoonlightDualSenseHapticState*>* states =
         [[NSMutableDictionary alloc] init];
+    dualsense_haptics::IrBackendLatch backendLatch;
+    dualsense_haptics::NativeStateLeaseTracker stateLeases;
+    int selectedLocalController = -1;
+    bool watchdogStopping = false;
+    std::thread watchdog;
+
+    Impl() :
+        watchdog([this] { runWatchdog(); })
+    {
+    }
 
     ~Impl()
     {
-        for (MoonlightDualSenseHapticState* state in states.allValues) {
-            stopState(state);
+        {
+            std::lock_guard lock(mutex);
+            watchdogStopping = true;
+            watchdogWake.notify_all();
         }
-        [states release];
+        watchdog.join();
+
+        @autoreleasepool {
+            std::lock_guard lock(mutex);
+            stopAll(false);
+            [states release];
+        }
     }
 
-    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+    void stopAll(bool latchFallback)
+    {
+        for (NSNumber* key in states) {
+            if (latchFallback) {
+                backendLatch.useFallback(key.unsignedShortValue);
+            }
+            stopState(states[key]);
+        }
+        [states removeAllObjects];
+        stateLeases.clear();
+        watchdogWake.notify_all();
+    }
+
+    void removeState(NSNumber* key, bool latchFallback)
+    {
+        MoonlightDualSenseHapticState* state = states[key];
+        if (state == nil) {
+            return;
+        }
+
+        const std::uint16_t controllerNumber = key.unsignedShortValue;
+        if (latchFallback) {
+            backendLatch.useFallback(controllerNumber);
+        }
+        stopState(state);
+        [states removeObjectForKey:key];
+        stateLeases.remove(controllerNumber);
+        watchdogWake.notify_all();
+    }
+
+    void runWatchdog()
+    {
+        std::unique_lock lock(mutex);
+        while (!watchdogStopping) {
+            const auto deadline = stateLeases.nextDeadline();
+            if (!deadline.has_value()) {
+                watchdogWake.wait(lock);
+                continue;
+            }
+
+            if (watchdogWake.wait_until(lock, *deadline) != std::cv_status::timeout) {
+                continue;
+            }
+
+            const auto expiredControllers = stateLeases.takeExpired();
+            @autoreleasepool {
+                for (std::uint16_t controllerNumber : expiredControllers) {
+                    NSNumber* key = @(controllerNumber);
+                    MoonlightDualSenseHapticState* state = states[key];
+                    if (state == nil) {
+                        continue;
+                    }
+
+                    SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                                "macOS native DualSense haptics timed out for controller %u",
+                                static_cast<unsigned>(controllerNumber));
+                    stopState(state);
+                    [states removeObjectForKey:key];
+                }
+            }
+        }
+    }
+
+    void setControllerTarget(int controllerNumber)
     {
         std::lock_guard lock(mutex);
+        if (selectedLocalController == controllerNumber) {
+            return;
+        }
+        stopAll(true);
+        selectedLocalController = controllerNumber;
+    }
+
+    void reset()
+    {
+        std::lock_guard lock(mutex);
+        stopAll(false);
+        backendLatch.reset();
+    }
+
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame, bool* startedNative)
+    {
+        std::lock_guard lock(mutex);
+        if (startedNative != nullptr) {
+            *startedNative = false;
+        }
+
+        const auto selection = findDualSenseSelection();
+        for (NSNumber* activeKey in states.allKeys) {
+            MoonlightDualSenseHapticState* activeState = states[activeKey];
+            const bool valid = !activeState.invalidationToken.isInvalidated &&
+                dualsense_haptics::canKeepNativeState(
+                    activeKey.unsignedShortValue,
+                    selectedLocalController,
+                    selection.count,
+                    activeState.controller == selection.controller);
+            if (!valid) {
+                removeState(activeKey, true);
+            }
+        }
+
         NSNumber* key = @(frame.controllerNumber);
         MoonlightDualSenseHapticState* state = states[key];
 
-        GCController* controller = findDualSense(frame.controllerNumber);
-        if (state != nil && state.controller != controller) {
-            stopState(state);
-            [states removeObjectForKey:key];
-            state = nil;
-        }
-
-        if (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) {
+        const bool streamEnd = (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) != 0;
+        if (!backendLatch.shouldAttemptNative(frame.controllerNumber, streamEnd)) {
             if (state != nil) {
-                stopState(state);
-                [states removeObjectForKey:key];
-                return true;
+                removeState(key, false);
             }
             return false;
         }
 
+        const bool silent = (frame.flags & LI_DS5_HAPTICS_IR_FLAG_SILENT) != 0;
+        if (silent && state == nil) {
+            return false;
+        }
+
+        GCController* controller = dualsense_haptics::canUseNativeController(
+            frame.controllerNumber, selectedLocalController, selection.count) ?
+                selection.controller : nil;
+
+        bool createdState = false;
         if (state == nil) {
             if (controller == nil) {
+                backendLatch.useFallback(frame.controllerNumber);
                 return false;
             }
-            state = createState(controller);
+            state = createState(controller, frame.controllerNumber);
             if (state == nil) {
+                backendLatch.useFallback(frame.controllerNumber);
                 return false;
             }
             states[key] = state;
+            createdState = true;
         }
 
         const auto output = dualsense_haptics::renderIrV2Native(frame);
@@ -248,9 +408,13 @@ struct MacDualSenseHapticsRenderer::Impl
             SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
                         "Unable to update macOS DualSense haptics: %s",
                         error.localizedDescription.UTF8String ?: "unknown error");
-            stopState(state);
-            [states removeObjectForKey:key];
+            removeState(key, true);
             return false;
+        }
+        stateLeases.renew(frame.controllerNumber);
+        watchdogWake.notify_all();
+        if (startedNative != nullptr) {
+            *startedNative = createdState;
         }
         return true;
     }
@@ -263,9 +427,24 @@ MacDualSenseHapticsRenderer::MacDualSenseHapticsRenderer() :
 
 MacDualSenseHapticsRenderer::~MacDualSenseHapticsRenderer() = default;
 
-bool MacDualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+void MacDualSenseHapticsRenderer::setControllerTarget(int controllerNumber)
 {
     @autoreleasepool {
-        return m_Impl->submit(frame);
+        m_Impl->setControllerTarget(controllerNumber);
+    }
+}
+
+void MacDualSenseHapticsRenderer::reset()
+{
+    @autoreleasepool {
+        m_Impl->reset();
+    }
+}
+
+bool MacDualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame,
+                                         bool* startedNative)
+{
+    @autoreleasepool {
+        return m_Impl->submit(frame, startedNative);
     }
 }

--- a/app/streaming/audio/dualsensehapticsmac.mm
+++ b/app/streaming/audio/dualsensehapticsmac.mm
@@ -1,0 +1,271 @@
+#include "dualsensehapticsmac.h"
+
+#include "dualsensehapticscalibration.h"
+
+#include "SDL_compat.h"
+
+#include <algorithm>
+#include <mutex>
+
+#import <CoreHaptics/CoreHaptics.h>
+#import <GameController/GameController.h>
+
+@interface MoonlightDualSenseHapticState : NSObject
+@property(nonatomic, strong) GCController* controller;
+@property(nonatomic, strong) CHHapticEngine* leftEngine;
+@property(nonatomic, strong) CHHapticEngine* rightEngine;
+@property(nonatomic, strong) id<CHHapticPatternPlayer> leftPlayer;
+@property(nonatomic, strong) id<CHHapticPatternPlayer> rightPlayer;
+@end
+
+@implementation MoonlightDualSenseHapticState
+- (void)dealloc
+{
+    [_controller release];
+    [_leftEngine release];
+    [_rightEngine release];
+    [_leftPlayer release];
+    [_rightPlayer release];
+    [super dealloc];
+}
+@end
+
+namespace {
+
+bool isDualSenseController(GCController* controller)
+{
+    return controller != nil &&
+           [controller.extendedGamepad isKindOfClass:[GCDualSenseGamepad class]];
+}
+
+GCController* findDualSense(std::uint16_t controllerNumber)
+{
+    NSMutableArray<GCController*>* fallbackControllers = [NSMutableArray array];
+    for (GCController* controller in GCController.controllers) {
+        if (!isDualSenseController(controller)) {
+            continue;
+        }
+
+        if (controller.playerIndex != GCControllerPlayerIndexUnset &&
+            static_cast<NSInteger>(controller.playerIndex) == controllerNumber) {
+            return controller;
+        }
+        [fallbackControllers addObject:controller];
+    }
+
+    // SDL and GameController share the player index on macOS. Some controllers
+    // remain unassigned until input begins, so retain a deterministic fallback
+    // for the common single-controller case and for initially unassigned pads.
+    if (controllerNumber < fallbackControllers.count) {
+        return fallbackControllers[controllerNumber];
+    }
+    return nil;
+}
+
+id<CHHapticPatternPlayer> createPlayer(CHHapticEngine* engine, NSError** error)
+{
+    CHHapticEventParameter* intensity =
+        [[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticIntensity
+                                                     value:1.0f];
+    CHHapticEventParameter* sharpness =
+        [[CHHapticEventParameter alloc] initWithParameterID:CHHapticEventParameterIDHapticSharpness
+                                                     value:0.5f];
+    CHHapticEvent* event =
+        [[CHHapticEvent alloc] initWithEventType:CHHapticEventTypeHapticContinuous
+                                     parameters:@[intensity, sharpness]
+                                   relativeTime:0
+                                       duration:GCHapticDurationInfinite];
+    CHHapticPattern* pattern = [[CHHapticPattern alloc] initWithEvents:@[event]
+                                                            parameters:@[]
+                                                                 error:error];
+    [intensity release];
+    [sharpness release];
+    [event release];
+    if (pattern == nil) {
+        return nil;
+    }
+
+    id<CHHapticPatternPlayer> player = [engine createPlayerWithPattern:pattern error:error];
+    [pattern release];
+    if (player == nil || ![player startAtTime:CHHapticTimeImmediate error:error]) {
+        return nil;
+    }
+    return player;
+}
+
+bool startHandle(GCDeviceHaptics* haptics, GCHapticsLocality locality,
+                 CHHapticEngine** engineOut, id<CHHapticPatternPlayer>* playerOut)
+{
+    if (![haptics.supportedLocalities containsObject:locality]) {
+        return false;
+    }
+
+    CHHapticEngine* engine = [haptics createEngineWithLocality:locality];
+    NSError* error = nil;
+    if (engine == nil || ![engine startAndReturnError:&error]) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                    "Unable to start macOS DualSense haptic engine: %s",
+                    error.localizedDescription.UTF8String ?: "unknown error");
+        return false;
+    }
+
+    id<CHHapticPatternPlayer> player = createPlayer(engine, &error);
+    if (player == nil) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                    "Unable to create macOS DualSense haptic player: %s",
+                    error.localizedDescription.UTF8String ?: "unknown error");
+        [engine stopWithCompletionHandler:nil];
+        return false;
+    }
+
+    *engineOut = engine;
+    *playerOut = player;
+    return true;
+}
+
+MoonlightDualSenseHapticState* createState(GCController* controller)
+{
+    GCDeviceHaptics* haptics = controller.haptics;
+    if (haptics == nil) {
+        return nil;
+    }
+
+    MoonlightDualSenseHapticState* state = [[MoonlightDualSenseHapticState alloc] init];
+    state.controller = controller;
+    CHHapticEngine* leftEngine = nil;
+    CHHapticEngine* rightEngine = nil;
+    id<CHHapticPatternPlayer> leftPlayer = nil;
+    id<CHHapticPatternPlayer> rightPlayer = nil;
+    if (!startHandle(haptics, GCHapticsLocalityLeftHandle,
+                     &leftEngine, &leftPlayer)) {
+        [state release];
+        return nil;
+    }
+    if (!startHandle(haptics, GCHapticsLocalityRightHandle,
+                     &rightEngine, &rightPlayer)) {
+        NSError* error = nil;
+        [leftPlayer stopAtTime:CHHapticTimeImmediate error:&error];
+        [leftEngine stopWithCompletionHandler:nil];
+        [state release];
+        return nil;
+    }
+    state.leftEngine = leftEngine;
+    state.rightEngine = rightEngine;
+    state.leftPlayer = leftPlayer;
+    state.rightPlayer = rightPlayer;
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_AUDIO,
+                "macOS native DualSense haptics ready for player %d",
+                static_cast<int>(controller.playerIndex));
+    return [state autorelease];
+}
+
+bool updatePlayer(id<CHHapticPatternPlayer> player,
+                  const dualsense_haptics::NativeHapticLaneOutput& output,
+                  NSError** error)
+{
+    CHHapticDynamicParameter* intensity =
+        [[CHHapticDynamicParameter alloc]
+            initWithParameterID:CHHapticDynamicParameterIDHapticIntensityControl
+                           value:std::clamp(output.intensity, 0.0f, 1.0f)
+                    relativeTime:0];
+    CHHapticDynamicParameter* sharpness =
+        [[CHHapticDynamicParameter alloc]
+            initWithParameterID:CHHapticDynamicParameterIDHapticSharpnessControl
+                           value:std::clamp(output.sharpness, 0.0f, 1.0f) - 0.5f
+                    relativeTime:0];
+    const bool updated = [player sendParameters:@[intensity, sharpness]
+                                         atTime:CHHapticTimeImmediate
+                                          error:error];
+    [intensity release];
+    [sharpness release];
+    return updated;
+}
+
+void stopState(MoonlightDualSenseHapticState* state)
+{
+    NSError* error = nil;
+    [state.leftPlayer stopAtTime:CHHapticTimeImmediate error:&error];
+    error = nil;
+    [state.rightPlayer stopAtTime:CHHapticTimeImmediate error:&error];
+    [state.leftEngine stopWithCompletionHandler:nil];
+    [state.rightEngine stopWithCompletionHandler:nil];
+}
+
+} // namespace
+
+struct MacDualSenseHapticsRenderer::Impl
+{
+    std::mutex mutex;
+    NSMutableDictionary<NSNumber*, MoonlightDualSenseHapticState*>* states =
+        [[NSMutableDictionary alloc] init];
+
+    ~Impl()
+    {
+        for (MoonlightDualSenseHapticState* state in states.allValues) {
+            stopState(state);
+        }
+        [states release];
+    }
+
+    bool submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+    {
+        std::lock_guard lock(mutex);
+        NSNumber* key = @(frame.controllerNumber);
+        MoonlightDualSenseHapticState* state = states[key];
+
+        GCController* controller = findDualSense(frame.controllerNumber);
+        if (state != nil && state.controller != controller) {
+            stopState(state);
+            [states removeObjectForKey:key];
+            state = nil;
+        }
+
+        if (frame.flags & LI_DS5_HAPTICS_IR_FLAG_STREAM_END) {
+            if (state != nil) {
+                stopState(state);
+                [states removeObjectForKey:key];
+                return true;
+            }
+            return false;
+        }
+
+        if (state == nil) {
+            if (controller == nil) {
+                return false;
+            }
+            state = createState(controller);
+            if (state == nil) {
+                return false;
+            }
+            states[key] = state;
+        }
+
+        const auto output = dualsense_haptics::renderIrV2Native(frame);
+        NSError* error = nil;
+        if (!updatePlayer(state.leftPlayer, output.left, &error) ||
+            !updatePlayer(state.rightPlayer, output.right, &error)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_AUDIO,
+                        "Unable to update macOS DualSense haptics: %s",
+                        error.localizedDescription.UTF8String ?: "unknown error");
+            stopState(state);
+            [states removeObjectForKey:key];
+            return false;
+        }
+        return true;
+    }
+};
+
+MacDualSenseHapticsRenderer::MacDualSenseHapticsRenderer() :
+    m_Impl(std::make_unique<Impl>())
+{
+}
+
+MacDualSenseHapticsRenderer::~MacDualSenseHapticsRenderer() = default;
+
+bool MacDualSenseHapticsRenderer::submit(const LI_DS5_HAPTICS_IR_FRAME_V2& frame)
+{
+    @autoreleasepool {
+        return m_Impl->submit(frame);
+    }
+}

--- a/app/streaming/audio/dualsensehapticsrouting.h
+++ b/app/streaming/audio/dualsensehapticsrouting.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace dualsense_haptics {
+
+struct LocalControllerCandidate
+{
+    int logicalNumber;
+    bool dualSense;
+};
+
+inline int selectUniqueLocalDualSense(const LocalControllerCandidate* controllers,
+                                     std::size_t controllerCount,
+                                     bool multiController)
+{
+    if (controllers == nullptr || controllerCount == 0 ||
+        (!multiController && controllerCount != 1)) {
+        return -1;
+    }
+
+    int selected = -1;
+    for (std::size_t i = 0; i < controllerCount; i++) {
+        if (!controllers[i].dualSense) {
+            continue;
+        }
+        if (selected >= 0) {
+            return -1;
+        }
+        selected = controllers[i].logicalNumber;
+    }
+    return selected;
+}
+
+inline bool canUseNativeController(std::uint16_t controllerNumber,
+                                   int selectedLocalController,
+                                   std::size_t nativeControllerCount)
+{
+    return selectedLocalController >= 0 &&
+           controllerNumber == static_cast<std::uint16_t>(selectedLocalController) &&
+           nativeControllerCount == 1;
+}
+
+inline bool canKeepNativeState(std::uint16_t controllerNumber,
+                               int selectedLocalController,
+                               std::size_t nativeControllerCount,
+                               bool sameNativeController)
+{
+    return sameNativeController &&
+           canUseNativeController(controllerNumber,
+                                  selectedLocalController,
+                                  nativeControllerCount);
+}
+
+class IrBackendLatch
+{
+public:
+    bool shouldAttemptNative(std::uint16_t controllerNumber, bool streamEnd)
+    {
+        if (streamEnd) {
+            m_FallbackControllers.erase(controllerNumber);
+            return false;
+        }
+        return m_FallbackControllers.find(controllerNumber) == m_FallbackControllers.end();
+    }
+
+    void useFallback(std::uint16_t controllerNumber)
+    {
+        m_FallbackControllers.insert(controllerNumber);
+    }
+
+    void reset()
+    {
+        m_FallbackControllers.clear();
+    }
+
+private:
+    std::unordered_set<std::uint16_t> m_FallbackControllers;
+};
+
+// IR updates arrive every 5 ms over an unreliable channel. Bound the lifetime
+// of Core Haptics' infinite players in case the final silent/end frame is lost.
+class NativeStateLeaseTracker
+{
+public:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    explicit NativeStateLeaseTracker(
+        Clock::duration timeout = std::chrono::milliseconds(250)) :
+        m_Timeout(timeout)
+    {
+    }
+
+    void renew(std::uint16_t controllerNumber, TimePoint now = Clock::now())
+    {
+        m_Deadlines[controllerNumber] = now + m_Timeout;
+    }
+
+    void remove(std::uint16_t controllerNumber)
+    {
+        m_Deadlines.erase(controllerNumber);
+    }
+
+    void clear()
+    {
+        m_Deadlines.clear();
+    }
+
+    std::optional<TimePoint> nextDeadline() const
+    {
+        if (m_Deadlines.empty()) {
+            return std::nullopt;
+        }
+        return std::min_element(
+            m_Deadlines.begin(), m_Deadlines.end(),
+            [](const auto& left, const auto& right) {
+                return left.second < right.second;
+            })->second;
+    }
+
+    std::vector<std::uint16_t> takeExpired(TimePoint now = Clock::now())
+    {
+        std::vector<std::uint16_t> expired;
+        for (auto it = m_Deadlines.begin(); it != m_Deadlines.end();) {
+            if (it->second <= now) {
+                expired.push_back(it->first);
+                it = m_Deadlines.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+        return expired;
+    }
+
+private:
+    Clock::duration m_Timeout;
+    std::unordered_map<std::uint16_t, TimePoint> m_Deadlines;
+};
+
+} // namespace dualsense_haptics

--- a/app/streaming/audio/dualsensehapticsrouting.h
+++ b/app/streaming/audio/dualsensehapticsrouting.h
@@ -1,13 +1,8 @@
 #pragma once
 
-#include <algorithm>
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <optional>
-#include <unordered_map>
 #include <unordered_set>
-#include <vector>
 
 namespace dualsense_haptics {
 
@@ -48,17 +43,6 @@ inline bool canUseNativeController(std::uint16_t controllerNumber,
            nativeControllerCount == 1;
 }
 
-inline bool canKeepNativeState(std::uint16_t controllerNumber,
-                               int selectedLocalController,
-                               std::size_t nativeControllerCount,
-                               bool sameNativeController)
-{
-    return sameNativeController &&
-           canUseNativeController(controllerNumber,
-                                  selectedLocalController,
-                                  nativeControllerCount);
-}
-
 class IrBackendLatch
 {
 public:
@@ -83,67 +67,6 @@ public:
 
 private:
     std::unordered_set<std::uint16_t> m_FallbackControllers;
-};
-
-// IR updates arrive every 5 ms over an unreliable channel. Bound the lifetime
-// of Core Haptics' infinite players in case the final silent/end frame is lost.
-class NativeStateLeaseTracker
-{
-public:
-    using Clock = std::chrono::steady_clock;
-    using TimePoint = Clock::time_point;
-
-    explicit NativeStateLeaseTracker(
-        Clock::duration timeout = std::chrono::milliseconds(250)) :
-        m_Timeout(timeout)
-    {
-    }
-
-    void renew(std::uint16_t controllerNumber, TimePoint now = Clock::now())
-    {
-        m_Deadlines[controllerNumber] = now + m_Timeout;
-    }
-
-    void remove(std::uint16_t controllerNumber)
-    {
-        m_Deadlines.erase(controllerNumber);
-    }
-
-    void clear()
-    {
-        m_Deadlines.clear();
-    }
-
-    std::optional<TimePoint> nextDeadline() const
-    {
-        if (m_Deadlines.empty()) {
-            return std::nullopt;
-        }
-        return std::min_element(
-            m_Deadlines.begin(), m_Deadlines.end(),
-            [](const auto& left, const auto& right) {
-                return left.second < right.second;
-            })->second;
-    }
-
-    std::vector<std::uint16_t> takeExpired(TimePoint now = Clock::now())
-    {
-        std::vector<std::uint16_t> expired;
-        for (auto it = m_Deadlines.begin(); it != m_Deadlines.end();) {
-            if (it->second <= now) {
-                expired.push_back(it->first);
-                it = m_Deadlines.erase(it);
-            }
-            else {
-                ++it;
-            }
-        }
-        return expired;
-    }
-
-private:
-    Clock::duration m_Timeout;
-    std::unordered_map<std::uint16_t, TimePoint> m_Deadlines;
 };
 
 } // namespace dualsense_haptics

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -176,6 +176,21 @@ void SdlInputHandler::sendGamepadBatteryState(GamepadState* state, SDL_JoystickP
     LiSendControllerBatteryEvent(state->index, batteryState, batteryPercentage);
 }
 
+void SdlInputHandler::sendGamepadArrival(GamepadState* state,
+                                         SDL_JoystickPowerLevel powerLevel)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    LiSendControllerArrivalEvent(state->index, m_GamepadMask, state->type,
+                                 state->supportedButtonFlags, state->capabilities);
+#else
+    sendGamepadState(state);
+#endif
+
+    if (powerLevel != SDL_JOYSTICK_POWER_UNKNOWN) {
+        sendGamepadBatteryState(state, powerLevel);
+    }
+}
+
 Uint32 SdlInputHandler::mouseEmulationTimerCallback(Uint32 interval, void *param)
 {
     auto gamepad = reinterpret_cast<GamepadState*>(param);
@@ -777,21 +792,10 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
         state->supportedButtonFlags = supportedButtonFlags;
         state->capabilities = capabilities;
         state->type = type;
-        if (notifyHost) {
-            LiSendControllerArrivalEvent(state->index, m_GamepadMask, type,
-                                         supportedButtonFlags, capabilities);
-        }
-#else
-
-        // Send an empty event to tell the PC we've arrived
-        if (notifyHost) {
-            sendGamepadState(state);
-        }
 #endif
 
-        // Send a power level if it's known at this time
-        if (notifyHost && powerLevel != SDL_JOYSTICK_POWER_UNKNOWN) {
-            sendGamepadBatteryState(state, powerLevel);
+        if (notifyHost) {
+            sendGamepadArrival(state, powerLevel);
         }
     }
     else if (event->type == SDL_CONTROLLERDEVICEREMOVED) {
@@ -846,18 +850,9 @@ void SdlInputHandler::notifyHostOfConnectedGamepads()
 
         hasConnectedGamepad = true;
 
-#if SDL_VERSION_ATLEAST(2, 0, 14)
-        LiSendControllerArrivalEvent(state->index, m_GamepadMask, state->type,
-                                     state->supportedButtonFlags, state->capabilities);
-#else
-        sendGamepadState(state);
-#endif
-
         const SDL_JoystickPowerLevel powerLevel =
             SDL_JoystickCurrentPowerLevel(SDL_GameControllerGetJoystick(state->controller));
-        if (powerLevel != SDL_JOYSTICK_POWER_UNKNOWN) {
-            sendGamepadBatteryState(state, powerLevel);
-        }
+        sendGamepadArrival(state, powerLevel);
     }
 
     // A reconnect can race with removal of the final controller. Send an empty

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -1,4 +1,5 @@
 #include "streaming/session.h"
+#include "streaming/audio/dualsensehapticsrouting.h"
 
 #include <Limelight.h>
 #include "SDL_compat.h"
@@ -33,6 +34,28 @@ const int SdlInputHandler::k_ButtonMap[] = {
     PADDLE1_FLAG, PADDLE2_FLAG, PADDLE3_FLAG, PADDLE4_FLAG,
     TOUCHPAD_FLAG,
 };
+
+int SdlInputHandler::getNativeDualSenseControllerNumber() const
+{
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    dualsense_haptics::LocalControllerCandidate controllers[MAX_GAMEPADS];
+    std::size_t controllerCount = 0;
+    for (int i = 0; i < MAX_GAMEPADS; i++) {
+        if (m_GamepadState[i].controller == nullptr) {
+            continue;
+        }
+        controllers[controllerCount++] = {
+            m_GamepadState[i].index,
+            SDL_GameControllerGetType(m_GamepadState[i].controller) == SDL_CONTROLLER_TYPE_PS5,
+        };
+    }
+
+    return dualsense_haptics::selectUniqueLocalDualSense(
+        controllers, controllerCount, m_MultiController);
+#else
+    return -1;
+#endif
+}
 
 GamepadState*
 SdlInputHandler::findStateForGamepad(SDL_JoystickID id)
@@ -513,7 +536,7 @@ void SdlInputHandler::handleJoystickBatteryEvent(SDL_JoyBatteryEvent* event)
 
 #endif
 
-void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* event)
+void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* event, bool notifyHost)
 {
     GamepadState* state;
 
@@ -751,15 +774,23 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
 #endif
             type == LI_CTYPE_PS;
 
-        LiSendControllerArrivalEvent(state->index, m_GamepadMask, type, supportedButtonFlags, capabilities);
+        state->supportedButtonFlags = supportedButtonFlags;
+        state->capabilities = capabilities;
+        state->type = type;
+        if (notifyHost) {
+            LiSendControllerArrivalEvent(state->index, m_GamepadMask, type,
+                                         supportedButtonFlags, capabilities);
+        }
 #else
 
         // Send an empty event to tell the PC we've arrived
-        sendGamepadState(state);
+        if (notifyHost) {
+            sendGamepadState(state);
+        }
 #endif
 
         // Send a power level if it's known at this time
-        if (powerLevel != SDL_JOYSTICK_POWER_UNKNOWN) {
+        if (notifyHost && powerLevel != SDL_JOYSTICK_POWER_UNKNOWN) {
             sendGamepadBatteryState(state, powerLevel);
         }
     }
@@ -793,12 +824,46 @@ void SdlInputHandler::handleControllerDeviceEvent(SDL_ControllerDeviceEvent* eve
                         state->index);
 
             // Send a final event to let the PC know this gamepad is gone
-            LiSendMultiControllerEvent(state->index, m_GamepadMask,
-                                       0, 0, 0, 0, 0, 0, 0);
+            if (notifyHost) {
+                LiSendMultiControllerEvent(state->index, m_GamepadMask,
+                                           0, 0, 0, 0, 0, 0, 0);
+            }
 
             // Clear all remaining state from this slot
             SDL_memset(state, 0, sizeof(*state));
         }
+    }
+}
+
+void SdlInputHandler::notifyHostOfConnectedGamepads()
+{
+    bool hasConnectedGamepad = false;
+    for (int i = 0; i < MAX_GAMEPADS; i++) {
+        GamepadState* state = &m_GamepadState[i];
+        if (state->controller == nullptr) {
+            continue;
+        }
+
+        hasConnectedGamepad = true;
+
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+        LiSendControllerArrivalEvent(state->index, m_GamepadMask, state->type,
+                                     state->supportedButtonFlags, state->capabilities);
+#else
+        sendGamepadState(state);
+#endif
+
+        const SDL_JoystickPowerLevel powerLevel =
+            SDL_JoystickCurrentPowerLevel(SDL_GameControllerGetJoystick(state->controller));
+        if (powerLevel != SDL_JOYSTICK_POWER_UNKNOWN) {
+            sendGamepadBatteryState(state, powerLevel);
+        }
+    }
+
+    // A reconnect can race with removal of the final controller. Send an empty
+    // state so the host observes the current mask even when there is no arrival.
+    if (!hasConnectedGamepad) {
+        LiSendMultiControllerEvent(0, m_GamepadMask, 0, 0, 0, 0, 0, 0, 0);
     }
 }
 
@@ -901,6 +966,17 @@ void SdlInputHandler::rumbleTriggers(uint16_t controllerNumber, uint16_t leftTri
         SDL_GameControllerRumbleTriggers(m_GamepadState[controllerNumber].controller, leftTrigger, rightTrigger, 30000);
     }
 #endif
+}
+
+void SdlInputHandler::stopAllRumble()
+{
+    for (int i = 0; i < MAX_GAMEPADS; i++) {
+        if (m_GamepadState[i].controller == nullptr) {
+            continue;
+        }
+        rumble(i, 0, 0);
+        rumbleTriggers(i, 0, 0);
+    }
 }
 
 void SdlInputHandler::setMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz)

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -946,13 +946,19 @@ void SdlInputHandler::setControllerLED(uint16_t controllerNumber, uint8_t r, uin
 void SdlInputHandler::setAdaptiveTriggers(uint16_t controllerNumber, DualSenseOutputReport *report){
 
 #if SDL_VERSION_ATLEAST(2, 0, 16)
-        // Make sure the controller number is within our supported count
-    if (controllerNumber <= MAX_GAMEPADS &&
+    // Make sure the controller number is within our supported count
+    if (report != nullptr &&
+        controllerNumber < MAX_GAMEPADS &&
         // and we have a valid controller
         m_GamepadState[controllerNumber].controller != nullptr &&
         // and it's a PS5 controller
         SDL_GameControllerGetType(m_GamepadState[controllerNumber].controller) == SDL_CONTROLLER_TYPE_PS5) {
-        SDL_GameControllerSendEffect(m_GamepadState[controllerNumber].controller, report, sizeof(*report));
+        if (SDL_GameControllerSendEffect(m_GamepadState[controllerNumber].controller,
+                                         report, sizeof(*report)) < 0) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
+                        "Unable to send DualSense adaptive trigger effect: %s",
+                        SDL_GetError());
+        }
     }
 #endif
 

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -362,6 +362,7 @@ SdlInputHandler::~SdlInputHandler()
 #endif
     cancelNativeTouchpadContacts();
     resetRemoteCursor();
+    stopAllRumble();
 
     for (int i = 0; i < MAX_GAMEPADS; i++) {
         if (m_GamepadState[i].mouseEmulationTimer != 0) {

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -268,6 +268,8 @@ private:
 
     void sendGamepadBatteryState(GamepadState* state, SDL_JoystickPowerLevel level);
 
+    void sendGamepadArrival(GamepadState* state, SDL_JoystickPowerLevel powerLevel);
+
     void handleAbsoluteFingerEvent(SDL_TouchFingerEvent* event);
 
     void emulateAbsoluteFingerEvent(SDL_TouchFingerEvent* event);

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -23,6 +23,12 @@ struct GamepadState {
     SDL_JoystickID jsId;
     short index;
 
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    uint32_t supportedButtonFlags;
+    uint32_t capabilities;
+    uint8_t type;
+#endif
+
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_Haptic* haptic;
     int hapticMethod;
@@ -146,7 +152,9 @@ public:
 
     void handleControllerButtonEvent(SDL_ControllerButtonEvent* event);
 
-    void handleControllerDeviceEvent(SDL_ControllerDeviceEvent* event);
+    void handleControllerDeviceEvent(SDL_ControllerDeviceEvent* event, bool notifyHost = true);
+
+    void notifyHostOfConnectedGamepads();
 
 #if SDL_VERSION_ATLEAST(2, 0, 14)
     void handleControllerSensorEvent(SDL_ControllerSensorEvent* event);
@@ -166,11 +174,15 @@ public:
 
     void rumbleTriggers(uint16_t controllerNumber, uint16_t leftTrigger, uint16_t rightTrigger);
 
+    void stopAllRumble();
+
     void setMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz);
 
     void setControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b);
 
     void setAdaptiveTriggers(uint16_t controllerNumber, DualSenseOutputReport *report);
+
+    int getNativeDualSenseControllerNumber() const;
 
     void handleTouchFingerEvent(SDL_TouchFingerEvent* event);
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -767,6 +767,12 @@ void Session::clDs5HapticsIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2* frame)
         return;
     }
 
+    Session* session = s_ActiveSession;
+    if (session != nullptr && session->m_DualSenseHapticsRenderer != nullptr &&
+        session->m_DualSenseHapticsRenderer->submit(*frame)) {
+        return;
+    }
+
     // IR lanes preserve authored left/right intent, while SDL exposes the
     // common low/high-frequency motor model. Fold both lanes into spectral
     // energy here; device-specific renderers can replace this calibration.
@@ -825,6 +831,11 @@ void Session::clSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlag
     // Based on the following SDL code:
     // https://github.com/libsdl-org/SDL/blob/120c76c84bbce4c1bfed4e9eb74e10678bd83120/test/testgamecontroller.c#L286-L307
     DualSenseOutputReport *state = (DualSenseOutputReport *) SDL_malloc(sizeof(DualSenseOutputReport));
+    if (state == nullptr) {
+        SDL_LogError(SDL_LOG_CATEGORY_INPUT,
+                     "Unable to allocate DualSense adaptive trigger report");
+        return;
+    }
     SDL_zero(*state);
     state->validFlag0 = (eventFlags & DS_EFFECT_RIGHT_TRIGGER) | (eventFlags & DS_EFFECT_LEFT_TRIGGER);
     state->rightTriggerEffectType = typeRight;
@@ -833,7 +844,12 @@ void Session::clSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlag
     SDL_memcpy(state->leftTriggerEffect, left, sizeof(state->leftTriggerEffect));
 
     setControllerLEDEvent.user.data2 = (void *) state;
-    SDL_PushEvent(&setControllerLEDEvent);
+    if (SDL_PushEvent(&setControllerLEDEvent) <= 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_INPUT,
+                     "Unable to queue DualSense adaptive trigger effect: %s",
+                     SDL_GetError());
+        SDL_free(state);
+    }
 }
 
 
@@ -3671,6 +3687,11 @@ void Session::start()
 #endif
     }
     else {
+#ifdef Q_OS_MACOS
+        if (m_DualSenseHapticsRenderer == nullptr) {
+            m_DualSenseHapticsRenderer = new DualSenseHapticsRenderer();
+        }
+#endif
         k_ConnCallbacks.ds5HapticsIrV2 = Session::clDs5HapticsIrV2;
     }
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -78,6 +78,22 @@
 #include <utility>
 
 namespace {
+
+int SDLCALL keepNonRumbleEvent(void*, SDL_Event* event)
+{
+    return event->type != SDL_USEREVENT ||
+           (event->user.code != SDL_CODE_GAMECONTROLLER_RUMBLE &&
+            event->user.code != SDL_CODE_GAMECONTROLLER_RUMBLE_TRIGGERS);
+}
+
+void stopControllerRumbleAtConnectionBoundary(SdlInputHandler* inputHandler)
+{
+    SDL_FilterEvents(keepNonRumbleEvent, nullptr);
+    if (inputHandler != nullptr) {
+        inputHandler->stopAllRumble();
+    }
+}
+
 QRect qtWindowCreationGeometryForSdl(QWindow* window)
 {
     if (!window) {
@@ -768,8 +784,12 @@ void Session::clDs5HapticsIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2* frame)
     }
 
     Session* session = s_ActiveSession;
+    bool startedNative = false;
     if (session != nullptr && session->m_DualSenseHapticsRenderer != nullptr &&
-        session->m_DualSenseHapticsRenderer->submit(*frame)) {
+        session->m_DualSenseHapticsRenderer->submit(*frame, &startedNative)) {
+        if (startedNative) {
+            clRumble(frame->controllerNumber, 0, 0);
+        }
         return;
     }
 
@@ -1945,6 +1965,10 @@ private:
 
         // Finish cleanup of the connection state
         QMetaObject::invokeMethod(m_Session, &Session::stopMicrophone, Qt::BlockingQueuedConnection);
+        if (m_Session->m_DualSenseHapticsRenderer != nullptr) {
+            m_Session->m_DualSenseHapticsRenderer->setControllerTarget(-1);
+            m_Session->m_DualSenseHapticsRenderer->reset();
+        }
         LiStopConnection();
         delete m_Session->m_DualSenseHapticsRenderer;
         m_Session->m_DualSenseHapticsRenderer = nullptr;
@@ -3185,7 +3209,13 @@ bool Session::tryReconnect()
 
     // Stop ABR feedback (startConnectionAsync() restarts it) and the dead connection
     stopSunshineAbr();
+    stopControllerRumbleAtConnectionBoundary(m_InputHandler);
+    if (m_DualSenseHapticsRenderer != nullptr) {
+        m_DualSenseHapticsRenderer->setControllerTarget(-1);
+        m_DualSenseHapticsRenderer->reset();
+    }
     LiStopConnection();
+    stopControllerRumbleAtConnectionBoundary(m_InputHandler);
 
     // Total time budget for reconnect attempts before giving up
     const Uint32 graceMs = 60 * 1000;
@@ -3212,6 +3242,23 @@ bool Session::tryReconnect()
         return false;
     };
 
+    auto handleReconnectEvent = [this, &isCancelEvent](SDL_Event& ev) -> bool {
+        if (isCancelEvent(ev)) {
+            return true;
+        }
+
+        if (m_InputHandler != nullptr &&
+            (ev.type == SDL_CONTROLLERDEVICEADDED ||
+             ev.type == SDL_CONTROLLERDEVICEREMOVED)) {
+            m_InputHandler->handleControllerDeviceEvent(&ev.cdevice, false);
+            if (m_DualSenseHapticsRenderer != nullptr) {
+                m_DualSenseHapticsRenderer->setControllerTarget(
+                    m_InputHandler->getNativeDualSenseControllerNumber());
+            }
+        }
+        return false;
+    };
+
     while (!cancelled && SDL_GetTicks() - startTicks < graceMs) {
         // Update the on-screen indicator (re-shown each attempt so it stays up)
         Uint32 remainingMs = graceMs - (SDL_GetTicks() - startTicks);
@@ -3222,13 +3269,17 @@ bool Session::tryReconnect()
         // Run the connection start on a worker thread and pump events while we wait
         m_AsyncConnectionSuccess = false;
         m_HasReceivedVideo = false;
+        if (m_DualSenseHapticsRenderer != nullptr && m_InputHandler != nullptr) {
+            m_DualSenseHapticsRenderer->setControllerTarget(
+                m_InputHandler->getNativeDualSenseControllerNumber());
+        }
         AsyncConnectionStartThread thread(this);
         thread.start();
 
         while (thread.isRunning()) {
             SDL_Event ev;
             while (SDL_PollEvent(&ev)) {
-                if (isCancelEvent(ev)) {
+                if (handleReconnectEvent(ev)) {
                     cancelled = true;
                 }
             }
@@ -3251,20 +3302,27 @@ bool Session::tryReconnect()
                 m_ClipboardHelper->updateHostContext();
             }
             if (m_InputHandler != nullptr) {
+                m_InputHandler->notifyHostOfConnectedGamepads();
                 m_InputHandler->raiseAllKeys();
             }
             break;
         }
 
         // Failed: clean up the partial attempt and back off before retrying
+        stopControllerRumbleAtConnectionBoundary(m_InputHandler);
+        if (m_DualSenseHapticsRenderer != nullptr) {
+            m_DualSenseHapticsRenderer->setControllerTarget(-1);
+            m_DualSenseHapticsRenderer->reset();
+        }
         LiStopConnection();
+        stopControllerRumbleAtConnectionBoundary(m_InputHandler);
 
         Uint32 backoffUntil = SDL_GetTicks() + backoffMs;
         while (SDL_GetTicks() < backoffUntil &&
                SDL_GetTicks() - startTicks < graceMs) {
             SDL_Event ev;
             while (SDL_PollEvent(&ev)) {
-                if (isCancelEvent(ev)) {
+                if (handleReconnectEvent(ev)) {
                     cancelled = true;
                     break;
                 }
@@ -3699,6 +3757,10 @@ void Session::start()
     // NB: m_InputHandler must be initialized before starting the connection.
     m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width,
                                          m_StreamConfig.height, enablePhysicalDualSenseHaptics);
+    if (m_DualSenseHapticsRenderer != nullptr) {
+        m_DualSenseHapticsRenderer->setControllerTarget(
+            m_InputHandler->getNativeDualSenseControllerNumber());
+    }
 
     // Kick off the async connection thread then return to the caller to pump the event loop
     auto thread = new AsyncConnectionStartThread(this);
@@ -3790,6 +3852,9 @@ void Session::exec()
             m_ClipboardHelper->stop();
             delete m_ClipboardHelper;
             m_ClipboardHelper = nullptr;
+        }
+        if (m_DualSenseHapticsRenderer != nullptr) {
+            m_DualSenseHapticsRenderer->setControllerTarget(-1);
         }
         delete m_InputHandler;
         m_InputHandler = nullptr;
@@ -3922,6 +3987,9 @@ void Session::exec()
                 m_ClipboardHelper->stop();
                 delete m_ClipboardHelper;
                 m_ClipboardHelper = nullptr;
+            }
+            if (m_DualSenseHapticsRenderer != nullptr) {
+                m_DualSenseHapticsRenderer->setControllerTarget(-1);
             }
             delete m_InputHandler;
             m_InputHandler = nullptr;
@@ -4732,6 +4800,10 @@ void Session::exec()
         case SDL_CONTROLLERDEVICEADDED:
         case SDL_CONTROLLERDEVICEREMOVED:
             m_InputHandler->handleControllerDeviceEvent(&event.cdevice);
+            if (m_DualSenseHapticsRenderer != nullptr) {
+                m_DualSenseHapticsRenderer->setControllerTarget(
+                    m_InputHandler->getNativeDualSenseControllerNumber());
+            }
             break;
         case SDL_JOYDEVICEADDED:
             m_InputHandler->handleJoystickArrivalEvent(&event.jdevice);
@@ -4838,6 +4910,9 @@ DispatchDeferredCleanup:
     // Destroy the input handler now. This must be destroyed
     // before allowwing the UI to continue execution or it could
     // interfere with SDLGamepadKeyNavigation.
+    if (m_DualSenseHapticsRenderer != nullptr) {
+        m_DualSenseHapticsRenderer->setControllerTarget(-1);
+    }
     delete m_InputHandler;
     m_InputHandler = nullptr;
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1969,6 +1969,7 @@ private:
             m_Session->m_DualSenseHapticsRenderer->setControllerTarget(-1);
         }
         LiStopConnection();
+        stopControllerRumbleAtConnectionBoundary(nullptr);
         delete m_Session->m_DualSenseHapticsRenderer;
         m_Session->m_DualSenseHapticsRenderer = nullptr;
 
@@ -3862,6 +3863,7 @@ void Session::exec()
         if (m_DualSenseHapticsRenderer != nullptr) {
             m_DualSenseHapticsRenderer->setControllerTarget(-1);
         }
+        stopControllerRumbleAtConnectionBoundary(m_InputHandler);
         delete m_InputHandler;
         m_InputHandler = nullptr;
         SDL_QuitSubSystem(SDL_INIT_VIDEO);
@@ -3997,6 +3999,7 @@ void Session::exec()
             if (m_DualSenseHapticsRenderer != nullptr) {
                 m_DualSenseHapticsRenderer->setControllerTarget(-1);
             }
+            stopControllerRumbleAtConnectionBoundary(m_InputHandler);
             delete m_InputHandler;
             m_InputHandler = nullptr;
             SDL_QuitSubSystem(SDL_INIT_VIDEO);
@@ -4926,6 +4929,7 @@ DispatchDeferredCleanup:
     if (m_DualSenseHapticsRenderer != nullptr) {
         m_DualSenseHapticsRenderer->setControllerTarget(-1);
     }
+    stopControllerRumbleAtConnectionBoundary(m_InputHandler);
     delete m_InputHandler;
     m_InputHandler = nullptr;
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -786,7 +786,7 @@ void Session::clDs5HapticsIrV2(const LI_DS5_HAPTICS_IR_FRAME_V2* frame)
     Session* session = s_ActiveSession;
     bool startedNative = false;
     if (session != nullptr && session->m_DualSenseHapticsRenderer != nullptr &&
-        session->m_DualSenseHapticsRenderer->submit(*frame, &startedNative)) {
+        session->m_DualSenseHapticsRenderer->submit(*frame, startedNative)) {
         if (startedNative) {
             clRumble(frame->controllerNumber, 0, 0);
         }
@@ -1967,7 +1967,6 @@ private:
         QMetaObject::invokeMethod(m_Session, &Session::stopMicrophone, Qt::BlockingQueuedConnection);
         if (m_Session->m_DualSenseHapticsRenderer != nullptr) {
             m_Session->m_DualSenseHapticsRenderer->setControllerTarget(-1);
-            m_Session->m_DualSenseHapticsRenderer->reset();
         }
         LiStopConnection();
         delete m_Session->m_DualSenseHapticsRenderer;
@@ -3173,6 +3172,15 @@ void Session::notifyMouseEmulationMode(bool enabled)
     }
 }
 
+void Session::updateDualSenseHapticsControllerTarget()
+{
+    if (m_DualSenseHapticsRenderer != nullptr) {
+        m_DualSenseHapticsRenderer->setControllerTarget(
+            m_InputHandler != nullptr ?
+                m_InputHandler->getNativeDualSenseControllerNumber() : -1);
+    }
+}
+
 class AsyncConnectionStartThread : public QThread
 {
 public:
@@ -3212,10 +3220,12 @@ bool Session::tryReconnect()
     stopControllerRumbleAtConnectionBoundary(m_InputHandler);
     if (m_DualSenseHapticsRenderer != nullptr) {
         m_DualSenseHapticsRenderer->setControllerTarget(-1);
-        m_DualSenseHapticsRenderer->reset();
     }
     LiStopConnection();
     stopControllerRumbleAtConnectionBoundary(m_InputHandler);
+    if (m_DualSenseHapticsRenderer != nullptr) {
+        m_DualSenseHapticsRenderer->reset();
+    }
 
     // Total time budget for reconnect attempts before giving up
     const Uint32 graceMs = 60 * 1000;
@@ -3251,10 +3261,7 @@ bool Session::tryReconnect()
             (ev.type == SDL_CONTROLLERDEVICEADDED ||
              ev.type == SDL_CONTROLLERDEVICEREMOVED)) {
             m_InputHandler->handleControllerDeviceEvent(&ev.cdevice, false);
-            if (m_DualSenseHapticsRenderer != nullptr) {
-                m_DualSenseHapticsRenderer->setControllerTarget(
-                    m_InputHandler->getNativeDualSenseControllerNumber());
-            }
+            updateDualSenseHapticsControllerTarget();
         }
         return false;
     };
@@ -3269,10 +3276,7 @@ bool Session::tryReconnect()
         // Run the connection start on a worker thread and pump events while we wait
         m_AsyncConnectionSuccess = false;
         m_HasReceivedVideo = false;
-        if (m_DualSenseHapticsRenderer != nullptr && m_InputHandler != nullptr) {
-            m_DualSenseHapticsRenderer->setControllerTarget(
-                m_InputHandler->getNativeDualSenseControllerNumber());
-        }
+        updateDualSenseHapticsControllerTarget();
         AsyncConnectionStartThread thread(this);
         thread.start();
 
@@ -3312,10 +3316,12 @@ bool Session::tryReconnect()
         stopControllerRumbleAtConnectionBoundary(m_InputHandler);
         if (m_DualSenseHapticsRenderer != nullptr) {
             m_DualSenseHapticsRenderer->setControllerTarget(-1);
-            m_DualSenseHapticsRenderer->reset();
         }
         LiStopConnection();
         stopControllerRumbleAtConnectionBoundary(m_InputHandler);
+        if (m_DualSenseHapticsRenderer != nullptr) {
+            m_DualSenseHapticsRenderer->reset();
+        }
 
         Uint32 backoffUntil = SDL_GetTicks() + backoffMs;
         while (SDL_GetTicks() < backoffUntil &&
@@ -3757,10 +3763,7 @@ void Session::start()
     // NB: m_InputHandler must be initialized before starting the connection.
     m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width,
                                          m_StreamConfig.height, enablePhysicalDualSenseHaptics);
-    if (m_DualSenseHapticsRenderer != nullptr) {
-        m_DualSenseHapticsRenderer->setControllerTarget(
-            m_InputHandler->getNativeDualSenseControllerNumber());
-    }
+    updateDualSenseHapticsControllerTarget();
 
     // Kick off the async connection thread then return to the caller to pump the event loop
     auto thread = new AsyncConnectionStartThread(this);
@@ -4800,10 +4803,7 @@ void Session::exec()
         case SDL_CONTROLLERDEVICEADDED:
         case SDL_CONTROLLERDEVICEREMOVED:
             m_InputHandler->handleControllerDeviceEvent(&event.cdevice);
-            if (m_DualSenseHapticsRenderer != nullptr) {
-                m_DualSenseHapticsRenderer->setControllerTarget(
-                    m_InputHandler->getNativeDualSenseControllerNumber());
-            }
+            updateDualSenseHapticsControllerTarget();
             break;
         case SDL_JOYDEVICEADDED:
             m_InputHandler->handleJoystickArrivalEvent(&event.jdevice);

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -3178,6 +3178,75 @@ void Session::updateDualSenseHapticsControllerTarget()
     }
 }
 
+void Session::handleSdlUserEvent(const SDL_UserEvent& event)
+{
+    switch (event.code) {
+    case SDL_CODE_FRAME_READY:
+        if (m_VideoDecoder != nullptr) {
+            m_VideoDecoder->renderFrameOnMainThread();
+        }
+        break;
+    case SDL_CODE_FLUSH_WINDOW_EVENT_BARRIER:
+        m_FlushingWindowEventsRef--;
+        break;
+    case SDL_CODE_GAMECONTROLLER_RUMBLE:
+        m_InputHandler->rumble((uint16_t)(uintptr_t)event.data1,
+                               (uint16_t)((uintptr_t)event.data2 >> 16),
+                               (uint16_t)((uintptr_t)event.data2 & 0xFFFF));
+        break;
+    case SDL_CODE_GAMECONTROLLER_RUMBLE_TRIGGERS:
+        m_InputHandler->rumbleTriggers((uint16_t)(uintptr_t)event.data1,
+                                       (uint16_t)((uintptr_t)event.data2 >> 16),
+                                       (uint16_t)((uintptr_t)event.data2 & 0xFFFF));
+        break;
+    case SDL_CODE_GAMECONTROLLER_SET_MOTION_EVENT_STATE:
+        m_InputHandler->setMotionEventState((uint16_t)(uintptr_t)event.data1,
+                                            (uint8_t)((uintptr_t)event.data2 >> 16),
+                                            (uint16_t)((uintptr_t)event.data2 & 0xFFFF));
+        break;
+    case SDL_CODE_GAMECONTROLLER_SET_CONTROLLER_LED:
+        m_InputHandler->setControllerLED((uint16_t)(uintptr_t)event.data1,
+                                         (uint8_t)((uintptr_t)event.data2 >> 16),
+                                         (uint8_t)((uintptr_t)event.data2 >> 8),
+                                         (uint8_t)((uintptr_t)event.data2));
+        break;
+    case SDL_CODE_GAMECONTROLLER_SET_ADAPTIVE_TRIGGERS:
+        m_InputHandler->setAdaptiveTriggers((uint16_t)(uintptr_t)event.data1,
+                                            (DualSenseOutputReport *)event.data2);
+        break;
+    case SDL_CODE_FLUSH_TOUCHPAD_FRAME:
+        m_InputHandler->flushPendingTouchpadFrameEvent();
+        break;
+    case SDL_CODE_FLUSH_CURSOR_VISIBILITY:
+        if (m_InputHandler != nullptr) {
+            m_InputHandler->flushPendingRemoteCursorHide();
+        }
+        break;
+    case SDL_CODE_CURSOR_UPDATE:
+    {
+        std::shared_ptr<RemoteCursorUpdate> cursorUpdate;
+        {
+            std::lock_guard<std::mutex> lock(m_CursorUpdateMutex);
+            cursorUpdate.swap(m_PendingCursorUpdate);
+            m_CursorUpdateEventQueued = false;
+        }
+        if (cursorUpdate != nullptr && m_InputHandler != nullptr) {
+            m_InputHandler->updateRemoteCursor(*cursorUpdate);
+        }
+        break;
+    }
+#ifdef Q_OS_WIN32
+    case SDL_CODE_PROCESS_QT_OVERLAY_EVENTS:
+        // The actual Qt processing happens after SDL dispatch below.
+        // Keeping this event side-effect free also coalesces bursts of
+        // native button messages without re-entering Qt from Win32.
+        break;
+#endif
+    default:
+        SDL_assert(false);
+    }
+}
+
 class AsyncConnectionStartThread : public QThread
 {
 public:
@@ -3252,6 +3321,11 @@ bool Session::tryReconnect()
     auto handleReconnectEvent = [this, &isCancelEvent](SDL_Event& ev) -> bool {
         if (isCancelEvent(ev)) {
             return true;
+        }
+
+        if (ev.type == SDL_USEREVENT) {
+            handleSdlUserEvent(ev.user);
+            return false;
         }
 
         if (m_InputHandler != nullptr &&
@@ -4375,71 +4449,7 @@ void Session::exec()
             goto DispatchDeferredCleanup;
 
         case SDL_USEREVENT:
-            switch (event.user.code) {
-            case SDL_CODE_FRAME_READY:
-                if (m_VideoDecoder != nullptr) {
-                    m_VideoDecoder->renderFrameOnMainThread();
-                }
-                break;
-            case SDL_CODE_FLUSH_WINDOW_EVENT_BARRIER:
-                m_FlushingWindowEventsRef--;
-                break;
-            case SDL_CODE_GAMECONTROLLER_RUMBLE:
-                m_InputHandler->rumble((uint16_t)(uintptr_t)event.user.data1,
-                                       (uint16_t)((uintptr_t)event.user.data2 >> 16),
-                                       (uint16_t)((uintptr_t)event.user.data2 & 0xFFFF));
-                break;
-            case SDL_CODE_GAMECONTROLLER_RUMBLE_TRIGGERS:
-                m_InputHandler->rumbleTriggers((uint16_t)(uintptr_t)event.user.data1,
-                                               (uint16_t)((uintptr_t)event.user.data2 >> 16),
-                                               (uint16_t)((uintptr_t)event.user.data2 & 0xFFFF));
-                break;
-            case SDL_CODE_GAMECONTROLLER_SET_MOTION_EVENT_STATE:
-                m_InputHandler->setMotionEventState((uint16_t)(uintptr_t)event.user.data1,
-                                                    (uint8_t)((uintptr_t)event.user.data2 >> 16),
-                                                    (uint16_t)((uintptr_t)event.user.data2 & 0xFFFF));
-                break;
-            case SDL_CODE_GAMECONTROLLER_SET_CONTROLLER_LED:
-                m_InputHandler->setControllerLED((uint16_t)(uintptr_t)event.user.data1,
-                                                 (uint8_t)((uintptr_t)event.user.data2 >> 16),
-                                                 (uint8_t)((uintptr_t)event.user.data2 >> 8),
-                                                 (uint8_t)((uintptr_t)event.user.data2));
-                break;
-            case SDL_CODE_GAMECONTROLLER_SET_ADAPTIVE_TRIGGERS:
-                m_InputHandler->setAdaptiveTriggers((uint16_t)(uintptr_t)event.user.data1,
-                                                    (DualSenseOutputReport *)event.user.data2);
-                break;
-            case SDL_CODE_FLUSH_TOUCHPAD_FRAME:
-                m_InputHandler->flushPendingTouchpadFrameEvent();
-                break;
-            case SDL_CODE_FLUSH_CURSOR_VISIBILITY:
-                if (m_InputHandler != nullptr) {
-                    m_InputHandler->flushPendingRemoteCursorHide();
-                }
-                break;
-            case SDL_CODE_CURSOR_UPDATE:
-            {
-                std::shared_ptr<RemoteCursorUpdate> cursorUpdate;
-                {
-                    std::lock_guard<std::mutex> lock(m_CursorUpdateMutex);
-                    cursorUpdate.swap(m_PendingCursorUpdate);
-                    m_CursorUpdateEventQueued = false;
-                }
-                if (cursorUpdate != nullptr && m_InputHandler != nullptr) {
-                    m_InputHandler->updateRemoteCursor(*cursorUpdate);
-                }
-                break;
-            }
-#ifdef Q_OS_WIN32
-            case SDL_CODE_PROCESS_QT_OVERLAY_EVENTS:
-                // The actual Qt processing happens after SDL dispatch below.
-                // Keeping this event side-effect free also coalesces bursts of
-                // native button messages without re-entering Qt from Win32.
-                break;
-#endif
-            default:
-                SDL_assert(false);
-            }
+            handleSdlUserEvent(event.user);
             break;
 
         case SDL_WINDOWEVENT:

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -178,6 +178,8 @@ private:
     // unexpected network interruption. Returns true if streaming resumed.
     bool tryReconnect();
 
+    void updateDualSenseHapticsControllerTarget();
+
     // Emit the appropriate error dialog for a connection termination code.
     void displayTerminationError(int errorCode);
 

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -178,6 +178,8 @@ private:
     // unexpected network interruption. Returns true if streaming resumed.
     bool tryReconnect();
 
+    void handleSdlUserEvent(const SDL_UserEvent& event);
+
     void updateDualSenseHapticsControllerTarget();
 
     // Emit the appropriate error dialog for a connection termination code.

--- a/tests/ds5_ir_renderer/main.cpp
+++ b/tests/ds5_ir_renderer/main.cpp
@@ -58,10 +58,6 @@ int main()
     CHECK(!dualsense_haptics::canUseNativeController(1, -1, 1));
     CHECK(!dualsense_haptics::canUseNativeController(1, 1, 0));
     CHECK(!dualsense_haptics::canUseNativeController(1, 1, 2));
-    CHECK(dualsense_haptics::canKeepNativeState(1, 1, 1, true));
-    CHECK(!dualsense_haptics::canKeepNativeState(1, 1, 2, true));
-    CHECK(!dualsense_haptics::canKeepNativeState(1, 1, 1, false));
-
     dualsense_haptics::IrBackendLatch backendLatch;
     CHECK(backendLatch.shouldAttemptNative(1, false));
     backendLatch.useFallback(1);
@@ -79,27 +75,6 @@ int main()
     backendLatch.reset();
     CHECK(backendLatch.shouldAttemptNative(0, false));
     CHECK(backendLatch.shouldAttemptNative(1, false));
-
-    using LeaseTracker = dualsense_haptics::NativeStateLeaseTracker;
-    using namespace std::chrono_literals;
-    LeaseTracker leases(250ms);
-    const auto leaseStart = LeaseTracker::TimePoint{};
-    CHECK(!leases.nextDeadline().has_value());
-    leases.renew(0, leaseStart);
-    CHECK(leases.nextDeadline() == leaseStart + 250ms);
-    leases.renew(0, leaseStart + 100ms);
-    CHECK(leases.takeExpired(leaseStart + 250ms).empty());
-    leases.renew(1, leaseStart);
-    const auto expiredLease = leases.takeExpired(leaseStart + 251ms);
-    CHECK(expiredLease.size() == 1);
-    CHECK(expiredLease[0] == 1);
-    CHECK(leases.takeExpired(leaseStart + 350ms).size() == 1);
-    leases.renew(0, leaseStart);
-    leases.remove(0);
-    CHECK(!leases.nextDeadline().has_value());
-    leases.renew(0, leaseStart);
-    leases.clear();
-    CHECK(!leases.nextDeadline().has_value());
 
     using Action = dualsense_haptics::PcmStreamTracker::Action;
     dualsense_haptics::PcmStreamTracker tracker;

--- a/tests/ds5_ir_renderer/main.cpp
+++ b/tests/ds5_ir_renderer/main.cpp
@@ -15,10 +15,20 @@ int main()
     CHECK(active.lowFrequency > 0);
     CHECK(active.highFrequency > 0);
 
+    const auto native = dualsense_haptics::renderIrV2Native(frame);
+    CHECK(native.left.intensity > 0.0f);
+    CHECK(native.right.intensity > 0.0f);
+    CHECK(native.left.sharpness < native.right.sharpness);
+    CHECK(native.left.intensity <= 1.0f);
+    CHECK(native.right.intensity <= 1.0f);
+
     frame.flags = LI_DS5_HAPTICS_IR_FLAG_STREAM_END;
     const auto ended = dualsense_haptics::renderIrV2(frame);
     CHECK(ended.lowFrequency == 0);
     CHECK(ended.highFrequency == 0);
+    const auto nativeEnded = dualsense_haptics::renderIrV2Native(frame);
+    CHECK(nativeEnded.left.intensity == 0.0f);
+    CHECK(nativeEnded.right.intensity == 0.0f);
 
     using Action = dualsense_haptics::PcmStreamTracker::Action;
     dualsense_haptics::PcmStreamTracker tracker;

--- a/tests/ds5_ir_renderer/main.cpp
+++ b/tests/ds5_ir_renderer/main.cpp
@@ -1,4 +1,5 @@
 #include "streaming/audio/dualsensehapticscalibration.h"
+#include "streaming/audio/dualsensehapticsrouting.h"
 #include "streaming/audio/dualsensehapticsstream.h"
 
 #define CHECK(condition) do { if (!(condition)) return __LINE__; } while (false)
@@ -29,6 +30,76 @@ int main()
     const auto nativeEnded = dualsense_haptics::renderIrV2Native(frame);
     CHECK(nativeEnded.left.intensity == 0.0f);
     CHECK(nativeEnded.right.intensity == 0.0f);
+
+    frame.flags = LI_DS5_HAPTICS_IR_FLAG_SILENT;
+    const auto silent = dualsense_haptics::renderIrV2(frame);
+    CHECK(silent.lowFrequency == 0);
+    CHECK(silent.highFrequency == 0);
+    const auto nativeSilent = dualsense_haptics::renderIrV2Native(frame);
+    CHECK(nativeSilent.left.intensity == 0.0f);
+    CHECK(nativeSilent.right.intensity == 0.0f);
+
+    using Candidate = dualsense_haptics::LocalControllerCandidate;
+    const Candidate singleDualSense[] = {{0, true}};
+    CHECK(dualsense_haptics::selectUniqueLocalDualSense(singleDualSense, 1, true) == 0);
+    CHECK(dualsense_haptics::selectUniqueLocalDualSense(singleDualSense, 1, false) == 0);
+
+    const Candidate mixedControllers[] = {{0, false}, {1, true}};
+    CHECK(dualsense_haptics::selectUniqueLocalDualSense(mixedControllers, 2, true) == 1);
+    const Candidate mergedControllers[] = {{0, false}, {0, true}};
+    CHECK(dualsense_haptics::selectUniqueLocalDualSense(mergedControllers, 2, false) == -1);
+
+    const Candidate twoDualSense[] = {{0, true}, {1, true}};
+    CHECK(dualsense_haptics::selectUniqueLocalDualSense(twoDualSense, 2, true) == -1);
+    CHECK(dualsense_haptics::selectUniqueLocalDualSense(nullptr, 0, true) == -1);
+
+    CHECK(!dualsense_haptics::canUseNativeController(0, 1, 1));
+    CHECK(dualsense_haptics::canUseNativeController(1, 1, 1));
+    CHECK(!dualsense_haptics::canUseNativeController(1, -1, 1));
+    CHECK(!dualsense_haptics::canUseNativeController(1, 1, 0));
+    CHECK(!dualsense_haptics::canUseNativeController(1, 1, 2));
+    CHECK(dualsense_haptics::canKeepNativeState(1, 1, 1, true));
+    CHECK(!dualsense_haptics::canKeepNativeState(1, 1, 2, true));
+    CHECK(!dualsense_haptics::canKeepNativeState(1, 1, 1, false));
+
+    dualsense_haptics::IrBackendLatch backendLatch;
+    CHECK(backendLatch.shouldAttemptNative(1, false));
+    backendLatch.useFallback(1);
+    CHECK(!backendLatch.shouldAttemptNative(1, false));
+    CHECK(!backendLatch.shouldAttemptNative(1, false));
+    backendLatch.useFallback(0);
+    CHECK(!backendLatch.shouldAttemptNative(0, false));
+    CHECK(!backendLatch.shouldAttemptNative(1, true));
+    CHECK(backendLatch.shouldAttemptNative(1, false));
+    CHECK(!backendLatch.shouldAttemptNative(0, false));
+    CHECK(!backendLatch.shouldAttemptNative(0, true));
+    CHECK(backendLatch.shouldAttemptNative(0, false));
+    backendLatch.useFallback(0);
+    backendLatch.useFallback(1);
+    backendLatch.reset();
+    CHECK(backendLatch.shouldAttemptNative(0, false));
+    CHECK(backendLatch.shouldAttemptNative(1, false));
+
+    using LeaseTracker = dualsense_haptics::NativeStateLeaseTracker;
+    using namespace std::chrono_literals;
+    LeaseTracker leases(250ms);
+    const auto leaseStart = LeaseTracker::TimePoint{};
+    CHECK(!leases.nextDeadline().has_value());
+    leases.renew(0, leaseStart);
+    CHECK(leases.nextDeadline() == leaseStart + 250ms);
+    leases.renew(0, leaseStart + 100ms);
+    CHECK(leases.takeExpired(leaseStart + 250ms).empty());
+    leases.renew(1, leaseStart);
+    const auto expiredLease = leases.takeExpired(leaseStart + 251ms);
+    CHECK(expiredLease.size() == 1);
+    CHECK(expiredLease[0] == 1);
+    CHECK(leases.takeExpired(leaseStart + 350ms).size() == 1);
+    leases.renew(0, leaseStart);
+    leases.remove(0);
+    CHECK(!leases.nextDeadline().has_value());
+    leases.renew(0, leaseStart);
+    leases.clear();
+    CHECK(!leases.nextDeadline().has_value());
 
     using Action = dualsense_haptics::PcmStreamTracker::Action;
     dualsense_haptics::PcmStreamTracker tracker;


### PR DESCRIPTION
## 改了啥呀

- 用 macOS GameController + Core Haptics，把 DS5 IR v2 的左右声道分别渲染到 DualSense 左右握把；其他平台和 PCM 路径不变
- 只在 SDL 侧能唯一定位一个逻辑 DualSense、GameController 侧也恰好只有一个 DualSense 时启用原生路径；映射不唯一就老实回退 SDL，不乱震别人的手柄
- 为每个 IR stream 锁存 native / fallback 选择；原生初始化或更新失败后保持 fallback 到 `STREAM_END`，避免同一条流在两个 backend 间反复横跳
- 把原先预付给“多 native 手柄”的 state 字典和 lease map 收敛成一个 retained state、一个 controller id 和一个 deadline，少掉一百多行杂鱼复杂度
- 保留 250 ms watchdog：IR 包每 5 ms 到达，但结束包可能丢失，超时会停止无限 Core Haptics player；engine stop/reset 也会使 state 失效并安全重建
- 重连边界会停止并过滤旧 SDL rumble、关闭 native target，连接停止后清掉旧 stream latch；成功重连时重新上报 controller mask、能力和电量
- 重连等待期间复用正常主循环的 SDL user-event consumer，避免丢掉 cursor mailbox、自适应扳机 report ownership，以及 rumble、LED、motion、touchpad/window flush barrier 等合并事件状态
- 补齐自适应扳机事件的 controller index、内存分配和 SDL 入队失败处理

## 为啥要改

macOS 明明原生认识 DualSense，之前这条杂鱼路径却只会把 authored IR 折成普通双马达振动，左右与频谱细节都会丢。这个 PR 让 IR v2 使用系统原生触觉执行器，同时对无法可靠建立 SDL / GameController 身份映射的情况保持保守 fallback。

原实现为了理论上的多 native controller 同时维护多份 Objective-C state 和 lease。实际路由规则本来就只允许唯一 DualSense，因此现在按真实不变量实现成单 state；watchdog 和 stream latch 则是防止无限振动、双 backend 混用所必需的复杂度，没有继续乱砍呀。

当前范围不冒充 Windows 的 raw PCM passthrough：macOS 原生路径消费 Moonlight 已有的 IR v2 描述，PCM 模式仍保持 Windows 专用。

## 验证

- `qmake tests/ds5_ir_renderer/ds5_ir_renderer.pro && make -j4 && ./ds5_ir_renderer_test`
- 同一单测使用 Clang ASan + UBSan：`-fsanitize=address,undefined -fno-omit-frame-pointer`，`ASAN_OPTIONS=detect_leaks=0`
- macOS arm64：`qmake moonlight-qt.pro && make -j4`
- Clang Static Analyzer：`osx.cocoa.RetainCount,core`，无诊断
- `git diff --check`

以上在不连接手柄时可以验证编译、纯逻辑路由、fallback latch、资源所有权和大部分生命周期，所以这部分不需要为了过 PR 硬接控制器。仍需真机验收 USB / 蓝牙两种连接、左右 locality 是否符合实体握把、实际强度/锐度、延迟和长时间热插拔；别只盯着绿勾就宣布手感无敌了，杂鱼～

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native DualSense haptic feedback support on macOS using Core Haptics.
  - Improved IR audio haptics with independent intensity and sharpness control for each side.
  - Physical haptics are preferred before falling back to rumble.
  - Improved controller selection and haptic routing during connections and reconnects.

- **Bug Fixes**
  - Improved adaptive-trigger safety and controller validation.
  - Silent and ended streams no longer produce unwanted haptic output.
  - Haptic effects now stop and clean up correctly when streams end or controllers change.
  - Improved controller connection notifications and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
