### PR TITLE
feat(clipboard): compound text+image clipboard via token-grouped bursts

### DIFF
--- a/app/streaming/clipboardsync.cpp
+++ b/app/streaming/clipboardsync.cpp
@@ -24,6 +24,9 @@
 
 #ifdef Q_OS_MACOS
 extern "C" int ClipboardHelperPasteboardChangeCount();
+extern "C" bool ClipboardHelperWritePasteboardCompound(const char* utf8Text,
+                                                       const unsigned char* pngBytes,
+                                                       int pngLength);
 #endif
 
 namespace {
@@ -189,6 +192,10 @@ void ClipboardSync::stop()
     m_EchoCache.clear();
     m_ImageEchoCache.clear();
     m_PendingSelfWrites = 0;
+    const QList<quint32> burstTokens = m_PendingBursts.keys();
+    for (quint32 token : burstTokens) {
+        removeBurst(token);
+    }
 #ifdef Q_OS_MACOS
     if (m_PasteboardPollTimer != nullptr) {
         m_PasteboardPollTimer->stop();
@@ -255,20 +262,29 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
     }
 
     uint8_t kind = 0;
+    quint32 token = 0;
     QByteArray payload;
-    if (!decodeFrame(frame, kind, payload)) {
+    if (!decodeFrame(frame, kind, token, payload)) {
         ClipboardLog::warn("ClipboardSync: discarding malformed inbound frame (%d bytes)",
                     static_cast<int>(frame.size()));
         return;
     }
 
     if (kind == KIND_TEXT) {
-        applyInboundText(payload);
+        if (token == 0) {
+            applyInboundText(payload);
+        } else {
+            handleBurstFrame(kind, token, payload);
+        }
         return;
     }
 
     if (kind == KIND_PNG) {
-        applyInboundPng(payload);
+        if (token == 0) {
+            applyInboundPng(payload);
+        } else {
+            handleBurstFrame(kind, token, payload);
+        }
         return;
     }
 
@@ -294,7 +310,24 @@ void ClipboardSync::onIncomingFrame(QByteArray frame)
                         static_cast<long long>(size), static_cast<long long>(MAX_BLOB_BYTES));
             return;
         }
-        fetchRefAndApply(id, mime, size);
+        if (token == 0) {
+            fetchRefAndApply(id, mime, size);
+            return;
+        }
+
+        // Burst REF: start the fetch now; the bytes land in the aggregator
+        // (or apply standalone if the burst window already closed).
+        const uint8_t flavorKind = (mime == QStringLiteral("image/png")) ? KIND_PNG
+                : mime.startsWith(QStringLiteral("text/")) ? KIND_TEXT : uint8_t(0);
+        fetchBlob(id, size, [this, token, flavorKind](const QByteArray& bytes, const QString& fetchedMime) {
+            Q_UNUSED(fetchedMime);
+            if (flavorKind == 0) {
+                ClipboardLog::info("ClipboardSync: dropping fetched blob with unsupported mime");
+                burstFlavorResolved(token, 0, QByteArray());
+                return;
+            }
+            burstFlavorResolved(token, flavorKind, bytes);
+        });
         return;
     }
 
