### PR TITLE
fix(hdr): propagate client SDR white level

### DIFF
--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -287,6 +287,14 @@ NvHTTP::startApp(QString verb,
                  "&minBrightness="+QString::number(remoteStreamConfig.minBrightness, 'f', 6)+
                  "&maxAverageBrightness="+QString::number(remoteStreamConfig.maxAverageBrightness, 'f', 3);
     }
+    if (remoteStreamConfig.sdrWhiteBrightness >= 50.0f &&
+            remoteStreamConfig.sdrWhiteBrightness <= 1000.0f) {
+        // Foundation Sunshine parses this extension as an integer number of
+        // nits. It uses the value to re-anchor SDR-referred content before
+        // converting the host's scRGB desktop to the negotiated HDR transfer.
+        query += "&sdrBrightness="+
+                 QString::number(qRound(remoteStreamConfig.sdrWhiteBrightness));
+    }
 
     query += LiGetLaunchUrlQueryParameters();
 

--- a/app/backend/remotecomputer.h
+++ b/app/backend/remotecomputer.h
@@ -12,12 +12,14 @@ public:
     float maxBrightness;
     float minBrightness;
     float maxAverageBrightness;
+    float sdrWhiteBrightness;
 
     RemoteStreamConfig(
         bool remoteResolution, int remoteResolutionWidth, int remoteResolutionHeight,
         bool remoteFps, int remoteFpsRate,
         int originalStreamWidth, int originalStreamHeight,
-        float maxBrightness = 0, float minBrightness = 0, float maxAverageBrightness = 0)
+        float maxBrightness = 0, float minBrightness = 0, float maxAverageBrightness = 0,
+        float sdrWhiteBrightness = 0)
     {
         this->remoteResolution = remoteResolution;
         this->remoteResolutionWidth = remoteResolutionWidth;
@@ -29,5 +31,6 @@ public:
         this->maxBrightness = maxBrightness;
         this->minBrightness = minBrightness;
         this->maxAverageBrightness = maxAverageBrightness;
+        this->sdrWhiteBrightness = sdrWhiteBrightness;
     }
 };

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -4500,12 +4500,15 @@ void Session::exec()
         lastSdrWhiteCheckTicks = now;
 
         const int displayIndex = SDL_GetWindowDisplayIndex(m_Window);
-        const char* displayName = displayIndex >= 0 ? SDL_GetDisplayName(displayIndex) : nullptr;
-        if (displayName == nullptr) {
+        QScreen* clientScreen = qtScreenForSdlDisplay(displayIndex);
+        if (clientScreen == nullptr || clientScreen->name().isEmpty()) {
             return;
         }
 
-        const float nits = queryDisplaySdrWhiteNits(QString::fromUtf8(displayName), false);
+        // SDL exposes a friendly monitor name on Windows, while DisplayConfig
+        // source paths use the GDI device name (for example, \\.\DISPLAY1).
+        // QScreen::name() is the latter, so resolve the SDL display first.
+        const float nits = queryDisplaySdrWhiteNits(clientScreen->name(), false);
         if (nits < 50.0f || qAbs(nits - m_LastClientSdrWhiteNits) < 0.5f) {
             return;
         }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -122,7 +122,14 @@ QRect qtWindowCreationGeometryForSdl(QWindow* window)
 #endif
 }
 
-QScreen* qtScreenForSdlDisplay(int displayIndex)
+enum class SdlDisplayMatchPolicy
+{
+    AllowFallback,
+    ExactOnly,
+};
+
+QScreen* qtScreenForSdlDisplay(int displayIndex,
+                               SdlDisplayMatchPolicy matchPolicy = SdlDisplayMatchPolicy::AllowFallback)
 {
     if (displayIndex < 0) {
         return nullptr;
@@ -168,14 +175,20 @@ QScreen* qtScreenForSdlDisplay(int displayIndex)
             }
         }
 
