### PR TITLE
feat(overlay): 悬浮菜单码率无级调整（滑块行 + 预设锚点）

### DIFF
--- a/app/gui/settings/BasicSettingsPage.qml
+++ b/app/gui/settings/BasicSettingsPage.qml
@@ -615,8 +615,9 @@ Column {
                     width: parent.width
 
                     // 使用对数刻度来实现非线性调整
+                    // 上限对齐 Sunshine /bitrate 接口的 800000 Kbps 拒绝线
                     property real logMin: Math.log(500)
-                    property real logMax: Math.log(2000000)
+                    property real logMax: Math.log(800000)
 
                     value: Math.log(StreamingPreferences.bitrateKbps)
                     stepSize: (logMax - logMin) / 200

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -2973,50 +2973,97 @@ void Session::requestRuntimeBitrateChange(int bitrateKbps)
         return;
     }
 
-    try {
-        NvHTTP http(m_Computer);
+    // Coalesce rapid slider commits. A worker applying earlier values picks
+    // up the newest pending one via startRuntimeBitrateWorker() on finish,
+    // so the synchronous HTTP request never runs on the stream loop.
+    m_PendingRuntimeBitrateKbps.store(bitrateKbps, std::memory_order_release);
+    if (m_RuntimeBitrateInFlight.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+    startRuntimeBitrateWorker();
+}
 
-        // Build clientname the same way as openConnection() does for /launch
-        QString clientname = QHostInfo::localHostName();
-        if (!m_Computer->uuid.isEmpty()) {
-            QString pairname = NvComputer::getPairname(m_Computer->uuid);
-            if (!pairname.isEmpty()) {
-                clientname = pairname;
-            }
+void Session::startRuntimeBitrateWorker()
+{
+    // Snapshot the connection under lock; the worker never touches Session
+    // or NvComputer (same pattern as startRemoteUsb()).
+    NvAddress address;
+    uint16_t httpsPort;
+    QString uuid;
+    QSslCertificate certificate;
+    {
+        QReadLocker locker(&m_Computer->lock);
+        address = m_Computer->activeAddress;
+        httpsPort = m_Computer->activeHttpsPort;
+        uuid = m_Computer->uuid;
+        certificate = m_Computer->serverCert;
+    }
+
+    // Build clientname the same way as openConnection() does for /launch
+    QString clientname = QHostInfo::localHostName();
+    if (!uuid.isEmpty()) {
+        QString pairname = NvComputer::getPairname(uuid);
+        if (!pairname.isEmpty()) {
+            clientname = pairname;
         }
-
-        QString args = QString("bitrate=%1&clientname=%2")
-                           .arg(bitrateKbps)
-                           .arg(clientname);
-
-        QString response = http.openConnectionToString(
-            http.m_BaseUrlHttps,
-            "bitrate",
-            args,
-            5000,
-            NvHTTP::NVLL_VERBOSE);
-
-        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                    "Runtime bitrate change to %d kbps: %s",
-                    bitrateKbps,
-                    response.toUtf8().constData());
-
-        m_AbrCurrentBitrateKbps->store(bitrateKbps);
     }
-    catch (const GfeHttpResponseException& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "Runtime bitrate change failed (HTTP): %s",
-                     e.toQString().toUtf8().constData());
-    }
-    catch (const QtNetworkReplyException& e) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "Runtime bitrate change failed (Network): %s",
-                     e.toQString().toUtf8().constData());
-    }
-    catch (...) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "Runtime bitrate change failed: unknown error");
-    }
+
+    auto bitrateToApply = std::make_shared<int>(
+        m_PendingRuntimeBitrateKbps.exchange(0, std::memory_order_acq_rel));
+    auto appliedBitrate = std::make_shared<std::atomic_int>(-1);
+
+    auto worker = QThread::create([bitrateToApply, appliedBitrate, address, httpsPort,
+                                   uuid, certificate, clientname] {
+        try {
+            NvHTTP http(address, httpsPort, certificate, true, nullptr, uuid);
+            QString args = QString("bitrate=%1&clientname=%2")
+                               .arg(*bitrateToApply)
+                               .arg(clientname);
+            QString response = http.openConnectionToString(
+                http.m_BaseUrlHttps,
+                "bitrate",
+                args,
+                5000,
+                NvHTTP::NVLL_VERBOSE);
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Runtime bitrate change to %d kbps: %s",
+                        *bitrateToApply,
+                        response.toUtf8().constData());
+            appliedBitrate->store(*bitrateToApply);
+        }
+        catch (const GfeHttpResponseException& e) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "Runtime bitrate change failed (HTTP): %s",
+                         e.toQString().toUtf8().constData());
+        }
+        catch (const QtNetworkReplyException& e) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "Runtime bitrate change failed (Network): %s",
+                         e.toQString().toUtf8().constData());
+        }
+        catch (...) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "Runtime bitrate change failed: unknown error");
+        }
+    });
+    connect(worker, &QThread::finished, this, [this, appliedBitrate]() {
+        const int applied = appliedBitrate->load();
+        if (applied > 0) {
+            m_AbrCurrentBitrateKbps->store(applied);
+            showStreamingToast(tr("Bitrate: %1").arg(
+                    OverlayMenuPanel::formatBitrateKbps(applied)));
+        }
+        // Commits that landed mid-flight are still pending; apply the
+        // newest one before going idle.
+        if (m_PendingRuntimeBitrateKbps.load(std::memory_order_acquire) != 0) {
+            startRuntimeBitrateWorker();
+        }
+        else {
+            m_RuntimeBitrateInFlight.store(false, std::memory_order_release);
+        }
+    });
+    connect(worker, &QThread::finished, worker, &QObject::deleteLater);
+    worker->start();
 }
 
 void Session::startSunshineAbr()
@@ -4654,10 +4701,9 @@ void Session::exec()
         m_Preferences->autoAdjustBitrate = false;
         m_Preferences->bitrateKbps = bitrateKbps;
         m_Preferences->save();
-        // Apply to the running session via the Sunshine API
+        // Applied asynchronously; the toast confirms the value the host
+        // actually accepted (see startRuntimeBitrateWorker()).
         requestRuntimeBitrateChange(bitrateKbps);