@@ -398,7 +431,8 @@ bool ClipboardSync::encodeImageAsPng(const QImage& image,
 }
 
 void ClipboardSync::sendClipboardPng(const QByteArray& png,
-                                     const QString& sourceDescription)
+                                     const QString& sourceDescription,
+                                     quint32 token)
 {
     const QByteArray sourceUtf8 = sourceDescription.isEmpty()
             ? QByteArrayLiteral("unknown source")
@@ -435,17 +469,59 @@ void ClipboardSync::sendClipboardPng(const QByteArray& png,
     if (shouldTransferOutOfBand(png.size())) {
         // Out-of-band path. The hashes recorded above suppress the echo
         // we'll see when the host loops the REF back to us.
-        uploadAndSendRef(png, QStringLiteral("image/png"));
+        uploadAndSendRef(png, QStringLiteral("image/png"), token);
         return;
     }
 
     QByteArray frame;
-    if (encodeFrame(KIND_PNG, png, frame)) {
-        ClipboardLog::debug("ClipboardSync: outbound PNG frame queued (%d bytes from %s)",
+    if (encodeFrame(KIND_PNG, token, png, frame)) {
+        ClipboardLog::debug("ClipboardSync: outbound PNG frame queued (%d bytes from %s, token %u)",
                      static_cast<int>(frame.size()),
-                     sourceUtf8.constData());
+                     sourceUtf8.constData(),
+                     token);
         emit outboundFrame(frame);
     }
+}
+
+void ClipboardSync::sendTextOutbound(const QByteArray& utf8, quint32 token)
+{
+    if (utf8.isEmpty()) {
+        return;
+    }
+
+    if (utf8.size() > MAX_BLOB_BYTES) {
+        ClipboardLog::info("ClipboardSync: text payload %lld B exceeds %lld B blob cap, dropping",
+                    static_cast<long long>(utf8.size()),
+                    static_cast<long long>(MAX_BLOB_BYTES));
+        return;
+    }
+
+    uint64_t hash = hashBytes(utf8);
+    if (seenRecently(hash)) {
+        // This change was the echo of a payload the host just pushed to us.
+        return;
+    }
+    recordHash(hash);
+
+    if (shouldTransferOutOfBand(utf8.size())) {
+        ClipboardLog::debug("ClipboardSync: uploading outbound text blob (%lld bytes)",
+                     static_cast<long long>(utf8.size()));
+        // Sunshine's blob endpoint intentionally accepts only a bare
+        // RFC 6838 type/subtype without parameters. KIND_TEXT already
+        // defines the blob bytes as UTF-8.
+        uploadAndSendRef(utf8, QStringLiteral("text/plain"), token);
+        return;
+    }
+
+    QByteArray frame;
+    if (!encodeFrame(KIND_TEXT, token, utf8, frame)) {
+        return;
+    }
+
+    ClipboardLog::debug("ClipboardSync: outbound text frame queued (%d bytes, token %u)",
+                 static_cast<int>(frame.size()),
+                 token);
+    emit outboundFrame(frame);
 }
 
 bool ClipboardSync::tryExtractImageBytes(const QMimeData* mime,
@@ -705,8 +781,33 @@ void ClipboardSync::onLocalClipboardChanged()
     // multiple extraction paths rather than only mime->imageData().
     QByteArray png;
     QString imageSourceDescription;
-    if (extractClipboardPng(mime, png, &imageSourceDescription)) {
-        sendClipboardPng(png, imageSourceDescription);
+    const bool havePng = extractClipboardPng(mime, png, &imageSourceDescription);
+
+    // A clipboard change can genuinely carry both flavors (browser image
+    // copies attach the source URL, IM clients alt text). Emit both as a
+    // compound burst so aggregating peers restore the full clipboard; peers
+    // without aggregation apply the frames in order and keep the v1 outcome.
+    // Note the burst text frame is inline-only: a REF text frame would race
+    // the image frame onto the wire (blob upload latency) and flip legacy
+    // peers' final state to text, so oversize text is dropped from bursts.
+    QString text = cb->text();
+    QByteArray utf8;
+    if (!text.isEmpty()) {
+        utf8 = text.toUtf8();
+    }
+
+    if (havePng) {
+        if (!utf8.isEmpty() && utf8.size() <= MAX_PAYLOAD) {
+            const quint32 token = nextToken();
+            sendTextOutbound(utf8, token);
+            sendClipboardPng(png, imageSourceDescription, token);
+        } else {
+            if (!utf8.isEmpty()) {
+                ClipboardLog::info("ClipboardSync: burst text %lld B exceeds inline cap; sending image only",
+                            static_cast<long long>(utf8.size()));
+            }
+            sendClipboardPng(png, imageSourceDescription);
+        }
         return;
     }
 
@@ -728,51 +829,10 @@ void ClipboardSync::onLocalClipboardChanged()
         }
     }
 
-    QString text = cb->text();
-    if (text.isEmpty()) {
-        return;
-    }
-
-    QByteArray utf8 = text.toUtf8();
-    if (utf8.isEmpty()) {
-        return;
-    }
-
-    if (utf8.size() > MAX_BLOB_BYTES) {
-        ClipboardLog::info("ClipboardSync: text payload %lld B exceeds %lld B blob cap, dropping",
-                    static_cast<long long>(utf8.size()),
-                    static_cast<long long>(MAX_BLOB_BYTES));
-        return;
-    }
-
-    uint64_t hash = hashBytes(utf8);
-    if (seenRecently(hash)) {
-        // This change was the echo of a payload the host just pushed to us.
-        return;
-    }
-    recordHash(hash);
-
-    if (shouldTransferOutOfBand(utf8.size())) {
-        ClipboardLog::debug("ClipboardSync: uploading outbound text blob (%lld bytes)",
-                     static_cast<long long>(utf8.size()));
-        // Sunshine's blob endpoint intentionally accepts only a bare
-        // RFC 6838 type/subtype without parameters. KIND_TEXT already
-        // defines the blob bytes as UTF-8.
-        uploadAndSendRef(utf8, QStringLiteral("text/plain"));
-        return;
-    }
-
-    QByteArray frame;
-    if (!encodeFrame(KIND_TEXT, utf8, frame)) {
-        return;
-    }
-
-    ClipboardLog::debug("ClipboardSync: outbound text frame queued (%d bytes)",
-                 static_cast<int>(frame.size()));
-    emit outboundFrame(frame);
+    sendTextOutbound(utf8, 0);
 }
 
-bool ClipboardSync::encodeFrame(uint8_t kind, const QByteArray& payload, QByteArray& outFrame) const
+bool ClipboardSync::encodeFrame(uint8_t kind, quint32 token, const QByteArray& payload, QByteArray& outFrame) const
 {
     if (payload.size() > MAX_PAYLOAD) {
         return false;
@@ -785,8 +845,9 @@ bool ClipboardSync::encodeFrame(uint8_t kind, const QByteArray& payload, QByteAr
     outFrame.append(static_cast<char>(WIRE_VERSION));
     // u8 kind
     outFrame.append(static_cast<char>(kind));
-    // u32 token (LE) - we don't generate tokens client-side; 0 is accepted.
-    quint32 tokenLE = qToLittleEndian<quint32>(0);
+    // u32 token (LE) - 0 for standalone frames; frames of one compound burst
+    // share a non-zero token (see class comment).
+    quint32 tokenLE = qToLittleEndian<quint32>(token);
     outFrame.append(reinterpret_cast<const char*>(&tokenLE), sizeof(tokenLE));
     // u32 length (LE)
     quint32 lenLE = qToLittleEndian<quint32>(static_cast<quint32>(payload.size()));
@@ -798,6 +859,7 @@ bool ClipboardSync::encodeFrame(uint8_t kind, const QByteArray& payload, QByteAr
 
 bool ClipboardSync::decodeFrame(const QByteArray& frame,
                                 uint8_t& outKind,
+                                quint32& outToken,
                                 QByteArray& outPayload) const
 {
     // 1 + 1 + 4 + 4 = 10 byte header minimum.
@@ -812,6 +874,10 @@ bool ClipboardSync::decodeFrame(const QByteArray& frame,
     }
 
     outKind = p[1];
+
+    quint32 tokenLE = 0;
+    memcpy(&tokenLE, p + 2, sizeof(tokenLE));
+    outToken = qFromLittleEndian<quint32>(tokenLE);
 
     quint32 lenLE = 0;
     memcpy(&lenLE, p + 6, sizeof(lenLE));
@@ -975,7 +1041,7 @@ bool ClipboardSync::buildBlobUrl(const QString& tail, QUrl& outUrl) const
     return outUrl.isValid();
 }
 
-void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& mime)
+void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& mime, quint32 token)
 {
     QUrl url;
     if (!buildBlobUrl(QStringLiteral("/blob"), url)) {
@@ -996,7 +1062,7 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
     req.setSslConfiguration(sslConfig);
 
     QNetworkReply* reply = nam()->post(req, payload);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, mime, payloadSize = payload.size()]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, mime, token, payloadSize = payload.size()]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
             ClipboardLog::warn("ClipboardSync: blob upload failed: %s",
@@ -1023,16 +1089,35 @@ void ClipboardSync::uploadAndSendRef(const QByteArray& payload, const QString& m
         QByteArray json = QJsonDocument(meta).toJson(QJsonDocument::Compact);
 
         QByteArray frame;
-        if (!encodeFrame(KIND_REF, json, frame)) {
+        if (!encodeFrame(KIND_REF, token, json, frame)) {
             return;
         }
-        ClipboardLog::debug("ClipboardSync: outbound REF frame queued (%d bytes)",
-                     static_cast<int>(frame.size()));
+        ClipboardLog::debug("ClipboardSync: outbound REF frame queued (%d bytes, token %u)",
+                     static_cast<int>(frame.size()),
+                     token);
         emit outboundFrame(frame);
     });
 }
 
 void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qint64 advertisedSize)
+{
+    fetchBlob(id, advertisedSize, [this, mime](const QByteArray& bytes, const QString& fetchedMime) {
+        Q_UNUSED(fetchedMime);
+        // Trust the REF descriptor's mime over Content-Type.
+        if (mime == QStringLiteral("image/png")) {
+            applyInboundPng(bytes);
+        } else if (mime.startsWith(QStringLiteral("text/"))) {
+            applyInboundText(bytes);
+        } else {
+            ClipboardLog::info("ClipboardSync: dropping fetched blob with unsupported mime '%s'",
+                        mime.toUtf8().constData());
+        }
+    });
+}
+
+void ClipboardSync::fetchBlob(const QString& id,
+                              qint64 advertisedSize,
+                              const std::function<void(const QByteArray&, const QString&)>& onFetched)
 {
     QUrl url;
     if (!buildBlobUrl(QStringLiteral("/blob/") + id, url)) {
@@ -1047,7 +1132,7 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qin
     req.setSslConfiguration(sslConfig);
 
     QNetworkReply* reply = nam()->get(req);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, mime, advertisedSize]() {
+    connect(reply, &QNetworkReply::finished, this, [reply, onFetched, advertisedSize]() {
         reply->deleteLater();
         if (reply->error() != QNetworkReply::NoError) {
             ClipboardLog::warn("ClipboardSync: blob fetch failed: %s",
@@ -1073,14 +1158,168 @@ void ClipboardSync::fetchRefAndApply(const QString& id, const QString& mime, qin
                         static_cast<long long>(advertisedSize));
             return;
         }
-        // Trust the REF descriptor's mime over Content-Type.
-        if (mime == QStringLiteral("image/png")) {
-            applyInboundPng(bytes);
-        } else if (mime.startsWith(QStringLiteral("text/"))) {
-            applyInboundText(bytes);
-        } else {
-            ClipboardLog::info("ClipboardSync: dropping fetched blob with unsupported mime '%s'",
-                        mime.toUtf8().constData());
-        }
+        const QString contentType = reply->header(QNetworkRequest::ContentTypeHeader).toString();
+        onFetched(bytes, contentType);
     });
+}
+
+quint32 ClipboardSync::nextToken()
+{
+    quint32 token = m_NextToken++;
+    if (m_NextToken == 0) {
+        m_NextToken = 1;
+    }
+    return token;
+}
+
+void ClipboardSync::handleBurstFrame(uint8_t kind, quint32 token, const QByteArray& payload)
+{
+    if (!m_PendingBursts.contains(token)) {
+        if (m_PendingBursts.size() >= MAX_PENDING_BURSTS) {
+            // Defensive bound: a pathological sender must not grow the map
+            // without limit; drop the oldest (already-applied) burst.
+            ClipboardLog::warn("ClipboardSync: burst backlog exceeded; dropping oldest burst");
+            removeBurst(m_PendingBursts.constBegin().key());
+        }
+
+        BurstState state;
+        state.timer = new QTimer(this);
+        state.timer->setSingleShot(true);
+        connect(state.timer, &QTimer::timeout, this, [this, token]() {
+            removeBurst(token);
+        });
+        state.timer->start(BURST_RETENTION_MS);
+        m_PendingBursts.insert(token, state);
+    }
+
+    BurstState& state = m_PendingBursts[token];
+    if (kind == KIND_TEXT && !state.haveText) {
+        state.haveText = true;
+        state.textPayload = payload;
+    } else if (kind == KIND_PNG && !state.havePng) {
+        state.havePng = true;
+        state.pngPayload = payload;
+    } else {
+        // Duplicate kind for this token; keep the first copy.
+        return;
+    }
+
+    // Apply-as-arrive: the text applies instantly (no latency vs v1) and is
+    // retained so the image can upgrade the clipboard to one compound write
+    // carrying both flavors. A png arriving with no retained text applies
+    // standalone; compliant senders put text first, so this only happens
+    // when a text frame was lost (e.g. queue overflow) — the v1-style flip
+    // to image-only is then the correct degradation.
+    if (kind == KIND_PNG) {
+        if (state.haveText) {
+            applyCompound(state.textPayload, state.pngPayload);
+        } else {
+            applyInboundPng(state.pngPayload);
+        }
+    }
+}
+
+void ClipboardSync::burstFlavorResolved(quint32 token, uint8_t kind, const QByteArray& payload)
+{
+    if (kind == 0) {
+        // Unsupported REF mime: nothing to contribute.
+        return;
+    }
+
+    if (!m_PendingBursts.contains(token)) {
+        // Retention for this token already expired; the late blob still
+        // deserves to land on its own.
+        if (kind == KIND_TEXT) {
+            applyInboundText(payload);
+        } else {
+            applyInboundPng(payload);
+        }
+        return;
+    }
+
+    handleBurstFrame(kind, token, payload);
+}
+
+void ClipboardSync::removeBurst(quint32 token)
+{
+    const auto it = m_PendingBursts.find(token);
+    if (it == m_PendingBursts.end()) {
+        return;
+    }
+
+    QTimer* timer = it.value().timer;
+    m_PendingBursts.erase(it);
+    if (timer != nullptr) {
+        timer->stop();
+        timer->deleteLater();
+    }
+}
+
+void ClipboardSync::applyCompound(const QByteArray& text, const QByteArray& png)
+{
+    QClipboard* cb = QGuiApplication::clipboard();
+    if (cb == nullptr) {
+        return;
+    }
+
+    if (hasFileReferences(cb->mimeData())) {
+        ClipboardLog::debug("ClipboardSync: preserving local file clipboard; inbound compound ignored");
+        return;
+    }
+
+    const bool textOk = !text.isEmpty() && !text.contains('\0');
+    QImage image;
+    if (!image.loadFromData(png, "PNG") || image.isNull()) {
+        image = QImage();
+    }
+
+    if (textOk && !image.isNull()) {
+#ifdef Q_OS_MACOS
+        // Qt's macOS clipboard backend drops the text flavor from a
+        // QMimeData that also carries an image, so compound writes go
+        // through the native pasteboard instead.
+        if (ClipboardHelperWritePasteboardCompound(text.constData(),
+                                                   reinterpret_cast<const unsigned char*>(png.constData()),
+                                                   png.size())) {
+            recordHash(hashBytes(text));
+            recordHash(hashBytes(png));
+            recordImageHash(hashImagePixels(image));
+            ++m_PendingSelfWrites;
+            ClipboardLog::debug("ClipboardSync: applied compound clipboard (text %d B + PNG %d B)",
+                         text.size(),
+                         png.size());
+            return;
+        }
+        ClipboardLog::warn("ClipboardSync: native compound pasteboard write failed; falling back to image only");
+#endif
+
+        // Record every identity before writing: the byte hashes suppress an
+        // immediate verbatim echo, the pixel hash suppresses the delayed
+        // platform re-encode echo, and the compound write fires exactly one
+        // dataChanged, so one pending-self-write slot suffices.
+        recordHash(hashBytes(text));
+        recordHash(hashBytes(png));
+        recordImageHash(hashImagePixels(image));
+        ++m_PendingSelfWrites;
+
+        QMimeData* mime = new QMimeData();
+        mime->setText(QString::fromUtf8(text));
+        mime->setImageData(image);
+        // Provide raw PNG bytes too so apps that prefer image/png over
+        // CF_DIB get the lossless copy verbatim (mirrors applyInboundPng).
+        mime->setData(QStringLiteral("image/png"), png);
+        cb->setMimeData(mime);
+        ClipboardLog::debug("ClipboardSync: applied compound clipboard (text %d B + PNG %d B)",
+                     text.size(),
+                     png.size());
+        return;
+    }
+
+    // One flavor was unusable — degrade to a single-flavor apply (each of
+    // these records its own echo identities).
+    if (textOk) {
+        applyInboundText(text);
+    } else if (!image.isNull()) {
+        applyInboundPng(png);
+    }
 }

--- a/app/streaming/clipboardsync.h
+++ b/app/streaming/clipboardsync.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QByteArray>
+#include <QHash>
 #include <QMutex>
 #include <QPair>
 #include <QQueue>
@@ -10,6 +11,7 @@
 #include <QString>
 #include <QStringList>
 #include <cstdint>
+#include <functional>
 
 class QImage;
 class QMimeData;
@@ -39,6 +41,22 @@ struct ClipboardSyncHostContext
 // /api/v1/clipboard/blob endpoints) in both directions. Payloads above the
 // 65 KB single-packet cap are switched to KIND_REF transparently.
 // File / other payloads are accepted on the wire but ignored.
+//
+// Compound clipboard (v2, no wire-format change): a clipboard change that
+// carries BOTH text and an image is emitted as two consecutive frames
+// sharing a non-zero token, text frame first, image frame second. Peers
+// that don't aggregate simply apply the frames in order and end up with
+// the image — the exact v1 outcome — so no version negotiation is needed.
+// Aggregating peers apply each frame as it arrives (zero added latency vs
+// v1) and retain the text payload: when the image lands — inline or after
+// its REF blob fetch — the clipboard is upgraded with one compound write
+// carrying both flavors. Single-flavor changes keep the legacy token=0
+// single frame. token=0 is never aggregated (the Qt client historically
+// emitted it for every frame). Inside a burst the text frame is always
+// inline (a burst text payload larger than the wire cap is dropped rather
+// than deferred via REF, which would race the image frame onto the wire
+// and flip legacy peers' final state to text); the image frame may still
+// use KIND_REF.
 //
 // Echo suppression: when we either write a payload to the local clipboard
 // (because the host pushed it) or send a payload to the host (because we
@@ -89,6 +107,12 @@ public:
         return payloadBytes >= INLINE_THRESHOLD;
     }
 
+    // How long a burst's payloads are retained after their frames applied —
+    // purely a memory bound; application is immediate on arrival (see class
+    // comment).
+    static constexpr int BURST_RETENTION_MS = 5000;
+    static constexpr int MAX_PENDING_BURSTS = 32;
+
     // File copy/paste is not part of the clipboard sync protocol. Native file
     // clipboards often also expose a thumbnail or application icon as an image,
     // so callers must reject file references before considering image formats.
@@ -137,9 +161,22 @@ private slots:
     void onIncomingFrame(QByteArray frame);
 
 private:
-    bool encodeFrame(uint8_t kind, const QByteArray& payload, QByteArray& outFrame) const;
+    // Aggregation state for one inbound compound burst (frames sharing a
+    // non-zero token). Frames are applied as they arrive; the retained text
+    // lets the arriving image upgrade the clipboard to one compound write.
+    struct BurstState
+    {
+        QByteArray textPayload;
+        QByteArray pngPayload;
+        bool haveText = false;
+        bool havePng = false;
+        QTimer* timer = nullptr;
+    };
+
+    bool encodeFrame(uint8_t kind, quint32 token, const QByteArray& payload, QByteArray& outFrame) const;
     bool decodeFrame(const QByteArray& frame,
                      uint8_t& outKind,
+                     quint32& outToken,
                      QByteArray& outPayload) const;
 
     // Hash + TTL bookkeeping; not thread-safe, only touched from GUI thread.
@@ -157,7 +194,12 @@ private:
                           QByteArray& outPng,
                           const char* sourceDescription) const;
     void sendClipboardPng(const QByteArray& png,
-                          const QString& sourceDescription);
+                          const QString& sourceDescription,
+                          quint32 token = 0);
+    // Shared text outbound path for single-flavor changes (token 0) and the
+    // text frame of a compound burst. Applies the size cap, echo checks and
+    // inline-vs-REF choice, then emits.
+    void sendTextOutbound(const QByteArray& utf8, quint32 token);
     bool extractClipboardPng(const QMimeData* mime,
                              QByteArray& outPng,
                              QString* outSourceDescription = nullptr) const;
@@ -176,10 +218,20 @@ private:
     // QNetworkAccessManager event-loop callbacks land back on the GUI thread.
     bool buildBlobUrl(const QString& tail, QUrl& outUrl) const;
     QNetworkAccessManager* nam();
-    void uploadAndSendRef(const QByteArray& payload, const QString& mime);
+    void uploadAndSendRef(const QByteArray& payload, const QString& mime, quint32 token = 0);
     void fetchRefAndApply(const QString& id, const QString& mime, qint64 advertisedSize);
+    void fetchBlob(const QString& id,
+                   qint64 advertisedSize,
+                   const std::function<void(const QByteArray&, const QString&)>& onFetched);
     void applyInboundText(const QByteArray& payload);
     void applyInboundPng(const QByteArray& payload);
+
+    // Compound burst aggregation (see class comment).
+    quint32 nextToken();
+    void handleBurstFrame(uint8_t kind, quint32 token, const QByteArray& payload);
+    void burstFlavorResolved(quint32 token, uint8_t kind, const QByteArray& payload);
+    void removeBurst(quint32 token);
+    void applyCompound(const QByteArray& text, const QByteArray& png);
 
     ClipboardSyncHostContext m_HostContext;
     QNetworkAccessManager* m_Nam = nullptr;
@@ -187,6 +239,8 @@ private:
     bool m_Active = false;
     QQueue<QPair<uint64_t, qint64>> m_EchoCache;       // (byte hash, timestamp_ms)
     QQueue<QPair<uint64_t, qint64>> m_ImageEchoCache;  // (pixel hash, timestamp_ms)
+    QHash<quint32, BurstState> m_PendingBursts;
+    quint32 m_NextToken = 1;
 
 #ifdef Q_OS_MACOS
     QTimer* m_PasteboardPollTimer = nullptr;

--- a/clipboard-helper/macos.mm
+++ b/clipboard-helper/macos.mm
@@ -9,3 +9,45 @@ extern "C" int ClipboardHelperPasteboardChangeCount()
 {
     return static_cast<int>([[NSPasteboard generalPasteboard] changeCount]);
 }
+
+// Write text and image flavors in ONE pasteboard transaction. Qt's macOS
+// backend drops the text flavor from a QMimeData that also carries an
+// image, so compound clipboard writes must bypass it. Returns false when
+// either payload is unusable; callers then fall back to single-flavor
+// writes.
+extern "C" bool ClipboardHelperWritePasteboardCompound(const char* utf8Text,
+                                                       const unsigned char* pngBytes,
+                                                       int pngLength)
+{
+    if (utf8Text == nullptr || pngBytes == nullptr || pngLength <= 0) {
+        return false;
+    }
+
+    @autoreleasepool {
+        NSString* text = [[NSString alloc] initWithBytes:utf8Text
+                                                  length:strlen(utf8Text)
+                                                encoding:NSUTF8StringEncoding];
+        NSData* pngData = [NSData dataWithBytes:pngBytes length:static_cast<NSUInteger>(pngLength)];
+        NSImage* image = [[NSImage alloc] initWithData:pngData];
+        if (text.length == 0 || pngData.length == 0 || image == nil) {
+            return false;
+        }
+
+        NSData* tiff = [image TIFFRepresentation];
+
+        NSPasteboard* pb = [NSPasteboard generalPasteboard];
+        NSMutableArray<NSPasteboardType>* types = [NSMutableArray array];
+        [types addObject:NSPasteboardTypeString];
+        [types addObject:NSPasteboardTypePNG];
+        if (tiff != nil) {
+            [types addObject:NSPasteboardTypeTIFF];
+        }
+        [pb declareTypes:types owner:nil];
+        [pb setString:text forType:NSPasteboardTypeString];
+        [pb setData:pngData forType:NSPasteboardTypePNG];
+        if (tiff != nil) {
+            [pb setData:tiff forType:NSPasteboardTypeTIFF];
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
> 原型 PR #213 在 #211 合并删分支时被 GitHub 误关闭（base 已删无法重开），本 PR 为同一分支重建，base 直接指向 master。#211 已合入。

## 背景

v1 是"快照单 payload"模型：混合剪贴板（图 + 来源 URL/文字）只同步图，对端粘贴到纯文本目标拿不到文字，富文本目标也只有裸图。RDP 的 CLIPRDR 用全格式通告实现了完整体验；本 PR 用最小的协议扩展达到 text+image 复合。

## 协议设计（无 wire 格式变化、无版本协商、服务端零改动）

- **发射**：混合变更 = 两帧共享同一**非零** token，文字帧在前、图片帧在后；每帧按现有规则内联或走 REF blob（>60KB）
- **接收（apply-as-arrive）**：每帧到达即应用（**比 v1 零额外延迟**），同时保留文字 payload；图片（内联或 blob 拉取完成）到达时用**一次复合写入**升级剪贴板，两种 flavor 共存
- **兼容性靠构造保证**：
  - 旧端收到 burst → 逐帧独立应用，最终态 = 图片 = v1 现状（帧序保证）
  - token=0 永不聚合（旧 Qt 客户端恒发 0）→ 立即应用
  - 旧 Rust 端非零单帧 → 立即应用（无窗口等待）
- burst 内文字恒内联：REF 文字帧会因 blob 上传延迟乱序上 wire，翻转旧端最终态为文字；超限文字直接丢弃只发图
- **服务端已验证为不透明 FIFO 逐帧转发**（bridge 无界 deque、SSE 逐事件保序、无去重/限流），零改动

## 平台要点

**macOS**：Qt 6.11 的 QClipboard 后端会丢弃同时携带 text+image 的 QMimeData 中的文字 flavor（已用最小程序复现）——复合写入绕过 Qt，走原生 `NSPasteboard declareTypes` 一次声明 string+PNG+TIFF（clipboard-helper/macos.mm）。

**回声抑制**：复合应用前记录 text 哈希 + 图片字节哈希 + 像素哈希（#211 的双缓存），`m_PendingSelfWrites` 单次自增；复合写入触发的混合 snapshot 逐帧命中全部丢弃。

## 实测（macOS 26.6.2，独立 helper harness，无串流干扰）

| 场景 | 结果 |
|---|---|
| 本地混合复制（PNGf+utf8 多 flavor） | ✅ 两帧同 token，文字在前 |
| 注入复合 burst（帧间隔 300ms） | ✅ 文字即时应用 → 图片到达复合升级，剪贴板 utf8+PNGf+TIFF+Unicode 四 flavor 共存，pbpaste 可读 |
| token=0 单帧 | ✅ 立即应用 |
| 非零 token 单帧（模拟旧 Rust 端） | ✅ 立即应用 |
| 单文字/单图片出站 | ✅ token=0 单帧无回归 |
| 回声 | ✅ 复合应用后 0 帧重发 |

配套主机侧：qiin2333/sunshine-control-panel#125（图片优先 + burst 发射/聚合 + Windows 多格式复合写入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clipboard synchronization now preserves text and PNG images together when both are copied.
  * Combined clipboard content is applied as a single update, including on macOS.
  * Single-item clipboard synchronization continues to work as before.
* **Bug Fixes**
  * Improved handling of clipboard data arriving in separate frames, reducing incomplete or split clipboard updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->