### PR TITLE
fix(streaming): stabilize Linux file-sharing toast size

### DIFF
--- a/app/streaming/video/overlaytoast.cpp
+++ b/app/streaming/video/overlaytoast.cpp
@@ -1,6 +1,7 @@
 #include "overlaytoast.h"
 #include "uifont.h"
 
+#include <QGuiApplication>
 #include <QScreen>
 #include <QFontMetrics>
 
@@ -38,7 +39,10 @@ OverlayToast::OverlayToast(QWindow* parent)
     // Manrope 由 main.cpp 注册进 QFontDatabase，进程内哪儿都能用；它没有中文字形，
     // 所以后面按平台补 CJK 回退（提示文案是会被翻译的）。
     m_Font.setFamilies(UiFont::familyChain(QStringLiteral("Manrope")));
-    m_Font.setPointSize(11);
+    // Use a fixed logical pixel size. Point sizes are resolved through the
+    // platform's font DPI, which is not the same thing as Qt's UI scale on
+    // Linux and can make this standalone window unexpectedly large.
+    m_Font.setPixelSize(15); // approximately equivalent to 11pt at 96 DPI
     m_Font.setWeight(QFont::DemiBold);
     m_Font.setStyleHint(QFont::SansSerif);
 
@@ -87,6 +91,16 @@ void OverlayToast::showToast(int parentX, int parentY, int parentW, int parentH,
                              const QString& message, int durationMs)
 {
     m_Message = message;
+
+    // This is an independent top-level window, so make its font/rendering
+    // context follow the stream window's monitor before measuring text.
+    QScreen* targetScreen = QGuiApplication::screenAt(QPoint(parentX, parentY));
+    if (targetScreen == nullptr) {
+        targetScreen = QGuiApplication::primaryScreen();
+    }
+    if (targetScreen != nullptr && screen() != targetScreen) {
+        setScreen(targetScreen);
+    }
 
     // Stop any ongoing fade before replacing the toast. The state deadline is
     // reset below, so an expired older toast cannot dismiss the new message.

--- a/app/streaming/video/overlaytoast.cpp
+++ b/app/streaming/video/overlaytoast.cpp
@@ -94,7 +94,8 @@ void OverlayToast::showToast(int parentX, int parentY, int parentW, int parentH,
 
     // This is an independent top-level window, so make its font/rendering
     // context follow the stream window's monitor before measuring text.
-    QScreen* targetScreen = QGuiApplication::screenAt(QPoint(parentX, parentY));
+    const QPoint parentCenter(parentX + parentW / 2, parentY + parentH / 2);
+    QScreen* targetScreen = QGuiApplication::screenAt(parentCenter);
     if (targetScreen == nullptr) {
         targetScreen = QGuiApplication::primaryScreen();
     }


### PR DESCRIPTION
### 改了啥呀
- 将串流内文件共享 Toast 从受系统 DPI 影响的 `11pt` 改为固定逻辑像素字号。
- 独立 Toast 窗口显示前绑定到串流所在屏幕，避免多屏环境误用主屏缩放。

### 为啥要改
Linux 的字体 DPI 和 Qt UI 缩放可能不一致，导致“主机文件已就绪”提示文字和背景框异常放大。这个小坏蛋只影响 Toast 尺寸处理，不改文件共享流程或 SDL 坐标逻辑。

### 验证
- `git diff --check`
- 使用当前 Qt 工程编译通过 `overlaytoast.cpp`（macOS）
- 未在 Linux/Wayland 环境运行截图验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toast text sizing for more consistent readability across different display settings.
  * Toast notifications now appear on the correct monitor when the parent window moves between screens.
  * Added a fallback to the primary display when the parent screen cannot be identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->