### PR TITLE
fix(streaming): stop polling Qt for idle macOS overlay button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
       run: |
         pushd tests/overlay_button_native_wake
         qmake overlay_button_native_wake.pro
-        make -j$(sysctl -n hw.ncpu)
+        make -j"$(sysctl -n hw.ncpu)"
         ./overlay_button_native_wake
         popd
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,14 @@ jobs:
         cache: true
         aqtsource: 'git+https://github.com/miurahr/aqtinstall.git@073e34d7c2ab4ae6961ed7cca690b3abd5ba5a7e'
 
+    - name: Test macOS overlay event wakeups
+      run: |
+        pushd tests/overlay_button_native_wake
+        qmake overlay_button_native_wake.pro
+        make -j$(sysctl -n hw.ncpu)
+        ./overlay_button_native_wake
+        popd
+
     - name: Build and generate DMG
       run: |
         scripts/generate-dmg.sh Release

--- a/app/app.pro
+++ b/app/app.pro
@@ -350,8 +350,12 @@ HEADERS += \
 
 # 把红绿灯沉到我们自己那条 bar 的中线上，顺带让 AppKit 的标题栏拖动区覆盖整条 bar
 macx {
-    HEADERS += gui/macwindowchrome.h
-    SOURCES += gui/macwindowchrome.mm
+    HEADERS += \
+        gui/macwindowchrome.h \
+        streaming/video/overlayeventmonitor_mac.h
+    SOURCES += \
+        gui/macwindowchrome.mm \
+        streaming/video/overlayeventmonitor_mac.mm
 }
 
 # Platform-specific renderers and decoders

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -48,7 +48,7 @@
 #define SDL_CODE_FLUSH_TOUCHPAD_FRAME 106
 #define SDL_CODE_CURSOR_UPDATE 107
 #define SDL_CODE_FLUSH_CURSOR_VISIBILITY 108
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
 #define SDL_CODE_PROCESS_QT_OVERLAY_EVENTS 109
 #endif
 
@@ -3257,7 +3257,7 @@ void Session::handleSdlUserEvent(const SDL_UserEvent& event)
         }
         break;
     }
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
     case SDL_CODE_PROCESS_QT_OVERLAY_EVENTS:
         // The actual Qt processing happens after SDL dispatch below.
         // Keeping this event side-effect free also coalesces bursts of
