### PR TITLE
fix(clipboard): suppress re-encoded image echo by pixel hash

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -187,6 +187,7 @@ void ClipboardSync::stop()
     }
 
     m_EchoCache.clear();
+    m_ImageEchoCache.clear();
     m_PendingSelfWrites = 0;
 #ifdef Q_OS_MACOS
     if (m_PasteboardPollTimer != nullptr) {
@@ -344,10 +345,15 @@ void ClipboardSync::applyInboundPng(const QByteArray& payload)
         return;
     }
 
-    // Hash the wire bytes (not the decoded pixels) so the echo we suppress
-    // matches what we'd re-encode if QClipboard hands the image straight back.
+    // Record both identities *before* writing. The byte hash suppresses the
+    // immediate dataChanged echo when the platform returns our payload
+    // verbatim (Windows). macOS instead re-encodes the image flavors after
+    // the write and bumps the pasteboard changeCount a second time, handing
+    // us back bytes that never match the wire payload — the pixel hash
+    // covers that delayed echo because the re-encodes are lossless.
     uint64_t hash = hashBytes(payload);
     recordHash(hash);
+    recordImageHash(hashImagePixels(image));
     ++m_PendingSelfWrites;
 
     QMimeData* mime = new QMimeData();
@@ -406,24 +412,32 @@ void ClipboardSync::sendClipboardPng(const QByteArray& png,
         return;
     }
 
-    if (shouldTransferOutOfBand(png.size())) {
-        // Out-of-band path. Record the underlying PNG hash before
-        // upload so the echo we'll see when the host loops the REF
-        // back (and we fetch the same bytes) is suppressed.
-        uint64_t hash = hashBytes(png);
-        if (seenRecently(hash)) {
-            return;
-        }
-        recordHash(hash);
-        uploadAndSendRef(png, QStringLiteral("image/png"));
-        return;
-    }
-
     uint64_t hash = hashBytes(png);
     if (seenRecently(hash)) {
         return;
     }
+
+    // The outbound image may be the delayed echo of an image the host just
+    // pushed: the platform clipboard re-encoded it, so its bytes no longer
+    // match any recorded hash, but its pixels do. Check the pixel identity
+    // before dispatching to either the inline or the out-of-band path.
+    QImage decoded;
+    if (decoded.loadFromData(png, "PNG") && !decoded.isNull()) {
+        uint64_t pixelHash = hashImagePixels(decoded);
+        if (pixelHash != 0 && seenImageRecently(pixelHash)) {
+            return;
+        }
+        recordImageHash(pixelHash);
+    }
+
     recordHash(hash);
+
+    if (shouldTransferOutOfBand(png.size())) {
+        // Out-of-band path. The hashes recorded above suppress the echo
+        // we'll see when the host loops the REF back to us.
+        uploadAndSendRef(png, QStringLiteral("image/png"));
+        return;
+    }
 
     QByteArray frame;
     if (encodeFrame(KIND_PNG, png, frame)) {
@@ -847,6 +861,81 @@ uint64_t ClipboardSync::hashBytes(const QByteArray& bytes)
         h *= 0x100000001b3ULL;
     }
     return h;