-        if (QScreen* cursorScreen = QGuiApplication::screenAt(QCursor::pos())) {
-            if (sizeMatches.contains(cursorScreen)) {
-                return cursorScreen;
-            }
-        }
         if (sizeMatches.size() == 1) {
             return sizeMatches.first();
         }
+        if (matchPolicy == SdlDisplayMatchPolicy::AllowFallback) {
+            if (QScreen* cursorScreen = QGuiApplication::screenAt(QCursor::pos())) {
+                if (sizeMatches.contains(cursorScreen)) {
+                    return cursorScreen;
+                }
+            }
+        }
+    }
+
+    if (matchPolicy == SdlDisplayMatchPolicy::ExactOnly) {
+        return nullptr;
     }
 
     if (QScreen* cursorScreen = QGuiApplication::screenAt(QCursor::pos())) {
@@ -4500,7 +4513,8 @@ void Session::exec()
         lastSdrWhiteCheckTicks = now;
 
         const int displayIndex = SDL_GetWindowDisplayIndex(m_Window);
-        QScreen* clientScreen = qtScreenForSdlDisplay(displayIndex);
+        QScreen* clientScreen = qtScreenForSdlDisplay(
+            displayIndex, SdlDisplayMatchPolicy::ExactOnly);
         if (clientScreen == nullptr || clientScreen->name().isEmpty()) {
             return;
         }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -76,6 +76,7 @@
 #include <QUrl>
 
 #include <utility>
+#include <vector>
 
 namespace {
 
@@ -1195,6 +1196,7 @@ Session::Session(NvComputer* computer,
       m_HasReceivedVideo(false),
       m_LastTerminationErrorCode(0),
       m_AsyncConnectionSuccess(false),
+      m_LastClientSdrWhiteNits(0.0f),
       m_PortTestResults(0),
       m_OpusDecoder(nullptr),
       m_AudioRenderer(nullptr),
@@ -1248,6 +1250,13 @@ Session::~Session()
 bool Session::initialize(QQuickWindow* qtWindow)
 {
     m_QtWindow = qtWindow;
+#ifdef Q_OS_WIN32
+    // Capture this on the Qt thread. The launch request is assembled later on
+    // a worker thread, where reading QWindow/QScreen state would be unsafe.
+    if (m_QtWindow != nullptr && m_QtWindow->screen() != nullptr) {
+        m_ClientDisplayName = m_QtWindow->screen()->name();
+    }
+#endif
 
     // SDL reads this hint when the video subsystem initializes. Configure it for
     // each session so preference changes take effect on the next stream without
@@ -3594,8 +3603,22 @@ bool Session::startConnectionAsync()
 
     QString rtspSessionUrl;
 
-    // Resolve the HDR brightness profile for Foundation Sunshine.
+    // Resolve the HDR brightness profile for Foundation Sunshine. SDR white
+    // is independent from the mastering-luminance tuple: the host needs it
+    // even when peak/min/full-frame brightness uses host defaults or a manual
+    // profile.
     float maxBrightness = 0, minBrightness = 0, maxAverageBrightness = 0;
+    float detectedMaxBrightness = 0, detectedMinBrightness = 0;
+    float detectedMaxAverageBrightness = 0, sdrWhiteBrightness = 0;
+#ifdef Q_OS_WIN32
+    if (m_StreamConfig.hdrMode != 0) {
+        queryDisplayHdrBrightness(m_ClientDisplayName,
+                                  detectedMaxBrightness,
+                                  detectedMinBrightness,
+                                  detectedMaxAverageBrightness,
+                                  sdrWhiteBrightness);
+    }
+#endif
     switch (m_Preferences->hdrBrightnessMode) {
     case StreamingPreferences::HBM_MANUAL:
         maxBrightness = static_cast<float>(m_Preferences->hdrMaxBrightness);
@@ -3613,7 +3636,9 @@ bool Session::startConnectionAsync()
         break;
     case StreamingPreferences::HBM_AUTO:
 #ifdef Q_OS_WIN32
-        queryDisplayHdrBrightness(maxBrightness, minBrightness, maxAverageBrightness);
+        maxBrightness = detectedMaxBrightness;
+        minBrightness = detectedMinBrightness;
+        maxAverageBrightness = detectedMaxAverageBrightness;
 #endif
         break;
     case StreamingPreferences::HBM_HOST_DEFAULT:
@@ -3633,8 +3658,10 @@ bool Session::startConnectionAsync()
             m_Preferences->height,
             maxBrightness,
             minBrightness,
-            maxAverageBrightness
+            maxAverageBrightness,
+            sdrWhiteBrightness
         );
+        m_LastClientSdrWhiteNits = sdrWhiteBrightness;
         http.startApp(resumingSession ? "resume" : "launch",
                       m_Computer->isNvidiaServerSoftware,
                       m_App.id, &m_StreamConfig,
@@ -3863,13 +3890,118 @@ void Session::interrupt()
 }
 
 #ifdef Q_OS_WIN32
-void Session::queryDisplayHdrBrightness(float& maxNits, float& minNits, float& maxFullNits)
+float Session::queryDisplaySdrWhiteNits(const QString& displayName, bool logFailures)
+{
+    if (displayName.isEmpty()) {
+        return 0.0f;
+    }
+
+    UINT32 pathCount = 0;
+    UINT32 modeCount = 0;
+    LONG status = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS,
+                                               &pathCount, &modeCount);
+    if (status != ERROR_SUCCESS) {
+        if (!logFailures) {
+            return 0.0f;
+        }
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "GetDisplayConfigBufferSizes() failed for SDR white query: %ld",
+                    status);
+        return 0.0f;
+    }
+
+    // The topology can change between sizing and querying. Retry once with
+    // fresh buffer sizes if Windows reports an insufficient buffer.
+    for (int attempt = 0; attempt < 2; attempt++) {
+        std::vector<DISPLAYCONFIG_PATH_INFO> paths(pathCount);
+        std::vector<DISPLAYCONFIG_MODE_INFO> modes(modeCount);
+        UINT32 queriedPathCount = pathCount;
+        UINT32 queriedModeCount = modeCount;
+        status = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS,
+                                    &queriedPathCount, paths.data(),
+                                    &queriedModeCount, modes.data(), nullptr);
+        if (status == ERROR_INSUFFICIENT_BUFFER) {
+            status = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS,
+                                                  &pathCount, &modeCount);
+            if (status == ERROR_SUCCESS) {
+                continue;
+            }
+        }
+        if (status != ERROR_SUCCESS) {
+            if (!logFailures) {
+                return 0.0f;
+            }
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "QueryDisplayConfig() failed for SDR white query: %ld",
+                        status);
+            return 0.0f;
+        }
+
+        paths.resize(queriedPathCount);
+        for (const DISPLAYCONFIG_PATH_INFO& path : paths) {
+            DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName = {};
+            sourceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+            sourceName.header.size = sizeof(sourceName);
+            sourceName.header.adapterId = path.sourceInfo.adapterId;
+            sourceName.header.id = path.sourceInfo.id;
+            if (DisplayConfigGetDeviceInfo(&sourceName.header) != ERROR_SUCCESS ||
+                    displayName.compare(QString::fromWCharArray(sourceName.viewGdiDeviceName),
+                                        Qt::CaseInsensitive) != 0) {
+                continue;
+            }
+
+            DISPLAYCONFIG_SDR_WHITE_LEVEL whiteLevel = {};
+            whiteLevel.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL;
+            whiteLevel.header.size = sizeof(whiteLevel);
+            whiteLevel.header.adapterId = path.targetInfo.adapterId;
+            whiteLevel.header.id = path.targetInfo.id;
+            status = DisplayConfigGetDeviceInfo(&whiteLevel.header);
+            if (status != ERROR_SUCCESS) {
+                if (!logFailures) {
+                    return 0.0f;
+                }
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "DisplayConfigGetDeviceInfo(SDR_WHITE_LEVEL) failed for %s: %ld",
+                            qPrintable(displayName), status);
+                return 0.0f;
+            }
+
+            // Windows stores this as a fixed-point multiplier where 1000 is
+            // the standard 80-nit SDR white level.
+            const float nits = static_cast<float>(whiteLevel.SDRWhiteLevel) * 80.0f / 1000.0f;
+            if (nits < 50.0f || nits > 1000.0f) {
+                if (!logFailures) {
+                    return 0.0f;
+                }
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "Ignoring out-of-range SDR white level for %s: %.1f nits",
+                            qPrintable(displayName), nits);
+                return 0.0f;
+            }
+            return nits;
+        }
+
+        if (logFailures) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Unable to map display %s to an active DisplayConfig path",
+                        qPrintable(displayName));
+        }
+        return 0.0f;
+    }
+
+    return 0.0f;
+}
+
+void Session::queryDisplayHdrBrightness(const QString& preferredDisplayName,
+                                        float& maxNits, float& minNits,
+                                        float& maxFullNits, float& sdrWhiteNits)
 {
     using Microsoft::WRL::ComPtr;
 
     maxNits = 0;
     minNits = 0;
     maxFullNits = 0;
+    sdrWhiteNits = 0;
 
     ComPtr<IDXGIFactory1> factory;
     if (FAILED(CreateDXGIFactory1(__uuidof(IDXGIFactory1), (void**)&factory))) {
@@ -3877,7 +4009,18 @@ void Session::queryDisplayHdrBrightness(float& maxNits, float& minNits, float& m
         return;
     }
 
-    // Enumerate adapters and outputs to find HDR-capable display
+    struct DisplayBrightness {
+        QString name;
+        float maxNits = 0;
+        float minNits = 0;
+        float maxFullNits = 0;
+        bool hdr = false;
+
+        bool isValid() const { return !name.isEmpty(); }
+    } preferred, firstHdr, firstDisplay;
+
+    // Prefer the display that owns the launch UI. If it cannot be matched,
+    // retain the previous behavior of selecting the first HDR display.
     ComPtr<IDXGIAdapter1> adapter;
     for (UINT adapterIdx = 0; SUCCEEDED(factory->EnumAdapters1(adapterIdx, &adapter)); adapterIdx++) {
         ComPtr<IDXGIOutput> output;
@@ -3886,30 +4029,42 @@ void Session::queryDisplayHdrBrightness(float& maxNits, float& minNits, float& m
             if (SUCCEEDED(output->QueryInterface(__uuidof(IDXGIOutput6), (void**)&output6))) {
                 DXGI_OUTPUT_DESC1 desc1;
                 if (SUCCEEDED(output6->GetDesc1(&desc1))) {
-                    // Use the first display with HDR support, or the first display if none support HDR
-                    if (maxNits == 0 || desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020) {
-                        maxNits = desc1.MaxLuminance;
-                        minNits = desc1.MinLuminance;
-                        maxFullNits = desc1.MaxFullFrameLuminance;
+                    DisplayBrightness candidate;
+                    candidate.name = QString::fromWCharArray(desc1.DeviceName);
+                    candidate.maxNits = desc1.MaxLuminance;
+                    candidate.minNits = desc1.MinLuminance;
+                    candidate.maxFullNits = desc1.MaxFullFrameLuminance;
+                    candidate.hdr = desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
 
-                        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                                    "Display HDR brightness: max=%.1f nits, min=%.4f nits, maxFull=%.1f nits (HDR: %s)",
-                                    maxNits, minNits, maxFullNits,
-                                    desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020 ? "yes" : "no");
-
-                        if (desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020) {
-                            return; // Found an HDR display, use it
-                        }
+                    if (!firstDisplay.isValid()) {
+                        firstDisplay = candidate;
+                    }
+                    if (candidate.hdr && !firstHdr.isValid()) {
+                        firstHdr = candidate;
+                    }
+                    if (!preferredDisplayName.isEmpty() &&
+                            candidate.name.compare(preferredDisplayName,
+                                                   Qt::CaseInsensitive) == 0) {
+                        preferred = candidate;
                     }
                 }
             }
+            output.Reset();
         }
+        adapter.Reset();
     }
 
-    if (maxNits > 0) {
+    const DisplayBrightness selected = preferred.isValid() ? preferred :
+                                       (firstHdr.isValid() ? firstHdr : firstDisplay);
+    if (selected.isValid()) {
+        maxNits = selected.maxNits;
+        minNits = selected.minNits;
+        maxFullNits = selected.maxFullNits;
+        sdrWhiteNits = queryDisplaySdrWhiteNits(selected.name);
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "Using SDR display brightness: max=%.1f, min=%.4f, maxFull=%.1f",
-                    maxNits, minNits, maxFullNits);
+                    "Client display brightness (%s): max=%.1f nits, min=%.4f nits, maxFull=%.1f nits, SDR white=%.1f nits (HDR: %s)",
+                    qPrintable(selected.name), maxNits, minNits, maxFullNits,
+                    sdrWhiteNits, selected.hdr ? "yes" : "no");
     } else {
         SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                     "No display brightness information available");
@@ -4329,6 +4484,45 @@ void Session::exec()
         }
     };
 