@@ -4412,7 +4412,7 @@ void Session::exec()
     // Keep a hidden button ready so placement can switch during a stream
     // without creating a window from inside an input callback.
     m_MenuButton = new OverlayMenuButton();
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
     m_MenuButton->setEventWakeCallback([]() {
         SDL_Event wakeEvent = {};
         wakeEvent.type = SDL_USEREVENT;
@@ -5120,7 +5120,7 @@ DispatchDeferredCleanup:
 
     // Destroy the Qt overlay menu button
     if (m_MenuButton) {
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
         m_MenuButton->setEventWakeCallback({});
 #endif
         m_MenuButton->hideButton();

--- a/app/streaming/video/overlayeventmonitor_mac.h
+++ b/app/streaming/video/overlayeventmonitor_mac.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+
+class MacOverlayEventMonitor
+{
+public:
+    explicit MacOverlayEventMonitor(std::function<void()> wakeCallback);
+    ~MacOverlayEventMonitor();
+
+    MacOverlayEventMonitor(const MacOverlayEventMonitor&) = delete;
+    MacOverlayEventMonitor& operator=(const MacOverlayEventMonitor&) = delete;
+
+    bool attach(void* nativeView);
+    void detach();
+    bool isAttached() const { return m_Monitor != nullptr; }
+
+private:
+    std::function<void()> m_WakeCallback;
+    void* m_Monitor = nullptr;
+    long m_WindowNumber = 0;
+};

--- a/app/streaming/video/overlayeventmonitor_mac.mm
+++ b/app/streaming/video/overlayeventmonitor_mac.mm
@@ -1,0 +1,86 @@
+#include "overlayeventmonitor_mac.h"
+
+#import <AppKit/AppKit.h>
+
+#include <utility>
+
+MacOverlayEventMonitor::MacOverlayEventMonitor(std::function<void()> wakeCallback)
+    : m_WakeCallback(std::move(wakeCallback))
+{
+}
+
+MacOverlayEventMonitor::~MacOverlayEventMonitor()
+{
+    detach();
+}
+
+bool MacOverlayEventMonitor::attach(void* nativeView)
+{
+    @autoreleasepool {
+        NSView* view = static_cast<NSView*>(nativeView);
+        NSWindow* window = view.window;
+        if (window == nil) {
+            detach();
+            return false;
+        }
+
+        const NSInteger windowNumber = window.windowNumber;
+        if (m_Monitor != nullptr && m_WindowNumber == windowNumber) {
+            return true;
+        }
+
+        detach();
+
+        const NSEventMask pointerEventMask =
+                NSEventMaskLeftMouseDown |
+                NSEventMaskLeftMouseUp |
+                NSEventMaskRightMouseDown |
+                NSEventMaskRightMouseUp |
+                NSEventMaskOtherMouseDown |
+                NSEventMaskOtherMouseUp |
+                NSEventMaskMouseMoved |
+                NSEventMaskLeftMouseDragged |
+                NSEventMaskRightMouseDragged |
+                NSEventMaskOtherMouseDragged |
+                NSEventMaskMouseEntered |
+                NSEventMaskMouseExited |
+                NSEventMaskCursorUpdate |
+                NSEventMaskScrollWheel |
+                NSEventMaskTabletPoint |
+                NSEventMaskTabletProximity |
+                NSEventMaskGesture |
+                NSEventMaskMagnify |
+                NSEventMaskSwipe |
+                NSEventMaskRotate |
+                NSEventMaskBeginGesture |
+                NSEventMaskEndGesture |
+                NSEventMaskSmartMagnify |
+                NSEventMaskPressure |
+                NSEventMaskDirectTouch;
+
+        const auto callback = m_WakeCallback;
+        id monitor = [NSEvent addLocalMonitorForEventsMatchingMask:pointerEventMask
+                                                          handler:^NSEvent*(NSEvent* event) {
+            if (event.windowNumber == windowNumber) {
+                callback();
+            }
+            return event;
+        }];
+        m_Monitor = [monitor retain];
+        m_WindowNumber = windowNumber;
+        return m_Monitor != nullptr;
+    }
+}
+
+void MacOverlayEventMonitor::detach()
+{
+    @autoreleasepool {
+        id monitor = static_cast<id>(m_Monitor);
+        if (monitor != nil) {
+            [NSEvent removeMonitor:monitor];
+            [monitor release];
+            m_Monitor = nullptr;
+        }
+        m_WindowNumber = 0;
+    }
+}

--- a/app/streaming/video/overlaymenubutton.cpp
+++ b/app/streaming/video/overlaymenubutton.cpp
@@ -8,6 +8,10 @@
 #include <QInputDevice>
 #endif
 
+#ifdef Q_OS_DARWIN
+#include "overlayeventmonitor_mac.h"
+#endif
+
 #ifdef Q_OS_WIN32
 #include <windows.h>
 #include <commctrl.h>
@@ -181,7 +185,7 @@ OverlayMenuButton::OverlayMenuButton(QWindow* parent)
 
 OverlayMenuButton::~OverlayMenuButton()
 {
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
     m_NativeEventMonitor.reset();
 #endif
 }
@@ -192,7 +196,7 @@ bool OverlayMenuButton::needsEventProcessing() const
         return false;
     }
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
     // If native monitoring is unavailable, retain the old continuous-pump
     // behavior so the button never becomes unusable on an unusual system.
     return !m_NativeEventMonitor || !m_NativeEventMonitor->isAttached() ||
@@ -224,14 +228,25 @@ void OverlayMenuButton::requestButtonUpdate()
     requestUpdate();
 }
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
 void OverlayMenuButton::ensureNativeEventMonitor()
 {
     if (!m_NativeEventMonitor) {
+#ifdef Q_OS_WIN32
         m_NativeEventMonitor = std::make_unique<NativeEventMonitor>(this);
+#else
+        m_NativeEventMonitor = std::make_unique<MacOverlayEventMonitor>([this]() {
+            requestEventProcessing();
+        });
+#endif
     }
 
-    if (!m_NativeEventMonitor->attach(reinterpret_cast<HWND>(winId()))) {
+#ifdef Q_OS_WIN32
+    const auto nativeWindow = reinterpret_cast<HWND>(winId());
+#else
+    void* nativeWindow = reinterpret_cast<void*>(winId());
+#endif
+    if (!m_NativeEventMonitor->attach(nativeWindow)) {
         qWarning("Failed to monitor native overlay button events; using continuous Qt event processing");
     }
 }
@@ -281,7 +296,7 @@ void OverlayMenuButton::showButton(int parentX, int parentY, int parentW, int pa
     repositionTo(parentX, parentY, parentW, parentH);
     m_ButtonVisible = true;
     show();
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
     ensureNativeEventMonitor();
 #endif
     raise();

--- a/app/streaming/video/overlaymenubutton.h
+++ b/app/streaming/video/overlaymenubutton.h
@@ -12,6 +12,10 @@
 #include "overlaybuttonposition.h"
 #include "overlayeventwakestate.h"
 
+#ifdef Q_OS_DARWIN
+class MacOverlayEventMonitor;
+#endif
+
 /**
  * OverlayMenuButton - A small floating button rendered by the OS compositor,
  * positioned inside the streaming window. It defaults to the top-right and
@@ -54,8 +58,8 @@ public:
 
     bool isButtonVisible() const { return m_ButtonVisible; }
 
-    // Windows can wake the SDL loop from the button's native window procedure,
-    // so an idle visible button does not need a continuous Qt event pump.
+    // Windows and macOS wake the SDL loop from native pointer events, so an
+    // idle visible button does not need a continuous Qt event pump.
     bool needsEventProcessing() const;
     void beginEventProcessing();
 
@@ -82,7 +86,7 @@ private:
     void cancelInteraction();
     void requestEventProcessing();
     void requestButtonUpdate();
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
     void ensureNativeEventMonitor();
 #endif
 
@@ -101,6 +105,8 @@ private:
     std::optional<QPointF> m_NormalizedPosition;
 #ifdef Q_OS_WIN32
     std::unique_ptr<NativeEventMonitor> m_NativeEventMonitor;
+#elif defined(Q_OS_DARWIN)
+    std::unique_ptr<MacOverlayEventMonitor> m_NativeEventMonitor;
 #endif
 
     // Button size (logical pixels)

--- a/tests/overlay_button_native_wake/main_mac.mm
+++ b/tests/overlay_button_native_wake/main_mac.mm
@@ -1,0 +1,91 @@
+#include "streaming/video/overlaymenubutton.h"
+
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <QTemporaryDir>
+
+#import <AppKit/AppKit.h>
+
+namespace {
+void require(bool condition, const char* message)
+{
+    if (!condition) {
+        qFatal("%s", message);
+    }
+}
+
+void settleQtEvents(OverlayMenuButton& button)
+{
+    for (int pass = 0; pass < 16 && button.needsEventProcessing(); ++pass) {
+        button.beginEventProcessing();
+        QCoreApplication::processEvents(QEventLoop::AllEvents);
+    }
+    require(!button.needsEventProcessing(),
+            "overlay button event processing must settle");
+}
+
+void sendPointerEvent(NSInteger windowNumber)
+{
+    NSEvent* event = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
+                                        location:NSMakePoint(1, 1)
+                                   modifierFlags:0
+                                       timestamp:NSProcessInfo.processInfo.systemUptime
+                                    windowNumber:windowNumber
+                                         context:nil
+                                     eventNumber:0
+                                      clickCount:0
+                                        pressure:0];
+    [NSApp sendEvent:event];
+}
+}
+
+int main(int argc, char* argv[])
+{
+    QTemporaryDir settingsDirectory;
+    require(settingsDirectory.isValid(), "temporary settings directory must be available");
+    qputenv("MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR",
+            settingsDirectory.path().toLocal8Bit());
+
+    QGuiApplication app(argc, argv);
+    OverlayMenuButton button;
+    int wakeCount = 0;
+    button.setEventWakeCallback([&wakeCount]() { wakeCount++; });
+    button.showButton(100, 100, 800, 600);
+    settleQtEvents(button);
+
+    NSView* nativeView = static_cast<NSView*>(reinterpret_cast<void*>(button.winId()));
+    require(nativeView.window != nil, "overlay button must have a native macOS window");
+    const NSInteger windowNumber = nativeView.window.windowNumber;
+
+    const int settledWakeCount = wakeCount;
+    sendPointerEvent(0);
+    require(!button.needsEventProcessing(),
+            "pointer input for another macOS window must not wake the overlay");
+    require(wakeCount == settledWakeCount,
+            "unrelated native pointer input must leave the owner loop idle");
+
+    sendPointerEvent(windowNumber);
+    require(button.needsEventProcessing(),
+            "native macOS pointer input must request Qt event processing");
+    require(wakeCount == settledWakeCount + 1,
+            "the first native pointer event must wake the owner loop");
+
+    constexpr int nativeEventCount = 100000;
+    for (int i = 0; i < nativeEventCount; ++i) {
+        sendPointerEvent(windowNumber);
+    }
+    require(wakeCount == settledWakeCount + 1,
+            "native macOS pointer bursts must be coalesced while pending");
+
+    settleQtEvents(button);
+    require(wakeCount == settledWakeCount + 1,
+            "settling native pointer input must not create an idle wake loop");
+
+    button.hideButton();
+    sendPointerEvent(windowNumber);
+    require(!button.needsEventProcessing(),
+            "hidden button must ignore native macOS pointer events");
+
+    qunsetenv("MOONLIGHT_DEVICE_LOCAL_SETTINGS_DIR");
+    return 0;
+}

--- a/tests/overlay_button_native_wake/overlay_button_native_wake.pro
+++ b/tests/overlay_button_native_wake/overlay_button_native_wake.pro
@@ -7,13 +7,22 @@ win32: LIBS += user32.lib
 INCLUDEPATH += ../../app
 
 SOURCES += \
-    main.cpp \
     ../../app/settings/devicelocalsettings.cpp \
     ../../app/streaming/video/overlaybuttonposition.cpp \
     ../../app/streaming/video/overlaymenubutton.cpp
+
+macx {
+    SOURCES += \
+        main_mac.mm \
+        ../../app/streaming/video/overlayeventmonitor_mac.mm
+} else {
+    SOURCES += main.cpp
+}
 
 HEADERS += \
     ../../app/settings/devicelocalsettings.h \
     ../../app/streaming/video/overlaybuttonposition.h \
     ../../app/streaming/video/overlayeventwakestate.h \
     ../../app/streaming/video/overlaymenubutton.h
+
+macx: HEADERS += ../../app/streaming/video/overlayeventmonitor_mac.h


### PR DESCRIPTION
## 改了啥呀

- 给 macOS 浮动按钮接入 Cocoa 本地事件监听，只在按钮自己的 `NSWindow` 收到鼠标、触控板、触摸或手势事件时唤醒 SDL 主循环。
- 复用现有 `OverlayEventWakeState` 合并连续唤醒，按钮空闲时不再把 SDL 等待时间长期压到 10 ms。
- 原生监听不可用时继续回退到持续 Qt 事件处理，避免按钮在异常环境中失去交互。
- 扩展原生唤醒测试和 macOS CI，覆盖无关窗口过滤、10 万事件合并和隐藏按钮静默。

## 为啥要改

#194 只给 Windows 实现了原生窗口消息唤醒。macOS 上 `needsEventProcessing()` 仍然无条件返回 `true`，所以浮动按钮只要可见，这个杂鱼空闲状态就会让串流线程每 10 ms 完整处理一次 Qt/AppKit 事件，重新带来输入丢失和视频延迟波动。

这次把 macOS 补到和 Windows 相同的按需模型，并按浮动按钮窗口号过滤事件，避免应用内其他窗口活动误唤醒串流主循环。

## 验证

- macOS 原生唤醒测试通过：无关窗口事件不唤醒，10 万个按钮窗口指针事件合并为一次唤醒，隐藏按钮保持静默。
- Qt 6.11.1 arm64 Release 完整编译和 `Moonlight.app` 最终链接通过。
- `git diff --check` 通过。

关联：#194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native macOS event monitoring for overlay menu interactions.
  * Overlay pointer activity now wakes event processing on macOS, matching existing Windows behavior.

* **Bug Fixes**
  * Improved responsiveness for macOS overlay controls, including event coalescing and hidden-button handling.

* **Tests**
  * Added automated macOS coverage for overlay wakeups, unrelated-window input, repeated events, and hidden controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->