-        showStreamingToast(QString("Bitrate: %1").arg(
-                OverlayMenuPanel::formatBitrateKbps(bitrateKbps)));
     });
     updateRemoteUsbMenuState();
     m_MenuPanel->setCloseCallback([this]() {

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -2778,36 +2778,9 @@ void Session::dispatchQtMenuAction(OverlayMenuPanel::MenuAction action)
         return;
     }
 
-    // --- Bitrate presets ---
-    case OverlayMenuPanel::MenuAction::SetBitrate1000:
-    case OverlayMenuPanel::MenuAction::SetBitrate2000:
-    case OverlayMenuPanel::MenuAction::SetBitrate5000:
-    case OverlayMenuPanel::MenuAction::SetBitrate10000:
-    case OverlayMenuPanel::MenuAction::SetBitrate20000:
-    case OverlayMenuPanel::MenuAction::SetBitrate30000:
-    case OverlayMenuPanel::MenuAction::SetBitrate50000:
-    case OverlayMenuPanel::MenuAction::SetBitrate100000:
-    {
-        static const int kBitrateMap[] = {
-            1000, 2000, 5000, 10000, 20000, 30000, 50000, 100000
-        };
-        int idx = (int)action - (int)OverlayMenuPanel::MenuAction::SetBitrate1000;
-        if (idx >= 0 && idx < 8) {
-            int newBitrate = kBitrateMap[idx];
-            // Save preference for future sessions
-            m_Preferences->bitrateKbps = newBitrate;
-            m_Preferences->save();
-            // Try to change bitrate in the current session via Sunshine API
-            requestRuntimeBitrateChange(newBitrate);
-            // Show toast notification
-            if (newBitrate >= 1000) {
-                showStreamingToast(QString("Bitrate: %1 Mbps").arg(newBitrate / 1000));
-            } else {
-                showStreamingToast(QString("Bitrate: %1 Kbps").arg(newBitrate));
-            }
-        }
-        return;
-    }
+    // --- Bitrate ---
+    // Adjustments from the overlay menu (scrubber row + presets) arrive via
+    // the panel's bitrate change callback; nothing to dispatch here.
 
 #ifdef MOONLIGHT_ENABLE_FUNCTION_TESTS
     case OverlayMenuPanel::MenuAction::OpenStylusReplayPanel:
@@ -4676,6 +4649,16 @@ void Session::exec()
     m_MenuPanel->setRemoteUsbReleaseCallback([this] {
         stopRemoteUsb();
     });
+    m_MenuPanel->setBitrateChangeCallback([this](int bitrateKbps) {
+        // Manual adjustment takes over from the settings page auto-recompute.
+        m_Preferences->autoAdjustBitrate = false;
+        m_Preferences->bitrateKbps = bitrateKbps;
+        m_Preferences->save();
+        // Apply to the running session via the Sunshine API
+        requestRuntimeBitrateChange(bitrateKbps);
+        showStreamingToast(QString("Bitrate: %1").arg(
+                OverlayMenuPanel::formatBitrateKbps(bitrateKbps)));
+    });
     updateRemoteUsbMenuState();
     m_MenuPanel->setCloseCallback([this]() {
         // Record close timestamp for edge-trigger debounce
@@ -5324,6 +5307,12 @@ void Session::exec()
                         break;
                     case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
                         m_MenuPanel->gamepadMoveDown();
+                        break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+                        m_MenuPanel->gamepadAdjustSlider(-1);
+                        break;
+                    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+                        m_MenuPanel->gamepadAdjustSlider(1);
                         break;
                     case SDL_CONTROLLER_BUTTON_A:
                         m_MenuPanel->gamepadSelect();

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -218,6 +218,7 @@ private:
     void syncQtOverlayWindowsWithSdlWindowState();
     void dispatchQtMenuAction(OverlayMenuPanel::MenuAction action);
     void requestRuntimeBitrateChange(int bitrateKbps);
+    void startRuntimeBitrateWorker();
     void showStreamingToast(const QString& message, int durationMs = 2000);
     void processQtOverlayEvents();
     void updateFileMappingMenuState();
@@ -409,6 +410,10 @@ private:
     RTP_VIDEO_STATS m_LastAbrVideoStats;
     std::shared_ptr<std::atomic_bool> m_AbrFeedbackInFlight;
     std::shared_ptr<std::atomic_int> m_AbrCurrentBitrateKbps;
+    // Runtime bitrate requests coalesce here; a single background worker
+    // applies the newest value so HTTP never blocks the stream loop.
+    std::atomic_int m_PendingRuntimeBitrateKbps { 0 };
+    std::atomic_bool m_RuntimeBitrateInFlight { false };
     OverlayMenuPanel* m_MenuPanel; // Qt-based overlay menu window
     OverlayMenuButton* m_MenuButton; // Qt-based floating menu button
     OverlayToast* m_Toast;           // Qt-based toast notification

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -700,6 +700,7 @@ void OverlayMenuPanel::showInternal()
     m_CurrentLevel = 0;
     m_HoveredIndex = -1;
     m_ContentOffset = 0;
+    m_WheelAccum = 0;
     m_SliderDragging = false;
     m_SliderPressedZone = SliderZone::None;
     m_SliderHotZone = SliderZone::None;
@@ -891,6 +892,7 @@ void OverlayMenuPanel::closeMenu()
     m_Visible = false;
     m_Closing = true;
     m_HoveredIndex = -1;
+    m_WheelAccum = 0;
 
     // A close can land mid-drag (e.g. window focus loss). Drop the drag and
     // the mouse grab so the next show doesn't treat motion as scrubbing.
@@ -1393,6 +1395,8 @@ void OverlayMenuPanel::wheelEvent(QWheelEvent* event)
     const int idx = itemAtPos(pos);
     if (idx < 0 || idx >= (int)m_MenuLevels[m_CurrentLevel].items.size()
             || m_MenuLevels[m_CurrentLevel].items[idx].type != MenuItemType::Slider) {
+        // Don't carry a partial notch into a later scrub session.
+        m_WheelAccum = 0;
         event->ignore();
         return;
     }

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -20,6 +20,15 @@ const QColor MenuDim("#AEB3AB");
 const QColor MenuFaint("#7E858E");
 const QColor MenuAccent("#39C5BB");
 const QColor MenuDanger("#FF876F");
+
+// Bitrate scrubber range and granularity — same log scale as the settings
+// page slider (HardSlider over log(500)..log(2000000)).
+constexpr int kBitrateMinKbps = 500;
+constexpr int kBitrateMaxKbps = 2000000;
+constexpr int kBitrateLogSteps = 200;
+const double kBitrateLogSpan = qLn(kBitrateMaxKbps / double(kBitrateMinKbps));
+// Idle window after the last scrub tick before the change is committed.
+constexpr int kBitrateCommitDelayMs = 450;
 }
 
 OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
@@ -111,6 +120,11 @@ OverlayMenuPanel::OverlayMenuPanel(QWindow* parent)
         else {
             schedulePointerOutsideCheck();
         }
+    });
+
+    m_BitrateCommitTimer.setSingleShot(true);
+    connect(&m_BitrateCommitTimer, &QTimer::timeout, this, [this]() {
+        commitBitrateNow();
     });
 
     buildMenuLevels();
@@ -216,25 +230,19 @@ void OverlayMenuPanel::buildMenuLevels()
                                MenuAction::TogglePointerRegionLock, 0, true, false, false});
     m_MenuLevels.push_back(shortcuts);
 
-    // === Level 2: Bitrate presets ===
+    // === Level 2: Bitrate (log-scale scrubber row + presets) ===
     MenuLevel bitrate;
     bitrate.title = tr("Bitrate");