+#ifdef Q_OS_WIN32
+    constexpr Uint32 SDR_WHITE_CHECK_INTERVAL_MS = 1000;
+    Uint32 lastSdrWhiteCheckTicks = 0;
+    auto processClientSdrWhiteUpdate = [this, &lastSdrWhiteCheckTicks]() {
+        if (m_StreamConfig.hdrMode == 0 ||
+                (LiGetHostFeatureFlags() & LI_FF_DYNAMIC_SDR_WHITE) == 0) {
+            return;
+        }
+
+        const Uint32 now = SDL_GetTicks();
+        if (now - lastSdrWhiteCheckTicks < SDR_WHITE_CHECK_INTERVAL_MS) {
+            return;
+        }
+        lastSdrWhiteCheckTicks = now;
+
+        const int displayIndex = SDL_GetWindowDisplayIndex(m_Window);
+        const char* displayName = displayIndex >= 0 ? SDL_GetDisplayName(displayIndex) : nullptr;
+        if (displayName == nullptr) {
+            return;
+        }
+
+        const float nits = queryDisplaySdrWhiteNits(QString::fromUtf8(displayName), false);
+        if (nits < 50.0f || qAbs(nits - m_LastClientSdrWhiteNits) < 0.5f) {
+            return;
+        }
+
+        const int result = LiSendClientSdrWhiteNits(nits);
+        if (result == LI_DYNAMIC_SDR_WHITE_OK) {
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Updated host client SDR white level: %.1f nits", nits);
+            m_LastClientSdrWhiteNits = nits;
+        }
+        else if (result != LI_DYNAMIC_SDR_WHITE_ERR_UNSUPPORTED) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Failed to update host client SDR white level: %d", result);
+        }
+    };
+#endif
+
     // 见上面 qtWindowHideDeadline 处的注释：串流窗口真的落定了（或者等超时了）
     // 再把界面窗口藏掉。
     auto hideGuiWindowWhenSettled = [&](bool settled) {
@@ -4345,6 +4539,9 @@ void Session::exec()
     for (;;) {
         hideGuiWindowWhenSettled(false);
         processSunshineAbrFeedback();
+#ifdef Q_OS_WIN32
+        processClientSdrWhiteUpdate();
+#endif
         processFileMappingUxProbeResult();
         processFileMappingMountResult();
         processClipboardHelperMessages();

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -220,7 +220,10 @@ private:
     void restoreCaptureAfterStylusReplayPanel();
 #endif
 #ifdef Q_OS_WIN32
-    void queryDisplayHdrBrightness(float& maxNits, float& minNits, float& maxFullNits);
+    void queryDisplayHdrBrightness(const QString& preferredDisplayName,
+                                   float& maxNits, float& minNits,
+                                   float& maxFullNits, float& sdrWhiteNits);
+    float queryDisplaySdrWhiteNits(const QString& displayName, bool logFailures = true);
 #endif
 
     void notifyMouseEmulationMode(bool enabled);
@@ -339,6 +342,7 @@ private:
     NvComputer* m_Computer;
     NvApp m_App;
     QString m_LaunchDisplayName;
+    QString m_ClientDisplayName;
     std::optional<bool> m_LaunchUseVdd;
     SDL_Window* m_Window;
     IVideoDecoder* m_VideoDecoder;
@@ -361,6 +365,7 @@ private:
     int m_LastTerminationErrorCode;      // stored to show final error if reconnect gives up
 
     bool m_AsyncConnectionSuccess;
+    float m_LastClientSdrWhiteNits;
     int m_PortTestResults;
 
     int m_ActiveVideoFormat;

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -2168,7 +2168,17 @@ bool D3D11VARenderer::needsTestFrame()
 
 void D3D11VARenderer::setHdrMode(bool enabled)
 {
-    auto clearHdrMetadata = [this]() {
+    auto clearVideoProcessorOutputHdrMetadata = [this]() {
+        if (m_VideoProcessor && m_VideoContext) {
+            m_VideoContext->VideoProcessorSetOutputHDRMetaData(
+                m_VideoProcessor.Get(),
+                DXGI_HDR_METADATA_TYPE_NONE,
+                0,
+                nullptr);
+        }
+    };
+
+    auto clearHdrMetadata = [this, &clearVideoProcessorOutputHdrMetadata]() {
         if (m_VideoProcessor && m_VideoContext) {
             m_VideoContext->VideoProcessorSetStreamHDRMetaData(
                 m_VideoProcessor.Get(),
@@ -2177,6 +2187,7 @@ void D3D11VARenderer::setHdrMode(bool enabled)
                 0,
                 nullptr);
         }
+        clearVideoProcessorOutputHdrMetadata();
 
         if (!m_SwapChain) {
             return;
@@ -2255,6 +2266,10 @@ void D3D11VARenderer::setHdrMode(bool enabled)
     if (!m_VideoProcessor || !m_VideoContext) {
         return;
     }
+
+    // The display may have changed since the last call. Clear the previous
+    // output metadata before probing so lookup failures cannot retain it.
+    clearVideoProcessorOutputHdrMetadata();
 
     // Prepare HDR Meta Data to match the monitor HDR specifications
     int appAdapterIndex = 0;

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -2173,8 +2173,8 @@ void D3D11VARenderer::setHdrMode(bool enabled)
     if (!enabled || !m_VideoProcessor || !(m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_10BIT))
         return;
 
-    DXGI_HDR_METADATA_HDR10 streamHDRMetaData;
-    DXGI_HDR_METADATA_HDR10 outputHDRMetaData;
+    DXGI_HDR_METADATA_HDR10 streamHDRMetaData = {};
+    DXGI_HDR_METADATA_HDR10 outputHDRMetaData = {};
 
     // Prepare HDR Meta Data for Streamed content
     bool streamSet = false;
@@ -2190,8 +2190,8 @@ void D3D11VARenderer::setHdrMode(bool enabled)
         streamHDRMetaData.WhitePoint[1] = hdrMetadata.whitePoint.y;
         streamHDRMetaData.MaxMasteringLuminance = hdrMetadata.maxDisplayLuminance;
         streamHDRMetaData.MinMasteringLuminance = hdrMetadata.minDisplayLuminance;
-        streamHDRMetaData.MaxContentLightLevel = 0;
-        streamHDRMetaData.MaxFrameAverageLightLevel = 0;
+        streamHDRMetaData.MaxContentLightLevel = hdrMetadata.maxContentLightLevel;
+        streamHDRMetaData.MaxFrameAverageLightLevel = hdrMetadata.maxFrameAverageLightLevel;
 
         m_VideoContext->VideoProcessorSetStreamHDRMetaData(
             m_VideoProcessor.Get(),
@@ -2200,6 +2200,20 @@ void D3D11VARenderer::setHdrMode(bool enabled)
             sizeof(DXGI_HDR_METADATA_HDR10),
             &streamHDRMetaData
             );
+
+        // The direct shader path bypasses the video processor, so publishing
+        // HDR10 metadata only on the VP is insufficient. Attach it to the
+        // swapchain too, allowing DWM/the display driver to map PQ content with
+        // the actual mastering and content-light information.
+        HRESULT swapChainHr = m_SwapChain->SetHDRMetaData(
+            DXGI_HDR_METADATA_TYPE_HDR10,
+            sizeof(DXGI_HDR_METADATA_HDR10),
+            &streamHDRMetaData);
+        if (FAILED(swapChainHr)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "IDXGISwapChain4::SetHDRMetaData(HDR10) failed: %x",
+                        swapChainHr);
+        }
 
         streamSet = true;
     }

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -2168,7 +2168,16 @@ bool D3D11VARenderer::needsTestFrame()
 
 void D3D11VARenderer::setHdrMode(bool enabled)
 {
-    auto clearSwapChainHdrMetadata = [this]() {
+    auto clearHdrMetadata = [this]() {
+        if (m_VideoProcessor && m_VideoContext) {
+            m_VideoContext->VideoProcessorSetStreamHDRMetaData(
+                m_VideoProcessor.Get(),
+                0,
+                DXGI_HDR_METADATA_TYPE_NONE,
+                0,
+                nullptr);
+        }
+
         if (!m_SwapChain) {
             return;
         }
@@ -2182,7 +2191,7 @@ void D3D11VARenderer::setHdrMode(bool enabled)
     };
 
     if (!enabled || !(m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_10BIT)) {
-        clearSwapChainHdrMetadata();
+        clearHdrMetadata();
         return;
     }
 
@@ -2235,7 +2244,7 @@ void D3D11VARenderer::setHdrMode(bool enabled)
         streamSet = true;
     }
     else {
-        clearSwapChainHdrMetadata();
+        clearHdrMetadata();
     }
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Set stream HDR mode: %s", streamSet ? "enabled" : "disabled");

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -2168,10 +2168,23 @@ bool D3D11VARenderer::needsTestFrame()
 
 void D3D11VARenderer::setHdrMode(bool enabled)
 {
-    // m_VideoProcessor needs to be available to be set,
-    // and it makes sense only when HDR is enabled from the UI
-    if (!enabled || !m_VideoProcessor || !(m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_10BIT))
+    auto clearSwapChainHdrMetadata = [this]() {
+        if (!m_SwapChain) {
+            return;
+        }
+
+        HRESULT hr = m_SwapChain->SetHDRMetaData(
+            DXGI_HDR_METADATA_TYPE_NONE, 0, nullptr);
+        if (FAILED(hr)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "IDXGISwapChain4::SetHDRMetaData(NONE) failed: %x", hr);
+        }
+    };
+
+    if (!enabled || !(m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_10BIT)) {
+        clearSwapChainHdrMetadata();
         return;
+    }
 
     DXGI_HDR_METADATA_HDR10 streamHDRMetaData = {};
     DXGI_HDR_METADATA_HDR10 outputHDRMetaData = {};
@@ -2193,32 +2206,46 @@ void D3D11VARenderer::setHdrMode(bool enabled)
         streamHDRMetaData.MaxContentLightLevel = hdrMetadata.maxContentLightLevel;
         streamHDRMetaData.MaxFrameAverageLightLevel = hdrMetadata.maxFrameAverageLightLevel;
 
-        m_VideoContext->VideoProcessorSetStreamHDRMetaData(
-            m_VideoProcessor.Get(),
-            0,
-            DXGI_HDR_METADATA_TYPE_HDR10,
-            sizeof(DXGI_HDR_METADATA_HDR10),
-            &streamHDRMetaData
-            );
+        if (m_VideoProcessor && m_VideoContext) {
+            m_VideoContext->VideoProcessorSetStreamHDRMetaData(
+                m_VideoProcessor.Get(),
+                0,
+                DXGI_HDR_METADATA_TYPE_HDR10,
+                sizeof(DXGI_HDR_METADATA_HDR10),
+                &streamHDRMetaData
+                );
+        }
 
         // The direct shader path bypasses the video processor, so publishing
         // HDR10 metadata only on the VP is insufficient. Attach it to the
         // swapchain too, allowing DWM/the display driver to map PQ content with
         // the actual mastering and content-light information.
-        HRESULT swapChainHr = m_SwapChain->SetHDRMetaData(
-            DXGI_HDR_METADATA_TYPE_HDR10,
-            sizeof(DXGI_HDR_METADATA_HDR10),
-            &streamHDRMetaData);
-        if (FAILED(swapChainHr)) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                        "IDXGISwapChain4::SetHDRMetaData(HDR10) failed: %x",
-                        swapChainHr);
+        if (m_SwapChain) {
+            HRESULT swapChainHr = m_SwapChain->SetHDRMetaData(
+                DXGI_HDR_METADATA_TYPE_HDR10,
+                sizeof(DXGI_HDR_METADATA_HDR10),
+                &streamHDRMetaData);
+            if (FAILED(swapChainHr)) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "IDXGISwapChain4::SetHDRMetaData(HDR10) failed: %x",
+                            swapChainHr);
+            }
         }
 
         streamSet = true;
     }
+    else {
+        clearSwapChainHdrMetadata();
+    }
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "Set stream HDR mode: %s", streamSet ? "enabled" : "disabled");
+
+    // Swapchain metadata is also used by the direct shader path. Everything
+    // below is video-processor-specific and can be skipped when VP creation
+    // failed without disabling the renderer.
+    if (!m_VideoProcessor || !m_VideoContext) {
+        return;
+    }
 
     // Prepare HDR Meta Data to match the monitor HDR specifications
     int appAdapterIndex = 0;