+}
+
+uint64_t ClipboardSync::hashImagePixels(const QImage& image)
+{
+    if (image.isNull()) {
+        return 0;
+    }
+
+    // Normalize to one straight-alpha format so identical pixel content
+    // hashes identically no matter which flavor (PNG/TIFF/DIB) or Qt format
+    // it came back as. Opaque images (the overwhelmingly common clipboard
+    // case) survive every lossless conversion bit-exact; semi-transparent
+    // pixels may drift by rounding through a premultiplied intermediate,
+    // which at worst degrades back to byte-hash-only suppression.
+    const QImage canonical = image.convertToFormat(QImage::Format_RGBA8888);
+    if (canonical.isNull() || canonical.width() <= 0 || canonical.height() <= 0) {
+        return 0;
+    }
+
+    uint64_t h = 0xcbf29ce484222325ULL;
+    const auto mixBytes = [&h](const uchar* bytes, int count) {
+        for (int i = 0; i < count; ++i) {
+            h ^= bytes[i];
+            h *= 0x100000001b3ULL;
+        }
+    };
+
+    // Fold dimensions in so equal bytes under different geometry don't collide.
+    const quint32 dimensions[2] = {
+        static_cast<quint32>(canonical.width()),
+        static_cast<quint32>(canonical.height()),
+    };
+    mixBytes(reinterpret_cast<const uchar*>(dimensions), sizeof(dimensions));
+
+    // Scan row data only, skipping any per-row stride padding.
+    const int rowBytes = canonical.width() * 4;
+    for (int y = 0; y < canonical.height(); ++y) {
+        mixBytes(canonical.constScanLine(y), rowBytes);
+    }
+
+    return h;
+}
+
+bool ClipboardSync::seenImageRecently(uint64_t pixelHash)
+{
+    if (pixelHash == 0) {
+        return false;
+    }
+
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+    while (!m_ImageEchoCache.isEmpty()
+               && (now - m_ImageEchoCache.front().second) > ECHO_TTL_MS) {
+        m_ImageEchoCache.removeFirst();
+    }
+
+    for (const auto& e : m_ImageEchoCache) {
+        if (e.first == pixelHash) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ClipboardSync::recordImageHash(uint64_t pixelHash)
+{
+    if (pixelHash == 0) {
+        return;
+    }
+
+    qint64 now = QDateTime::currentMSecsSinceEpoch();
+    m_ImageEchoCache.enqueue(qMakePair(pixelHash, now));
+    while (m_ImageEchoCache.size() > ECHO_MAX) {
+        m_ImageEchoCache.removeFirst();
+    }
 }
 
 QNetworkAccessManager* ClipboardSync::nam()

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -47,6 +47,13 @@ struct ClipboardSyncHostContext
 // notifications for the same content are dropped, mirroring the Sunshine
 // GUI agent's logic so the two ends don't ping-pong.
 //
+// Text keys the cache on the payload bytes. Images key a second cache on
+// the decoded pixels: platforms re-encode clipboard image flavors after we
+// write them (macOS synthesizes new PNGf/TIFF data lazily and bumps the
+// pasteboard changeCount again), so the delayed echo hands back a
+// re-encoded copy whose bytes never match the wire payload. Pixels survive
+// those lossless re-encodes, making them the only stable identity.
+//
 // Threading:
 //   * Construct on the GUI thread.
 //   * start() / stop() must run on the GUI thread.
@@ -141,6 +148,11 @@ private:
 
     static uint64_t hashBytes(const QByteArray& bytes);
 
+    // Pixel-level echo bookkeeping for images (see class comment).
+    bool seenImageRecently(uint64_t pixelHash);
+    void recordImageHash(uint64_t pixelHash);
+    static uint64_t hashImagePixels(const QImage& image);
+
     bool encodeImageAsPng(const QImage& image,
                           QByteArray& outPng,
                           const char* sourceDescription) const;
@@ -173,7 +185,8 @@ private:
     QNetworkAccessManager* m_Nam = nullptr;
 
     bool m_Active = false;
-    QQueue<QPair<uint64_t, qint64>> m_EchoCache; // (hash, timestamp_ms)
+    QQueue<QPair<uint64_t, qint64>> m_EchoCache;       // (byte hash, timestamp_ms)
+    QQueue<QPair<uint64_t, qint64>> m_ImageEchoCache;  // (pixel hash, timestamp_ms)
 
 #ifdef Q_OS_MACOS
     QTimer* m_PasteboardPollTimer = nullptr;


### PR DESCRIPTION
## 问题

入站图片（主机 → Mac）同步后，图片会被原样发回主机一次，理论上两端可乒乓循环。

根因：macOS 在我们写入图片后**异步重编码** pasteboard 各 flavor（PNGf→TIFF→PNG 等）并再次 bump changeCount。这个延迟变更事件里读回的 PNG 字节与入站 payload 不再相同，字节级回声缓存永远不命中，图片被当作新内容重发给主机。Windows 端 GUI 代理同样会重编码（DIB↔PNG），两端可互相触发。

## 修复

在字节哈希缓存之外增加**像素级**回声缓存：
- `hashImagePixels()`：解码后统一转 `RGBA8888`，折入宽高、跳过行尾 padding 后做 FNV-1a。无损重编码保留像素，因此是稳定标识
- `applyInboundPng()`：写入剪贴板前同时记录字节哈希 + 像素哈希
- `sendClipboardPng()`：字节哈希未命中后，再按像素哈希查缓存，命中即丢弃（内联与 out-of-band 路径都覆盖）

文字路径不变（仍按字节）。

## 验证（macOS 26.6.2，独立运行 helper 复现）

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 入站 PNG → 延迟回声 | `outbound PNG frame queued (178 bytes)` 重发 | ✅ 无回发帧，剪贴板正常落图 |
| 本地复制图片（真实浏览器多格式剪贴板） | ✅ | ✅ 正常出站 kind=2 |
| 本地复制文字 | ✅ | ✅ 正常出站 kind=1 |
| 入站文字 | ✅ | ✅ |

半透明像素经预乘中间格式可能产生 ±1 舍入漂移，此时退化为原有字节级行为（不多发不少发），不透明图片（绝大多数场景）精确命中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved clipboard image synchronization to prevent duplicate image echoes when platforms re-encode image data.
  - Image changes are now recognized consistently based on their visual pixel content, improving reliability across clipboard formats.
  - Echo tracking is cleared when synchronization stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->