-    bitrate.items.push_back({tr("1 Mbps"),    QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate1000,   0, true, false, false});
-    bitrate.items.push_back({tr("2 Mbps"),    QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate2000,   0, true, false, false});
-    bitrate.items.push_back({tr("5 Mbps"),    QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate5000,   0, true, false, false});
-    bitrate.items.push_back({tr("10 Mbps"),   QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate10000,  0, true, false, false});
-    bitrate.items.push_back({tr("20 Mbps"),   QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate20000,  0, true, false, false});
-    bitrate.items.push_back({tr("30 Mbps"),   QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate30000,  0, true, false, false});
-    bitrate.items.push_back({tr("50 Mbps"),   QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate50000,  0, true, false, false});
-    bitrate.items.push_back({tr("100 Mbps"),  QString(), MenuItemType::Action,
-                             MenuAction::SetBitrate100000, 0, true, false, false});
+    bitrate.items.push_back({QString(), QString(), MenuItemType::Slider,
+                             MenuAction::MenuActionMax, 0, true, false, true});
+    static const int kBitratePresets[] = {
+        1000, 2000, 5000, 10000, 20000, 30000, 50000, 100000
+    };
+    for (int kbps : kBitratePresets) {
+        bitrate.items.push_back({formatBitrateKbps(kbps), QString(), MenuItemType::Action,
+                                 MenuAction::SetBitrate, 0, true, false, false,
+                                 QString::number(kbps)});
+    }
     m_MenuLevels.push_back(bitrate);
 
     // === Level 3: Overlay menu placement ===
@@ -312,6 +320,10 @@ void OverlayMenuPanel::buildMenuLevels()
     if (m_CurrentLevel >= static_cast<int>(m_MenuLevels.size())) {
         m_CurrentLevel = 0;
     }
+
+    // Rebuilds (gamepad set / USB refresh) wipe derived details; re-stamp
+    // the bitrate state so the scrubber row and preset checkmarks survive.
+    refreshBitrateDetails();
 }
 
 // ---------------------------------------------------------------------------
@@ -346,40 +358,188 @@ void OverlayMenuPanel::updateBitrateState(int bitrateKbps)
 {
     if (m_MenuLevels.empty()) return;
 
-    // Show current bitrate as detail text on the Bitrate category (level 0)
+    if (m_BitrateCommitTimer.isActive()) {
+        // A scrub is still pending commit; it will land shortly and update
+        // the preference. Don't clobber the slider with the stale value.
+        return;
+    }
+
+    m_BitrateKbps = qBound(kBitrateMinKbps, bitrateKbps, kBitrateMaxKbps);
+    m_CommittedBitrateKbps = m_BitrateKbps;
+    refreshBitrateDetails();
+    forceRepaint();
+}
+
+// ---------------------------------------------------------------------------
+// Bitrate slider row
+// ---------------------------------------------------------------------------
+
+QString OverlayMenuPanel::formatBitrateKbps(int kbps)
+{
+    if (kbps >= 1000000) {
+        const bool whole = kbps % 1000000 == 0;
+        return QStringLiteral("%1 Gbps").arg(kbps / 1000000.0, 0, 'f', whole ? 0 : 1);
+    }
+    if (kbps >= 1000) {
+        const bool whole = kbps % 1000 == 0;
+        return QStringLiteral("%1 Mbps").arg(kbps / 1000.0, 0, 'f', whole ? 0 : 1);
+    }
+    return QStringLiteral("%1 kbps").arg(kbps);
+}
+
+void OverlayMenuPanel::refreshBitrateDetails()
+{
+    if (m_MenuLevels.empty()) return;
+
+    // Current bitrate as detail text on the Bitrate category (level 0)
     for (auto& item : m_MenuLevels[0].items) {
         if (item.type == MenuItemType::SubMenu && item.targetLevel == 2) {
-            if (bitrateKbps >= 1000) {
-                item.detail = QString("%1 Mbps").arg(bitrateKbps / 1000);
-            } else {
-                item.detail = QString("%1 kbps").arg(bitrateKbps);
-            }
+            item.detail = formatBitrateKbps(m_BitrateKbps);
             break;
         }
     }
 
-    // Mark the active bitrate preset in level 2
+    // Mark the active preset (✓) in level 2; custom values stay unmarked
+    // since the scrubber row itself shows the exact value.
     if ((int)m_MenuLevels.size() > 2) {
-        auto actionToKbps = [](MenuAction a) -> int {
-            switch (a) {
-            case MenuAction::SetBitrate1000:   return 1000;
-            case MenuAction::SetBitrate2000:   return 2000;
-            case MenuAction::SetBitrate5000:   return 5000;
-            case MenuAction::SetBitrate10000:  return 10000;
-            case MenuAction::SetBitrate20000:  return 20000;
-            case MenuAction::SetBitrate30000:  return 30000;
-            case MenuAction::SetBitrate50000:  return 50000;
-            case MenuAction::SetBitrate100000: return 100000;
-            default: return -1;
-            }
-        };
         for (auto& item : m_MenuLevels[2].items) {
-            if (item.type == MenuItemType::Action) {
-                int kbps = actionToKbps(item.action);
-                item.detail = (kbps == bitrateKbps) ? QString::fromUtf8("\342\234\223") : QString();
+            if (item.action == MenuAction::SetBitrate) {
+                item.detail = (item.payload.toInt() == m_BitrateKbps)
+                                  ? QString::fromUtf8("\342\234\223") : QString();
             }
         }
     }
+}
+
+double OverlayMenuPanel::bitrateFraction() const
+{
+    return qBound(0.0, qLn(m_BitrateKbps / double(kBitrateMinKbps)) / kBitrateLogSpan, 1.0);
+}
+
+void OverlayMenuPanel::setBitrateKbps(int bitrateKbps)
+{
+    bitrateKbps = qBound(kBitrateMinKbps, bitrateKbps, kBitrateMaxKbps);
+    // Round to display-friendly granularity so the label doesn't flicker
+    // while scrubbing (also keeps committed values tidy).
+    if (bitrateKbps < 10000) {
+        bitrateKbps = qRound(bitrateKbps / 50.0) * 50;
+    } else if (bitrateKbps < 100000) {
+        bitrateKbps = qRound(bitrateKbps / 500.0) * 500;
+    } else {
+        bitrateKbps = qRound(bitrateKbps / 5000.0) * 5000;
+    }
+    bitrateKbps = qBound(kBitrateMinKbps, bitrateKbps, kBitrateMaxKbps);
+    if (bitrateKbps == m_BitrateKbps) return;
+
+    m_BitrateKbps = bitrateKbps;
+    refreshBitrateDetails();
+    m_BitrateCommitTimer.start(kBitrateCommitDelayMs);
+    forceRepaint();
+}
+
+void OverlayMenuPanel::setBitrateFromFraction(double fraction)
+{
+    fraction = qBound(0.0, fraction, 1.0);
+    setBitrateKbps(qRound(kBitrateMinKbps * qExp(fraction * kBitrateLogSpan)));
+}
+
+void OverlayMenuPanel::adjustBitrateStep(int direction, int multiplier)
+{
+    const double step = (kBitrateLogSpan / kBitrateLogSteps) * qMax(1, multiplier);
+    setBitrateFromFraction(bitrateFraction() + direction * step);
+}
+
+void OverlayMenuPanel::commitBitrateNow()
+{
+    m_BitrateCommitTimer.stop();
+    if (m_BitrateKbps == m_CommittedBitrateKbps) return;
+
+    m_CommittedBitrateKbps = m_BitrateKbps;
+    if (m_BitrateChangeCallback) {
+        m_BitrateChangeCallback(m_BitrateKbps);
+    }
+}
+
+void OverlayMenuPanel::selectBitratePreset(const MenuItem& item)
+{
+    // Presets snap the scrubber and commit immediately, but keep the menu
+    // open so the value can be fine-tuned right away.
+    beginInteraction();
+    m_BitrateKbps = qBound(kBitrateMinKbps, item.payload.toInt(), kBitrateMaxKbps);
+    refreshBitrateDetails();
+    commitBitrateNow();
+    forceRepaint();
+}
+
+OverlayMenuPanel::SliderRowRects OverlayMenuPanel::sliderRowRects(int contentWidth, int itemY) const
+{
+    const int textPad = 16;
+    const int buttonSize = 22;
+    const int buttonGap = 4;
+
+    SliderRowRects r;
+    r.value = QRect(textPad, itemY, 78, m_ItemHeight);
+    r.plus = QRect(contentWidth - textPad - buttonSize,
+                   itemY + (m_ItemHeight - buttonSize) / 2, buttonSize, buttonSize);
+    r.minus = QRect(r.plus.x() - buttonSize - buttonGap, r.plus.y(),
+                    buttonSize, buttonSize);
+    const int trackLeft = r.value.right() + 1 + 8;
+    const int trackRight = r.minus.x() - 6;
+    r.track = QRect(trackLeft, itemY + m_ItemHeight / 2 - 3,
+                    qMax(0, trackRight - trackLeft), 6);
+    return r;
+}
+
+OverlayMenuPanel::SliderZone OverlayMenuPanel::sliderZoneAt(const QPoint& localPos, int rowIdx) const
+{
+    const auto& items = m_MenuLevels[m_CurrentLevel].items;
+    if (rowIdx < 0 || rowIdx >= (int)items.size()
+            || items[rowIdx].type != MenuItemType::Slider) {
+        return SliderZone::None;
+    }
+
+    const int itemY = m_TitleHeight + m_Padding + rowIdx * m_ItemHeight;
+    const SliderRowRects r = sliderRowRects(width() - 2 * m_ShadowMargin, itemY);
+
+    // Buttons win over the track so their hit area feels solid.
+    if (r.minus.adjusted(-2, -2, 2, 2).contains(localPos)) return SliderZone::Minus;
+    if (r.plus.adjusted(-2, -2, 2, 2).contains(localPos)) return SliderZone::Plus;
+    if (QRect(r.track.x() - 4, itemY, r.track.width() + 8, m_ItemHeight).contains(localPos)) {
+        return SliderZone::Track;
+    }
+    return SliderZone::None;
+}
+
+void OverlayMenuPanel::gamepadAdjustSlider(int direction)
+{
+    if (!m_Visible) return;
+    const auto& items = m_MenuLevels[m_CurrentLevel].items;
+
+    // D-pad left/right anywhere in the scrubber's submenu drives the slider;
+    // focus follows so the highlight shows what is being adjusted.
+    int rowIdx = -1;
+    for (int i = 0; i < (int)items.size(); i++) {
+        if (items[i].type == MenuItemType::Slider) {
+            rowIdx = i;
+            break;
+        }
+    }
+    if (rowIdx < 0) return;
+
+    beginInteraction();
+    if (m_HoveredIndex != rowIdx) {
+        m_HoveredIndex = rowIdx;
+        m_SliderAdjustStreak = 0;
+        forceRepaint();
+    }
+    if (m_SliderAdjustClock.isValid() && m_SliderAdjustClock.elapsed() <= 350) {
+        m_SliderAdjustStreak++;
+    } else {
+        m_SliderAdjustStreak = 0;
+    }
+    m_SliderAdjustClock.start();
+    // 1x → 2x → 4x → 8x (capped) while the d-pad is held or rapidly tapped.
+    adjustBitrateStep(direction, 1 << qMin(m_SliderAdjustStreak / 2, 3));
 }
 
 void OverlayMenuPanel::updateMenuPositionState(MenuAction activePlacementAction)
@@ -954,6 +1114,53 @@ void OverlayMenuPanel::paintEvent(QPaintEvent*)
             p.fillRect(QRect(trackX + (item.toggleState ? trackW - 16 : 4),
                              trackY + 4, 12, 12), item.toggleState ? MenuSurface : MenuDim);
         }