### PR DESCRIPTION
## 改了啥呀
- 在 Windows HDR 客户端读取串流窗口所在输出的 SDR reference white，并随 launch/resume 上报给主机
- 串流期间每秒检测显示器或白点变化，主机支持时通过加密控制通道动态更新
- HDR 亮度检测改为优先使用实际选中的显示器，而不是随手抓第一个 HDR 输出
- 给 D3D11 swapchain 补齐 HDR10 mastering metadata、MaxCLL 和 MaxFALL，直通 shader 路径也能拿到正确显示信息
- 更新 `moonlight-common-c` 到已合入的动态 SDR 白点协议提交

## 为啥要改
PQ 是绝对亮度编码，主机必须知道观看端的 SDR 白点，才能把主机 scRGB 桌面的 SDR band 锚到正确亮度。此前客户端没有传这个值，多显示器时还可能取错亮度 profile，于是主机只能在错误基准上编码，调 PQ 参数也救不回那层泛白，真是杂鱼级误差链啦。

旧主机不识别扩展参数时会忽略它；运行时更新也受 feature flag 保护。Android 已有自己的显示亮度链路，这次修改只落在 Windows 客户端路径。

配套主机修复：AlkaidLab/foundation-sunshine#1008

## 验证
- Qt 6.11.1 / MSVC 2022 x64 Release 完整编译通过
- 产物：`Moonlight.exe`（7,901,184 bytes）
- `git diff --check origin/master...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved HDR streaming by detecting the client display’s SDR white level.
  - Dynamically updates SDR brightness during active streaming when display settings change.
  - Sends accurate SDR brightness to improve display tone mapping.

- **Bug Fixes**
  - Improved HDR metadata cleanup when HDR output is disabled or metadata is unavailable.
  - Corrected HDR brightness reporting for supported displays.
  - Prevented stale HDR metadata after display changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->