+        // --- Slider item (bitrate scrubber) ---
+        else if (item.type == MenuItemType::Slider) {
+            const SliderRowRects r = sliderRowRects(cw, itemY);
+            const bool sliderFocused = i == m_HoveredIndex && item.enabled;
+
+            // Current value in the shared brand accent.
+            p.setFont(m_LabelFont);
+            p.setPen(sliderFocused ? MenuAccent : MenuText);
+            p.drawText(r.value, Qt::AlignLeft | Qt::AlignVCenter,
+                       formatBitrateKbps(m_BitrateKbps));
+
+            // Log-scale track: hover base, accent fill up to the square thumb.
+            p.fillRect(r.track, MenuHover);
+            p.setPen(QPen(MenuLine, 1));
+            p.drawRect(r.track);
+            const double frac = bitrateFraction();
+            const int fillW = qRound(r.track.width() * frac);
+            if (fillW > 0) {
+                p.fillRect(QRect(r.track.x(), r.track.y(), fillW, r.track.height()),
+                           MenuAccent);
+            }
+            const int thumbW = 10, thumbH = 16;
+            const int thumbX = qBound(r.track.x() - thumbW / 2,
+                                      r.track.x() + fillW - thumbW / 2,
+                                      r.track.x() + r.track.width() - thumbW / 2);
+            const QRect thumb(thumbX, itemY + (m_ItemHeight - thumbH) / 2, thumbW, thumbH);
+            p.fillRect(thumb, m_SliderDragging ? MenuAccent : MenuText);
+            p.setPen(QPen(MenuLine, 1));
+            p.drawRect(thumb);
+
+            // −/+ steppers with hover/pressed feedback
+            const QRect zones[] = { r.minus, r.plus };
+            const SliderZone zoneIds[] = { SliderZone::Minus, SliderZone::Plus };
+            const QString glyphs[] = { QStringLiteral("-"), QStringLiteral("+") };
+            for (int z = 0; z < 2; z++) {
+                const bool hot = sliderFocused && m_SliderHotZone == zoneIds[z];
+                const bool pressed = m_SliderPressedZone == zoneIds[z];
+                if (hot || pressed) {
+                    p.fillRect(zones[z], pressed ? MenuAccent : MenuHover);
+                }
+                p.setPen(QPen(pressed ? MenuAccent : MenuLine, 1));
+                p.drawRect(zones[z]);
+                p.setFont(m_LabelFont);
+                p.setPen(hot || pressed ? MenuText : MenuDim);
+                p.drawText(zones[z], Qt::AlignCenter, glyphs[z]);
+            }
+        }
         // --- Action item ---
         else if (item.type == MenuItemType::Action) {
             p.setFont(m_LabelFont);
@@ -1021,12 +1228,30 @@ void OverlayMenuPanel::paintEvent(QPaintEvent*)
 void OverlayMenuPanel::mouseMoveEvent(QMouseEvent* event)
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    int newIdx = itemAtPos(event->position().toPoint());
+    const QPoint pos = event->position().toPoint();
 #else
-    int newIdx = itemAtPos(event->pos());
+    const QPoint pos = event->pos();
 #endif
-    if (newIdx != m_HoveredIndex) {
+
+    if (m_SliderDragging) {
+        // Keep scrubbing even when the pointer leaves the panel (mouse grab).
+        const auto& items = m_MenuLevels[m_CurrentLevel].items;
+        for (int i = 0; i < (int)items.size(); i++) {
+            if (items[i].type != MenuItemType::Slider) continue;
+            const int itemY = m_TitleHeight + m_Padding + i * m_ItemHeight;
+            const SliderRowRects r = sliderRowRects(width() - 2 * m_ShadowMargin, itemY);
+            const double frac = (pos.x() - r.track.x()) / double(r.track.width());
+            setBitrateFromFraction(frac);
+            break;
+        }
+        return;
+    }
+
+    const int newIdx = itemAtPos(pos);
+    const SliderZone hotZone = sliderZoneAt(pos, newIdx);
+    if (newIdx != m_HoveredIndex || hotZone != m_SliderHotZone) {
         m_HoveredIndex = newIdx;
+        m_SliderHotZone = hotZone;
         setCursor((m_HoveredIndex >= 0 || m_HoveredIndex == -2 || m_HoveredIndex == -3)
                           ? Qt::PointingHandCursor
                           : Qt::ArrowCursor);
@@ -1040,10 +1265,11 @@ void OverlayMenuPanel::mousePressEvent(QMouseEvent* event)
     beginInteraction();
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    int idx = itemAtPos(event->position().toPoint());
+    const QPoint pos = event->position().toPoint();
 #else
-    int idx = itemAtPos(event->pos());
+    const QPoint pos = event->pos();
 #endif
+    int idx = itemAtPos(pos);
 
     if (idx == -3) {
         closeMenu();
@@ -1073,8 +1299,35 @@ void OverlayMenuPanel::mousePressEvent(QMouseEvent* event)
         break;
 
     case MenuItemType::Action:
+        if (item.action == MenuAction::SetBitrate) {
+            selectBitratePreset(item);
+            break;
+        }
         dispatchActionItem(item);
         break;
+
+    case MenuItemType::Slider:
+    {
+        const SliderZone zone = sliderZoneAt(pos, idx);
+        m_SliderPressedZone = zone;
+        m_SliderHotZone = zone;
+        if (zone == SliderZone::Minus) {
+            adjustBitrateStep(-1, 1);
+        }
+        else if (zone == SliderZone::Plus) {
+            adjustBitrateStep(1, 1);
+        }
+        else if (zone == SliderZone::Track) {
+            const int itemY = m_TitleHeight + m_Padding + idx * m_ItemHeight;
+            const SliderRowRects r = sliderRowRects(width() - 2 * m_ShadowMargin, itemY);
+            m_SliderDragging = true;
+            setMouseGrabEnabled(true);
+            const double frac = (pos.x() - r.track.x()) / double(r.track.width());
+            setBitrateFromFraction(frac);
+        }
+        forceRepaint();
+        break;
+    }
 
     case MenuItemType::Toggle:
     {
@@ -1088,6 +1341,54 @@ void OverlayMenuPanel::mousePressEvent(QMouseEvent* event)
         break;
     }
     }
+}
+
+void OverlayMenuPanel::mouseReleaseEvent(QMouseEvent* event)
+{
+    Q_UNUSED(event);
+    if (!m_SliderDragging && m_SliderPressedZone == SliderZone::None) return;
+
+    if (m_SliderDragging) {
+        m_SliderDragging = false;
+        setMouseGrabEnabled(false);
+    }
+    m_SliderPressedZone = SliderZone::None;
+    m_SliderHotZone = SliderZone::None;
+    // The commit timer keeps running; the value lands once the pointer idles.
+    forceRepaint();
+}
+
+void OverlayMenuPanel::wheelEvent(QWheelEvent* event)
+{
+    if (!m_Visible) {
+        event->ignore();
+        return;
+    }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const QPoint pos = event->position().toPoint();
+#else
+    const QPoint pos = event->pos();
+#endif
+    const int idx = itemAtPos(pos);
+    if (idx < 0 || idx >= (int)m_MenuLevels[m_CurrentLevel].items.size()
+            || m_MenuLevels[m_CurrentLevel].items[idx].type != MenuItemType::Slider) {
+        event->ignore();
+        return;
+    }
+
+    // Wheeling the scrubber counts as interaction; don't race the leave timer.
+    beginInteraction();
+
+    // Accumulate high-resolution wheel deltas; one notch = one fine step.
+    m_WheelAccum += event->angleDelta().y() / 120.0;
+    int notches = 0;
+    while (m_WheelAccum >= 1.0) { notches++; m_WheelAccum -= 1.0; }
+    while (m_WheelAccum <= -1.0) { notches--; m_WheelAccum += 1.0; }
+    if (notches != 0) {
+        adjustBitrateStep(notches > 0 ? 1 : -1, qAbs(notches));
+    }
+    event->accept();
 }
 
 // ---------------------------------------------------------------------------
@@ -1172,7 +1473,15 @@ void OverlayMenuPanel::gamepadSelect()
         navigateToLevel(item.targetLevel);
         break;
     case MenuItemType::Action:
+        if (item.action == MenuAction::SetBitrate) {
+            selectBitratePreset(item);
+            break;
+        }
         dispatchActionItem(item);
+        break;
+    case MenuItemType::Slider:
+        // A confirms — flush a pending scrub immediately.
+        commitBitrateNow();
         break;
     case MenuItemType::Toggle:
     {

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -6,6 +6,7 @@
 #include <QCoreApplication>
 #include <QCursor>
 #include <QFontMetrics>
+#include <QtMath>
 #include <memory>
 
 namespace {
@@ -1382,7 +1383,9 @@ void OverlayMenuPanel::wheelEvent(QWheelEvent* event)
         return;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // QWheelEvent::pos() is unavailable on the SteamLink Qt 5.14 build;
+    // position() exists everywhere from 5.14 on.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     const QPoint pos = event->position().toPoint();
 #else
     const QPoint pos = event->pos();

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -21,10 +21,11 @@ const QColor MenuFaint("#7E858E");
 const QColor MenuAccent("#39C5BB");
 const QColor MenuDanger("#FF876F");
 
-// Bitrate scrubber range and granularity — same log scale as the settings
-// page slider (HardSlider over log(500)..log(2000000)).
+// Bitrate scrubber range and granularity — log scale like the settings page
+// slider. The maximum matches Sunshine's /bitrate runtime endpoint cap
+// (800000 Kbps); higher values would be rejected by the host.
 constexpr int kBitrateMinKbps = 500;
-constexpr int kBitrateMaxKbps = 2000000;
+constexpr int kBitrateMaxKbps = 800000;
 constexpr int kBitrateLogSteps = 200;
 const double kBitrateLogSpan = qLn(kBitrateMaxKbps / double(kBitrateMinKbps));
 // Idle window after the last scrub tick before the change is committed.

--- a/app/streaming/video/overlaymenupanel.cpp
+++ b/app/streaming/video/overlaymenupanel.cpp
@@ -491,7 +491,7 @@ OverlayMenuPanel::SliderRowRects OverlayMenuPanel::sliderRowRects(int contentWid
     return r;
 }
 
-OverlayMenuPanel::SliderZone OverlayMenuPanel::sliderZoneAt(const QPoint& localPos, int rowIdx) const
+OverlayMenuPanel::SliderZone OverlayMenuPanel::sliderZoneAt(const QPoint& windowPos, int rowIdx) const
 {
     const auto& items = m_MenuLevels[m_CurrentLevel].items;
     if (rowIdx < 0 || rowIdx >= (int)items.size()
@@ -499,13 +499,15 @@ OverlayMenuPanel::SliderZone OverlayMenuPanel::sliderZoneAt(const QPoint& localP
         return SliderZone::None;
     }
 
+    // Row rects live in content coordinates; callers hand us window coords.
+    const QPoint contentPos = windowPos - QPoint(m_ShadowMargin, m_ShadowMargin);
     const int itemY = m_TitleHeight + m_Padding + rowIdx * m_ItemHeight;
     const SliderRowRects r = sliderRowRects(width() - 2 * m_ShadowMargin, itemY);
 
     // Buttons win over the track so their hit area feels solid.
-    if (r.minus.adjusted(-2, -2, 2, 2).contains(localPos)) return SliderZone::Minus;
-    if (r.plus.adjusted(-2, -2, 2, 2).contains(localPos)) return SliderZone::Plus;
-    if (QRect(r.track.x() - 4, itemY, r.track.width() + 8, m_ItemHeight).contains(localPos)) {
+    if (r.minus.adjusted(-2, -2, 2, 2).contains(contentPos)) return SliderZone::Minus;
+    if (r.plus.adjusted(-2, -2, 2, 2).contains(contentPos)) return SliderZone::Plus;
+    if (QRect(r.track.x() - 4, itemY, r.track.width() + 8, m_ItemHeight).contains(contentPos)) {
         return SliderZone::Track;
     }
     return SliderZone::None;
@@ -697,6 +699,9 @@ void OverlayMenuPanel::showInternal()
     m_CurrentLevel = 0;
     m_HoveredIndex = -1;
     m_ContentOffset = 0;
+    m_SliderDragging = false;
+    m_SliderPressedZone = SliderZone::None;
+    m_SliderHotZone = SliderZone::None;
 
     // If closing animation is in progress, cancel it
     if (m_Closing) {
@@ -885,6 +890,15 @@ void OverlayMenuPanel::closeMenu()
     m_Visible = false;
     m_Closing = true;
     m_HoveredIndex = -1;
+
+    // A close can land mid-drag (e.g. window focus loss). Drop the drag and
+    // the mouse grab so the next show doesn't treat motion as scrubbing.
+    if (m_SliderDragging) {
+        m_SliderDragging = false;
+        setMouseGrabEnabled(false);
+    }
+    m_SliderPressedZone = SliderZone::None;
+    m_SliderHotZone = SliderZone::None;
 
     // Stop any show/level animations
     m_SlideAnim->stop();
@@ -1241,7 +1255,8 @@ void OverlayMenuPanel::mouseMoveEvent(QMouseEvent* event)
             if (items[i].type != MenuItemType::Slider) continue;
             const int itemY = m_TitleHeight + m_Padding + i * m_ItemHeight;
             const SliderRowRects r = sliderRowRects(width() - 2 * m_ShadowMargin, itemY);
-            const double frac = (pos.x() - r.track.x()) / double(r.track.width());
+            const double frac = (pos.x() - m_ShadowMargin - r.track.x())
+                                    / double(r.track.width());
             setBitrateFromFraction(frac);
             break;
         }
@@ -1323,7 +1338,8 @@ void OverlayMenuPanel::mousePressEvent(QMouseEvent* event)
             const SliderRowRects r = sliderRowRects(width() - 2 * m_ShadowMargin, itemY);
             m_SliderDragging = true;
             setMouseGrabEnabled(true);
-            const double frac = (pos.x() - r.track.x()) / double(r.track.width());
+            const double frac = (pos.x() - m_ShadowMargin - r.track.x())
+                                    / double(r.track.width());
             setBitrateFromFraction(frac);
         }
         forceRepaint();

--- a/app/streaming/video/overlaymenupanel.h
+++ b/app/streaming/video/overlaymenupanel.h
@@ -3,6 +3,7 @@
 #include <QRasterWindow>
 #include <QPainter>
 #include <QMouseEvent>
+#include <QWheelEvent>
 #include <QPoint>
 #include <QFont>
 #include <QIcon>
@@ -26,7 +27,7 @@
  * Menu structure:
  *   Level 0 (Top):      Quick Actions >, Menu Position >, Bitrate >, Fullscreen, Microphone [toggle], Disconnect
  *   Level 1 (Actions):  Quit, Performance Stats, Mouse Mode, Cursor, Minimize, ...
- *   Level 2 (Bitrate):  1/2/5/10/20/30/50/100 Mbps
+ *   Level 2 (Bitrate):  log-scale scrubber row + 1/2/5/10/20/30/50/100 Mbps presets
  *   Level 3 (Position): Top, Right, Left, Floating button, Disabled
  *   Developer builds may append a function-test panel entry.
  *
@@ -55,15 +56,9 @@ public:
         ToggleMicrophone,
         // Gamepad mouse emulation
         ToggleGamepadMouse,
-        // Bitrate presets (kbps)
-        SetBitrate1000,
-        SetBitrate2000,
-        SetBitrate5000,
-        SetBitrate10000,
-        SetBitrate20000,
-        SetBitrate30000,
-        SetBitrate50000,
-        SetBitrate100000,
+        // Set bitrate to the kbps value carried in MenuItem::payload.
+        // Handled inside the panel (slider row + presets); never dispatched.
+        SetBitrate,
         SetMenuPlacementTop,
         SetMenuPlacementRight,
         SetMenuPlacementLeft,
@@ -107,12 +102,16 @@ public:
         SubMenu,    // navigate to sub-level
         Toggle,     // dispatch action, toggle visual state, keep menu open
         Back,       // navigate back to top level
+        Slider,     // in-row value scrubber (drag/wheel/gamepad); keeps menu open
     };
 
     using ActionCallback = std::function<void(MenuAction)>;
     using CloseCallback  = std::function<void()>;
     using RemoteUsbDeviceCallback = std::function<void(const QString&)>;
     using RemoteUsbReleaseCallback = std::function<void()>;
+    // Fired when a bitrate adjustment settles (debounced while scrubbing,
+    // immediate for preset taps). The value is in kbps.
+    using BitrateChangeCallback = std::function<void(int)>;
 
     explicit OverlayMenuPanel(QWindow* parent = nullptr);
     ~OverlayMenuPanel() override;
@@ -125,6 +124,12 @@ public:
     void setRemoteUsbReleaseCallback(RemoteUsbReleaseCallback cb) {
         m_RemoteUsbReleaseCallback = std::move(cb);
     }
+    void setBitrateChangeCallback(BitrateChangeCallback cb) {
+        m_BitrateChangeCallback = std::move(cb);
+    }
+
+    // Human-readable bitrate label shared with toast/log formatting.
+    static QString formatBitrateKbps(int kbps);
 
     // Position the panel at the right edge of the given Qt logical parent rect.
     void showAtRightEdge(int parentX, int parentY, int parentW, int parentH,
@@ -174,11 +179,16 @@ public:
     void gamepadMoveDown();
     void gamepadSelect();
     void gamepadBack();
+    // Step the focused slider row (DPAD left/right); direction is -1 or +1.
+    // Rapid consecutive presses accelerate the step size.
+    void gamepadAdjustSlider(int direction);
 
 protected:
     void paintEvent(QPaintEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void wheelEvent(QWheelEvent* event) override;
     bool event(QEvent* event) override;
 
 private:
@@ -222,6 +232,16 @@ private:
 
     enum class AnchorMode { RightEdge, LeftEdge, TopEdge, AtCursor };
 
+    // Hit zones inside the slider row (local coordinates).
+    enum class SliderZone { None, Minus, Track, Plus };
+
+    struct SliderRowRects {
+        QRect value;
+        QRect track;
+        QRect minus;
+        QRect plus;
+    };
+
     void buildMenuLevels();
     void navigateToLevel(int level);
     void repositionWindow();
@@ -231,6 +251,17 @@ private:
     void forceRepaint();     // synchronous repaint (requestUpdate is async on Windows)
     int  itemAtPos(const QPoint& pos) const;
     void dispatchActionItem(const MenuItem& item);
+
+    // --- Bitrate slider row ---
+    SliderRowRects sliderRowRects(int contentWidth, int itemY) const;
+    SliderZone sliderZoneAt(const QPoint& localPos, int rowIdx) const;
+    double bitrateFraction() const;                 // m_BitrateKbps on the log scale, 0..1
+    void setBitrateFromFraction(double fraction);   // inverse of bitrateFraction()
+    void setBitrateKbps(int bitrateKbps);           // clamp + refresh + schedule commit
+    void adjustBitrateStep(int direction, int multiplier);
+    void selectBitratePreset(const MenuItem& item); // snap to preset + commit now
+    void commitBitrateNow();                        // flush pending change to callback
+    void refreshBitrateDetails();                   // level-0 detail + preset checkmarks
 
     std::vector<MenuLevel> m_MenuLevels;
     int  m_CurrentLevel;
@@ -249,6 +280,19 @@ private:
     CloseCallback  m_CloseCallback;
     RemoteUsbDeviceCallback m_RemoteUsbDeviceCallback;
     RemoteUsbReleaseCallback m_RemoteUsbReleaseCallback;
+    BitrateChangeCallback m_BitrateChangeCallback;
+
+    // Bitrate slider state. m_BitrateKbps is the on-screen value;
+    // m_CommittedBitrateKbps is the last value sent to the callback.
+    int m_BitrateKbps = 10000;
+    int m_CommittedBitrateKbps = 10000;
+    QTimer m_BitrateCommitTimer;      // debounces callback while scrubbing
+    bool m_SliderDragging = false;    // pointer is scrubbing the track
+    SliderZone m_SliderPressedZone = SliderZone::None;
+    SliderZone m_SliderHotZone = SliderZone::None;
+    qreal m_WheelAccum = 0.0;         // high-resolution wheel accumulation
+    QElapsedTimer m_SliderAdjustClock; // gamepad repeat acceleration window
+    int m_SliderAdjustStreak = 0;
 
     // Parent window rect in Qt global logical coordinates for level changes
     int m_ParentX, m_ParentY, m_ParentW, m_ParentH;

--- a/tests/overlay_menu_navigation/main.cpp
+++ b/tests/overlay_menu_navigation/main.cpp
@@ -3,6 +3,7 @@
 #include <QFontDatabase>
 #include <QCursor>
 #include <QKeyEvent>
+#include <QWheelEvent>
 #include <QTest>
 
 // Native preview of the production panel, with simulated USB status changes.
@@ -129,5 +130,40 @@ int main(int argc, char **argv)
     panel.gamepadBack();
     QTest::qWait(220);
     if (panel.isVisible()) qFatal("back at top level failed to close menu");
+
+    // --- Bitrate scrubber: preset tap, debounced scrub, wheel, flush ---
+    int bitrateCommits = 0;
+    int lastBitrate = 0;
+    panel.setBitrateChangeCallback([&](int kbps) {
+        lastBitrate = kbps;
+        ++bitrateCommits;
+    });
+    panel.updateBitrateState(10000);
+    panel.showAtCursor(0, 0, 1600, 1200, QPoint(400, 400), false);
+    QTest::qWait(240);
+    // Enter the Bitrate submenu (row 2), then tap the 5 Mbps preset (row 3).
+    QTest::mouseClick(&panel, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(140, 8 + 32 + 4 + 2 * 38 + 19));
+    QTest::mouseClick(&panel, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(140, 8 + 32 + 4 + 3 * 38 + 19));
+    if (lastBitrate != 5000 || bitrateCommits != 1) qFatal("preset tap did not commit");
+    if (!panel.isMenuVisible()) qFatal("preset tap closed the menu");
+    // D-pad right scrubs upward but must wait out the commit debounce.
+    panel.gamepadAdjustSlider(1);
+    if (bitrateCommits != 1 || lastBitrate != 5000) qFatal("scrub committed before debounce");
+    QTest::qWait(600);
+    if (bitrateCommits != 2 || lastBitrate <= 5000) qFatal("scrub never committed");
+    const int afterScrub = lastBitrate;
+    // One wheel notch on the slider row steps again; A flushes immediately.
+    QWheelEvent wheelUp(QPointF(140, 8 + 32 + 4 + 19), QPointF(),
+                        QPoint(), QPoint(0, 120), Qt::NoButton, Qt::NoModifier,
+                        Qt::NoScrollPhase, false);
+    QCoreApplication::sendEvent(&panel, &wheelUp);
+    panel.gamepadSelect();
+    if (bitrateCommits != 3 || lastBitrate <= afterScrub) qFatal("wheel step not flushed");
+    if (!panel.isMenuVisible()) qFatal("slider interaction closed the menu");
+    panel.dismissOnOutsideClick(QPoint(-100, -100));
+    QTest::qWait(220);
+    if (panel.isVisible()) qFatal("outside click after slider use failed to dismiss");
     return 0;
 }

--- a/tests/overlay_menu_navigation/main.cpp
+++ b/tests/overlay_menu_navigation/main.cpp
@@ -119,7 +119,8 @@ int main(int argc, char **argv)
     panel.dismissOnOutsideClick(panel.geometry().center());
     if (!panel.isMenuVisible()) qFatal("inside click dismissed menu");
     panel.dismissOnOutsideClick(QPoint(-100, -100));
-    QTest::qWait(220);
+    // The close animation needs a beat; tolerate slow CI timers.
+    for (int i = 0; i < 40 && panel.isVisible(); i++) QTest::qWait(50);
     if (panel.isVisible()) qFatal("outside click failed to dismiss menu");
     // Reopening restores transient pointer-triggered behavior.
     panel.showAtCursor(0, 0, 1600, 1200, QPoint(400, 400), true);
@@ -171,8 +172,20 @@ int main(int argc, char **argv)
     }
     panel.gamepadSelect();
     if (lastBitrate != 800000) qFatal("scrubber did not clamp at 800000 Kbps");
+    // Track press scrubs to the click position (window → content coords):
+    // near the left end lands near the minimum, near the right end at the cap.
+    QTest::mouseClick(&panel, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(8 + 102 + 4, 8 + 32 + 4 + 19));
+    panel.gamepadSelect();
+    if (bitrateCommits != 5 || lastBitrate > 2000)
+        qFatal("track press near minimum failed: commits=%d last=%d", bitrateCommits, lastBitrate);
+    QTest::mouseClick(&panel, Qt::LeftButton, Qt::NoModifier,
+                      QPoint(8 + 252, 8 + 32 + 4 + 19));
+    panel.gamepadSelect();
+    if (bitrateCommits != 6 || lastBitrate != 800000)
+        qFatal("track press near maximum failed: commits=%d last=%d", bitrateCommits, lastBitrate);
     panel.dismissOnOutsideClick(QPoint(-100, -100));
-    QTest::qWait(220);
+    for (int i = 0; i < 40 && panel.isVisible(); i++) QTest::qWait(50);
     if (panel.isVisible()) qFatal("outside click after slider use failed to dismiss");
     return 0;
 }

--- a/tests/overlay_menu_navigation/main.cpp
+++ b/tests/overlay_menu_navigation/main.cpp
@@ -162,6 +162,15 @@ int main(int argc, char **argv)
     panel.gamepadSelect();
     if (bitrateCommits != 3 || lastBitrate <= afterScrub) qFatal("wheel step not flushed");
     if (!panel.isMenuVisible()) qFatal("slider interaction closed the menu");
+    // Saturating the wheel must clamp at the Sunshine /bitrate cap (800 Mbps).
+    for (int i = 0; i < 250; i++) {
+        QWheelEvent wheelMax(QPointF(140, 8 + 32 + 4 + 19), QPointF(),
+                             QPoint(), QPoint(0, 120), Qt::NoButton, Qt::NoModifier,
+                             Qt::NoScrollPhase, false);
+        QCoreApplication::sendEvent(&panel, &wheelMax);
+    }
+    panel.gamepadSelect();
+    if (lastBitrate != 800000) qFatal("scrubber did not clamp at 800000 Kbps");
     panel.dismissOnOutsideClick(QPoint(-100, -100));
     QTest::qWait(220);
     if (panel.isVisible()) qFatal("outside click after slider use failed to dismiss");


### PR DESCRIPTION
## 概述

把串流悬浮菜单的码率子菜单从 8 个固定档位（1/2/5/10/20/30/50/100 Mbps）改成**对数刻度无级调整**：一条滑块行 + 预设快捷锚点。调整范围 **500 kbps–800 Mbps**，上限对齐 Sunshine `/bitrate` 运行时接口的 800000 Kbps 拒绝线（设置页滑条同步收紧，见第二个提交）。

## 动机

- 8 档之间间隙大（30→50→100 Mbps 之间取不到值），想微调抗卡顿做不到
- 原来选中即关闭整个菜单，试不同值必须反复重开菜单
- 设置页拖出的非整档值（如 8 Mbps）在子菜单里没有任何选中标记，看起来像"没选"
- 手柄玩家被锁死在 8 档

## 交互设计

- **滑块行**：左侧当前值（聚焦时品牌青色高亮）、中间对数刻度轨道 + 方形游标、右侧 −/+ 步进按钮，沿用现有 neo-brutalist 方角风格
- **鼠标**：拖轨道连续调整、行上滚轮微调（一格约 ±4%）、−/+ 点击步进
- **手柄**：DPAD 左右在码率子菜单任意位置直接驱动滑块（焦点自动跟随），连按/长按步进加速（1x→2x→4x→8x 封顶），A 键确认冲刷
- **菜单保持打开**：调整全程不关闭，预设点击吸附并立即提交但同样不关菜单，方便反复试

## 提交与防抖

拖动只更新显示；停手 450ms 后才落盘（保存偏好 + Sunshine `/bitrate` 运行时接口 + toast）。避免拖动时每帧发一次 HTTP 编码器重配。提交时设置 `autoAdjustBitrate = false`，与设置页滑条行为一致。菜单重开时若还有未落盘的调整，不回读旧值覆盖。

## 附带修复

`updateBitrateState` 原用整数除法，1500 kbps 显示成 "1 Mbps"。统一走新增的 `OverlayMenuPanel::formatBitrateKbps()`（共享给 toast），小数 Mbps 正确显示。

## 实现说明（reviewer 参考）

- `MenuItemType` 新增 `Slider` 行类型；8 个 `SetBitrate*` 枚举合并为单个 `SetBitrate`（kbps 走 `MenuItem::payload`），预设点击在面板内拦截，不再进 session 的 action 分发
- 滑块命中分区（−/轨道/+）由 `sliderRowRects()` 统一给出，绘制与命中测试共用同一几何
- 拖拽用 QWindow 的 `setMouseGrabEnabled`（QRasterWindow 无 QWidget 的 grabMouse）
- `buildMenuLevels()` 重建（手柄热插拔/USB 刷新）后通过 `refreshBitrateDetails()` 重盖码率状态，修复原有"重建后预设 ✓ 丢失"的问题
- 无新增可翻译字符串（预设标签由 formatBitrateKbps 生成，数字语言无关）
- 上限 800 Mbps 的依据：Sunshine `nvhttp/dynamic_params.cpp` 的 `change_bitrate` 校验 `bitrate > 800000` 即返回 400，超出部分是静默失效的死区，故客户端两处滑条一并钳制

## 测试

- `tests/overlay_menu_navigation` 新增滑块交互断言：预设提交且菜单不关、防抖窗口内不提前提交、停手后落盘、滚轮步进、A 键立即冲刷、滚轮拉满钳制在 800000 Kbps、外点关闭不受影响——offscreen 下全部通过
- `session.cpp` 在完整依赖环境（moonlight-qt-deps v12 + MSVC 14.44 + Qt 6.11.1）编译零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced fixed bitrate options with an interactive logarithmic slider supporting dragging, mouse-wheel input, steppers, presets, and gamepad adjustment.
  * Bitrate changes are applied after a brief pause or immediately when selecting a preset, with confirmation shown after the host accepts the change.
  * Bitrate selection is capped at 800 Mbps.

* **Tests**
  * Added coverage for presets, slider adjustments, delayed commits, gamepad controls, wheel input, saturation, and menu dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->